### PR TITLE
Exposes blendWidth property in editor

### DIFF
--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -85,6 +85,7 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(serializedObject.FindProperty("intensityMultiplier"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("enableLeftRightSplit"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("blendWidth"));
             EditorGUILayout.PropertyField(serializedObject.FindProperty("overwriteExisting"));
 
             EditorGUILayout.Space();


### PR DESCRIPTION
Adds a property field for blendWidth in the ARKitBlendShapeGenerator editor.

This allows users to directly control the blend width parameter from the Unity editor, providing more flexibility and control over blend shape generation.
