### PR TITLE
Removes unused metadata fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "description": "VRChat/MMDのBlendShapeからARKit用BlendShapeを自動生成するNDMFプラグイン。Jerry's Templatesと組み合わせて使用することで、フェイストラッキング非対応アバターを簡単に対応させることができます。",
     "unity": "2022.3",
     "unityRelease": "6f1",
-    "documentationUrl": "",
-    "changelogUrl": "",
-    "licensesUrl": "",
     "dependencies": {},
     "vpmDependencies": {
         "com.vrchat.avatars": ">=3.5.0",


### PR DESCRIPTION
Removes the documentationUrl, changelogUrl, and licensesUrl fields from package.json.

These fields are not currently used and removing them cleans up the project's metadata.
