### PR TITLE
Adds VRChat standard expression preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.qazx7412.kx-vrc-arkit-blendshape-generator",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "displayName": "Kx VRC ARKit BlendShape Generator",
     "description": "VRChat/MMDのBlendShapeからARKit用BlendShapeを自動生成するNDMFプラグイン。Jerry's Templatesと組み合わせて使用することで、フェイストラッキング非対応アバターを簡単に対応させることができます。",
     "unity": "2022.3",


### PR DESCRIPTION
Adds a preset for VRChat standard expressions to the ARKit BlendShape Generator.

This allows users with avatars that do not have MMD shape keys to easily set up ARKit blendshapes using the standard VRChat visemes (vrc.v_aa, vrc.v_ih, vrc.v_ou, etc.). It also adds a "(未検出)" suffix to blendshape names in the dropdown list if the blendshape is not found, but allows the user to keep the original name if they select that option.