### PR TITLE
Fix NDMF preview consistency and optimize overwriteExisting generation with strict custom ARKit validation

### DIFF
--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -193,6 +193,15 @@ namespace ARKitBlendShapeGenerator
                 MessageType.Info
             );
 
+            var duplicateArkitNames = CustomMappingValidation.GetDuplicateArkitNames(_component.customMappings);
+            if (duplicateArkitNames.Count > 0)
+            {
+                EditorGUILayout.HelpBox(
+                    CustomMappingValidation.BuildDuplicateMessage(duplicateArkitNames) +
+                    "\n重複を解消するまでプレビュー/生成は停止されます。",
+                    MessageType.Error);
+            }
+
             // VRChat標準表情のみを使用したプリセット
             EditorGUILayout.LabelField("プリセット", EditorStyles.miniBoldLabel);
             EditorGUILayout.BeginHorizontal();
@@ -358,13 +367,66 @@ namespace ARKitBlendShapeGenerator
             return 46f + (sourceCount * 22f);
         }
 
+        private List<string> GetSelectableArkitNames(int mappingIndex)
+        {
+            var allArkitNames = ARKitBlendShapeNames.GetAll();
+            var customMappings = _component.customMappings ?? new List<CustomBlendShapeMapping>();
+            var usedByOthers = new HashSet<string>(
+                customMappings
+                    .Where((mapping, index) =>
+                        index != mappingIndex &&
+                        mapping != null &&
+                        !string.IsNullOrWhiteSpace(mapping.arkitName))
+                    .Select(mapping => mapping.arkitName.Trim()));
+
+            var options = allArkitNames
+                .Where(name => !usedByOthers.Contains(name))
+                .ToList();
+
+            if (mappingIndex < 0 || mappingIndex >= customMappings.Count)
+            {
+                return options;
+            }
+
+            var currentName = customMappings[mappingIndex]?.arkitName;
+            if (!string.IsNullOrWhiteSpace(currentName))
+            {
+                var trimmedCurrentName = currentName.Trim();
+                if (!options.Contains(trimmedCurrentName))
+                {
+                    options.Insert(0, trimmedCurrentName);
+                }
+            }
+
+            return options;
+        }
+
+        private string GetFirstUnusedArkitName()
+        {
+            var customMappings = _component.customMappings ?? new List<CustomBlendShapeMapping>();
+            var usedNames = new HashSet<string>(
+                customMappings
+                    .Where(mapping => mapping != null && !string.IsNullOrWhiteSpace(mapping.arkitName))
+                    .Select(mapping => mapping.arkitName.Trim()));
+
+            foreach (var arkitName in ARKitBlendShapeNames.GetAll())
+            {
+                if (!usedNames.Contains(arkitName))
+                {
+                    return arkitName;
+                }
+            }
+
+            return null;
+        }
+
         private void AddCategoryMappings(string[] arkitNames)
         {
             Undo.RecordObject(_component, "Add Category Mappings");
 
             foreach (var name in arkitNames)
             {
-                if (_component.customMappings.Any(m => m.arkitName == name))
+                if (_component.customMappings.Any(m => m != null && m.arkitName == name))
                     continue;
 
                 _component.customMappings.Add(new CustomBlendShapeMapping
@@ -394,16 +456,27 @@ namespace ARKitBlendShapeGenerator
                 MarkComponentChanged();
             }
 
-            // ARKit名のドロップダウン
-            var arkitNames = ARKitBlendShapeNames.GetAll();
-            int currentIndex = System.Array.IndexOf(arkitNames, mapping.arkitName);
-            if (currentIndex < 0) currentIndex = 0;
-
-            int newIndex = EditorGUILayout.Popup(currentIndex, arkitNames);
-            if (newIndex != currentIndex || string.IsNullOrEmpty(mapping.arkitName))
+            // ARKit名のドロップダウン（同一ARKit名の重複は選択不可）
+            var selectableArkitNames = GetSelectableArkitNames(index);
+            if (selectableArkitNames.Count == 0)
             {
-                mapping.arkitName = arkitNames[newIndex];
-                MarkComponentChanged();
+                EditorGUILayout.LabelField("(利用可能なARKit名なし)");
+            }
+            else
+            {
+                string currentArkitName = string.IsNullOrWhiteSpace(mapping.arkitName)
+                    ? null
+                    : mapping.arkitName.Trim();
+                int currentIndex = selectableArkitNames.IndexOf(currentArkitName);
+                if (currentIndex < 0) currentIndex = 0;
+
+                int newIndex = EditorGUILayout.Popup(currentIndex, selectableArkitNames.ToArray());
+                string selectedArkitName = selectableArkitNames[newIndex];
+                if (!string.Equals(mapping.arkitName, selectedArkitName))
+                {
+                    mapping.arkitName = selectedArkitName;
+                    MarkComponentChanged();
+                }
             }
 
             if (GUILayout.Button("+", GUILayout.Width(25)))
@@ -512,9 +585,19 @@ namespace ARKitBlendShapeGenerator
 
         private void AddNewMapping()
         {
+            string firstUnusedArkitName = GetFirstUnusedArkitName();
+            if (string.IsNullOrEmpty(firstUnusedArkitName))
+            {
+                EditorUtility.DisplayDialog(
+                    "ARKit BlendShape Generator",
+                    "追加可能なARKit名がありません。\n既存マッピングを削除するか、ARKit名を変更してください。",
+                    "OK");
+                return;
+            }
+
             var newMapping = new CustomBlendShapeMapping
             {
-                arkitName = "eyeBlinkLeft",
+                arkitName = firstUnusedArkitName,
                 enabled = true,
                 sources = new List<BlendShapeSource>()
             };

--- a/Editor/ARKitBlendShapeGeneratorPlugin.cs
+++ b/Editor/ARKitBlendShapeGeneratorPlugin.cs
@@ -60,6 +60,15 @@ namespace ARKitBlendShapeGenerator
 
         private void ProcessComponent(ARKitBlendShapeGeneratorComponent component, BuildContext ctx)
         {
+            if (CustomMappingValidation.HasDuplicateArkitNames(component.customMappings, out var duplicateArkitNames))
+            {
+                Debug.LogError(
+                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しているため、生成を中止しました。\n" +
+                    $"重複: {string.Join(", ", duplicateArkitNames)}",
+                    component);
+                return;
+            }
+
             var renderer = component.targetRenderer;
             if (renderer == null)
             {

--- a/Editor/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/ARKitBlendShapeGeneratorPreview.cs
@@ -106,6 +106,15 @@ namespace ARKitBlendShapeGenerator
                 return Task.FromResult<IRenderFilterNode>(null);
             }
 
+            if (CustomMappingValidation.HasDuplicateArkitNames(component.customMappings, out var duplicateArkitNames))
+            {
+                Debug.LogError(
+                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しています。重複を解消するまでプレビューを停止します。\n" +
+                    $"重複: {string.Join(", ", duplicateArkitNames)}",
+                    component);
+                return Task.FromResult<IRenderFilterNode>(null);
+            }
+
             if (original is not SkinnedMeshRenderer originalSmr ||
                 proxy is not SkinnedMeshRenderer proxySmr)
             {

--- a/Editor/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/ARKitBlendShapeGeneratorPreview.cs
@@ -125,7 +125,12 @@ namespace ARKitBlendShapeGenerator
             private readonly ARKitBlendShapeGeneratorComponent _component;
             private readonly int _componentInstanceId;
             private readonly int _observedComponentConfigRevision;
+            private readonly float _observedIntensityMultiplier;
+            private readonly bool _observedEnableLeftRightSplit;
+            private readonly float _observedBlendWidth;
+            private readonly bool _observedOverwriteExisting;
             private readonly int _observedTargetRendererInstanceId;
+            private readonly int _observedCustomMappingsSignature;
             private readonly Dictionary<string, int> _shapeIndices = new Dictionary<string, int>();
             private HashSet<int> _appliedInteractiveIndices = new HashSet<int>();
             private HashSet<int> _nextAppliedInteractiveIndices = new HashSet<int>();
@@ -143,16 +148,28 @@ namespace ARKitBlendShapeGenerator
                 _observedComponentConfigRevision = context.Observe(ARKitBlendShapeGeneratorPreviewState.ComponentConfigRevision);
 
                 // customMappingsの内容を含むコンポーネント変更全体を監視
+                float observedIntensityMultiplier = 0f;
+                bool observedEnableLeftRightSplit = false;
+                float observedBlendWidth = 0f;
+                bool observedOverwriteExisting = false;
+                int observedCustomMappingsSignature = 0;
                 SkinnedMeshRenderer observedTargetRenderer = null;
                 if (component != null)
                 {
                     context.Observe(component);
-                    context.Observe(component, c => c.intensityMultiplier);
-                    context.Observe(component, c => c.enableLeftRightSplit);
-                    context.Observe(component, c => c.blendWidth);
-                    context.Observe(component, c => c.overwriteExisting);
+                    observedIntensityMultiplier = context.Observe(component, c => c.intensityMultiplier);
+                    observedEnableLeftRightSplit = context.Observe(component, c => c.enableLeftRightSplit);
+                    observedBlendWidth = context.Observe(component, c => c.blendWidth);
+                    observedOverwriteExisting = context.Observe(component, c => c.overwriteExisting);
+                    observedCustomMappingsSignature = BuildCustomMappingsSignature(component.customMappings);
                     observedTargetRenderer = context.Observe(component, c => c.targetRenderer);
                 }
+
+                _observedIntensityMultiplier = observedIntensityMultiplier;
+                _observedEnableLeftRightSplit = observedEnableLeftRightSplit;
+                _observedBlendWidth = observedBlendWidth;
+                _observedOverwriteExisting = observedOverwriteExisting;
+                _observedCustomMappingsSignature = observedCustomMappingsSignature;
                 _observedTargetRendererInstanceId = observedTargetRenderer != null ? observedTargetRenderer.GetInstanceID() : 0;
 
                 context.Observe(originalRenderer, r => r.sharedMesh);
@@ -188,7 +205,7 @@ namespace ARKitBlendShapeGenerator
                 ComputeContext context,
                 RenderAspects updatedAspects)
             {
-                if (_generatedMesh == null || proxyPairs == null)
+                if (_generatedMesh == null || proxyPairs == null || _component == null)
                 {
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
@@ -204,14 +221,43 @@ namespace ARKitBlendShapeGenerator
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
 
-                if (_component != null)
+                context.Observe(_component);
+
+                float currentIntensityMultiplier = context.Observe(_component, c => c.intensityMultiplier);
+                if (!Mathf.Approximately(currentIntensityMultiplier, _observedIntensityMultiplier))
                 {
-                    var currentTargetRenderer = context.Observe(_component, c => c.targetRenderer);
-                    int currentTargetRendererId = currentTargetRenderer != null ? currentTargetRenderer.GetInstanceID() : 0;
-                    if (currentTargetRendererId != _observedTargetRendererInstanceId)
-                    {
-                        return Task.FromResult<IRenderFilterNode>(null);
-                    }
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                bool currentEnableLeftRightSplit = context.Observe(_component, c => c.enableLeftRightSplit);
+                if (currentEnableLeftRightSplit != _observedEnableLeftRightSplit)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                float currentBlendWidth = context.Observe(_component, c => c.blendWidth);
+                if (!Mathf.Approximately(currentBlendWidth, _observedBlendWidth))
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                bool currentOverwriteExisting = context.Observe(_component, c => c.overwriteExisting);
+                if (currentOverwriteExisting != _observedOverwriteExisting)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                int currentCustomMappingsSignature = BuildCustomMappingsSignature(_component.customMappings);
+                if (currentCustomMappingsSignature != _observedCustomMappingsSignature)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                var currentTargetRenderer = context.Observe(_component, c => c.targetRenderer);
+                int currentTargetRendererId = currentTargetRenderer != null ? currentTargetRenderer.GetInstanceID() : 0;
+                if (currentTargetRendererId != _observedTargetRendererInstanceId)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
                 }
 
                 var pair = proxyPairs.FirstOrDefault();
@@ -284,13 +330,67 @@ namespace ARKitBlendShapeGenerator
                 for (int i = 0; i < mesh.blendShapeCount; i++)
                 {
                     string shapeName = mesh.GetBlendShapeName(i);
-                    if (string.IsNullOrEmpty(shapeName) || _shapeIndices.ContainsKey(shapeName))
+                    if (string.IsNullOrEmpty(shapeName))
                     {
                         continue;
                     }
 
-                    _shapeIndices.Add(shapeName, i);
+                    // 同名がある場合は後勝ちにして、overwriteExistingで再生成された最新indexを使う。
+                    _shapeIndices[shapeName] = i;
                 }
+            }
+
+            private static int BuildCustomMappingsSignature(List<CustomBlendShapeMapping> customMappings)
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    if (customMappings == null)
+                    {
+                        return hash;
+                    }
+
+                    hash = (hash * 31) + customMappings.Count;
+                    foreach (var mapping in customMappings)
+                    {
+                        if (mapping == null)
+                        {
+                            hash = (hash * 31) + 1;
+                            continue;
+                        }
+
+                        hash = (hash * 31) + (mapping.enabled ? 1 : 0);
+                        hash = (hash * 31) + HashString(mapping.arkitName);
+
+                        var sources = mapping.sources;
+                        if (sources == null)
+                        {
+                            hash = (hash * 31) + 2;
+                            continue;
+                        }
+
+                        hash = (hash * 31) + sources.Count;
+                        foreach (var source in sources)
+                        {
+                            if (source == null)
+                            {
+                                hash = (hash * 31) + 3;
+                                continue;
+                            }
+
+                            hash = (hash * 31) + HashString(source.blendShapeName);
+                            hash = (hash * 31) + source.weight.GetHashCode();
+                            hash = (hash * 31) + (int)source.side;
+                        }
+                    }
+
+                    return hash;
+                }
+            }
+
+            private static int HashString(string value)
+            {
+                return value != null ? value.GetHashCode() : 0;
             }
 
             public void Dispose()

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -71,6 +71,18 @@ namespace ARKitBlendShapeGenerator
             }
         }
 
+        private sealed class PlannedBlendShape
+        {
+            public readonly string ArkitName;
+            public readonly List<(int index, float weight, BlendShapeSide side)> Sources;
+
+            public PlannedBlendShape(string arkitName, List<(int index, float weight, BlendShapeSide side)> sources)
+            {
+                ArkitName = arkitName;
+                Sources = sources;
+            }
+        }
+
         public static BlendShapeGenerationResult Generate(
             Mesh sourceMesh,
             Mesh targetMesh,
@@ -100,6 +112,16 @@ namespace ARKitBlendShapeGenerator
                 autoMappings = new List<ARKitMapping>();
             }
 
+            if (CustomMappingValidation.HasDuplicateArkitNames(customMappings, out var duplicateArkitNames))
+            {
+                Debug.LogError(
+                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しているため、生成を中止しました。\n" +
+                    $"重複: {string.Join(", ", duplicateArkitNames)}");
+                return new BlendShapeGenerationResult(
+                    new List<string>(),
+                    new Dictionary<string, int>());
+            }
+
             var existingShapes = new Dictionary<string, int>();
             for (int i = 0; i < sourceMesh.blendShapeCount; i++)
             {
@@ -108,36 +130,59 @@ namespace ARKitBlendShapeGenerator
 
             var generatedShapes = new List<string>();
             var customMappedNames = new HashSet<string>();
+            var plannedBlendShapes = new List<PlannedBlendShape>();
 
-            ProcessCustomMappings(
+            CollectCustomMappings(
                 sourceMesh,
-                targetMesh,
                 customMappings,
                 options,
                 existingShapes,
                 customMappedNames,
-                generatedShapes);
+                plannedBlendShapes);
 
-            ProcessAutoMappings(
+            CollectAutoMappings(
                 sourceMesh,
-                targetMesh,
                 autoMappings,
                 options,
                 existingShapes,
                 customMappedNames,
-                generatedShapes);
+                plannedBlendShapes);
+
+            if (options.OverwriteExisting && plannedBlendShapes.Count > 0)
+            {
+                var namesToReplace = new HashSet<string>(
+                    plannedBlendShapes.Select(planned => planned.ArkitName));
+                namesToReplace.IntersectWith(GetExistingBlendShapeNames(targetMesh));
+
+                if (namesToReplace.Count > 0)
+                {
+                    int removedCount = RemoveBlendShapesByNames(targetMesh, namesToReplace);
+                    if (removedCount > 0)
+                    {
+                        Log(options, $"Replaced existing blendshapes: {string.Join(", ", namesToReplace.OrderBy(name => name))}");
+                    }
+                }
+            }
+
+            foreach (var planned in plannedBlendShapes)
+            {
+                if (TryAddBlendShape(sourceMesh, targetMesh, planned.ArkitName, planned.Sources, options))
+                {
+                    existingShapes[planned.ArkitName] = targetMesh.blendShapeCount - 1;
+                    generatedShapes.Add(planned.ArkitName);
+                }
+            }
 
             return new BlendShapeGenerationResult(generatedShapes, existingShapes);
         }
 
-        private static void ProcessCustomMappings(
+        private static void CollectCustomMappings(
             Mesh sourceMesh,
-            Mesh targetMesh,
             List<CustomBlendShapeMapping> customMappings,
             BlendShapeGenerationOptions options,
             Dictionary<string, int> existingShapes,
             HashSet<string> customMappedNames,
-            List<string> generatedShapes)
+            List<PlannedBlendShape> plannedBlendShapes)
         {
             foreach (var mapping in customMappings)
             {
@@ -183,22 +228,17 @@ namespace ARKitBlendShapeGenerator
                     continue;
                 }
 
-                if (TryAddBlendShape(sourceMesh, targetMesh, mapping.arkitName, sources, options))
-                {
-                    existingShapes[mapping.arkitName] = targetMesh.blendShapeCount - 1;
-                    generatedShapes.Add(mapping.arkitName);
-                }
+                plannedBlendShapes.Add(new PlannedBlendShape(mapping.arkitName, sources));
             }
         }
 
-        private static void ProcessAutoMappings(
+        private static void CollectAutoMappings(
             Mesh sourceMesh,
-            Mesh targetMesh,
             List<ARKitMapping> autoMappings,
             BlendShapeGenerationOptions options,
             Dictionary<string, int> existingShapes,
             HashSet<string> customMappedNames,
-            List<string> generatedShapes)
+            List<PlannedBlendShape> plannedBlendShapes)
         {
             var processedArkitNames = new HashSet<string>();
 
@@ -237,12 +277,8 @@ namespace ARKitBlendShapeGenerator
                 var side = options.EnableLeftRightSplit ? mapping.side : BlendShapeSide.Both;
                 var sourcesWithSide = sources.Select(s => (s.index, s.weight, side)).ToList();
 
-                if (TryAddBlendShape(sourceMesh, targetMesh, mapping.arkitName, sourcesWithSide, options))
-                {
-                    existingShapes[mapping.arkitName] = targetMesh.blendShapeCount - 1;
-                    generatedShapes.Add(mapping.arkitName);
-                    processedArkitNames.Add(mapping.arkitName);
-                }
+                plannedBlendShapes.Add(new PlannedBlendShape(mapping.arkitName, sourcesWithSide));
+                processedArkitNames.Add(mapping.arkitName);
             }
         }
 
@@ -384,52 +420,46 @@ namespace ARKitBlendShapeGenerator
                 return false;
             }
 
-            if (options.OverwriteExisting && ContainsBlendShape(targetMesh, arkitName))
-            {
-                if (RemoveBlendShapeByName(targetMesh, arkitName))
-                {
-                    Log(options, $"Replaced existing blendshape: {arkitName}");
-                }
-            }
-
             targetMesh.AddBlendShapeFrame(arkitName, 100f, deltaVertices, deltaNormals, deltaTangents);
             Log(options, $"Generated: {arkitName} from {sourceCount} source(s)");
             return true;
         }
 
-        private static bool ContainsBlendShape(Mesh mesh, string shapeName)
+        private static HashSet<string> GetExistingBlendShapeNames(Mesh mesh)
         {
-            if (mesh == null || string.IsNullOrEmpty(shapeName))
+            var result = new HashSet<string>();
+            if (mesh == null)
             {
-                return false;
+                return result;
             }
 
             for (int i = 0; i < mesh.blendShapeCount; i++)
             {
-                if (mesh.GetBlendShapeName(i) == shapeName)
+                var shapeName = mesh.GetBlendShapeName(i);
+                if (!string.IsNullOrEmpty(shapeName))
                 {
-                    return true;
+                    result.Add(shapeName);
                 }
             }
 
-            return false;
+            return result;
         }
 
-        private static bool RemoveBlendShapeByName(Mesh mesh, string shapeName)
+        private static int RemoveBlendShapesByNames(Mesh mesh, HashSet<string> shapeNamesToRemove)
         {
-            if (mesh == null || string.IsNullOrEmpty(shapeName))
+            if (mesh == null || shapeNamesToRemove == null || shapeNamesToRemove.Count == 0)
             {
-                return false;
+                return 0;
             }
 
             int blendShapeCount = mesh.blendShapeCount;
             if (blendShapeCount == 0)
             {
-                return false;
+                return 0;
             }
 
             int vertexCount = mesh.vertexCount;
-            bool removed = false;
+            int removedCount = 0;
             var preserved = new List<BlendShapeData>(blendShapeCount);
 
             for (int shapeIndex = 0; shapeIndex < blendShapeCount; shapeIndex++)
@@ -440,9 +470,9 @@ namespace ARKitBlendShapeGenerator
                     continue;
                 }
 
-                if (existingName == shapeName)
+                if (shapeNamesToRemove.Contains(existingName))
                 {
-                    removed = true;
+                    removedCount++;
                     continue;
                 }
 
@@ -472,9 +502,9 @@ namespace ARKitBlendShapeGenerator
                 preserved.Add(new BlendShapeData(existingName, frames));
             }
 
-            if (!removed)
+            if (removedCount == 0)
             {
-                return false;
+                return 0;
             }
 
             mesh.ClearBlendShapes();
@@ -491,7 +521,7 @@ namespace ARKitBlendShapeGenerator
                 }
             }
 
-            return true;
+            return removedCount;
         }
 
         private static void Log(BlendShapeGenerationOptions options, string message)

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -39,6 +39,38 @@ namespace ARKitBlendShapeGenerator
 
     internal static class BlendShapeGenerationEngine
     {
+        private sealed class BlendShapeFrameData
+        {
+            public readonly float Weight;
+            public readonly Vector3[] DeltaVertices;
+            public readonly Vector3[] DeltaNormals;
+            public readonly Vector3[] DeltaTangents;
+
+            public BlendShapeFrameData(
+                float weight,
+                Vector3[] deltaVertices,
+                Vector3[] deltaNormals,
+                Vector3[] deltaTangents)
+            {
+                Weight = weight;
+                DeltaVertices = deltaVertices;
+                DeltaNormals = deltaNormals;
+                DeltaTangents = deltaTangents;
+            }
+        }
+
+        private sealed class BlendShapeData
+        {
+            public readonly string Name;
+            public readonly List<BlendShapeFrameData> Frames;
+
+            public BlendShapeData(string name, List<BlendShapeFrameData> frames)
+            {
+                Name = name;
+                Frames = frames;
+            }
+        }
+
         public static BlendShapeGenerationResult Generate(
             Mesh sourceMesh,
             Mesh targetMesh,
@@ -352,8 +384,113 @@ namespace ARKitBlendShapeGenerator
                 return false;
             }
 
+            if (options.OverwriteExisting && ContainsBlendShape(targetMesh, arkitName))
+            {
+                if (RemoveBlendShapeByName(targetMesh, arkitName))
+                {
+                    Log(options, $"Replaced existing blendshape: {arkitName}");
+                }
+            }
+
             targetMesh.AddBlendShapeFrame(arkitName, 100f, deltaVertices, deltaNormals, deltaTangents);
             Log(options, $"Generated: {arkitName} from {sourceCount} source(s)");
+            return true;
+        }
+
+        private static bool ContainsBlendShape(Mesh mesh, string shapeName)
+        {
+            if (mesh == null || string.IsNullOrEmpty(shapeName))
+            {
+                return false;
+            }
+
+            for (int i = 0; i < mesh.blendShapeCount; i++)
+            {
+                if (mesh.GetBlendShapeName(i) == shapeName)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool RemoveBlendShapeByName(Mesh mesh, string shapeName)
+        {
+            if (mesh == null || string.IsNullOrEmpty(shapeName))
+            {
+                return false;
+            }
+
+            int blendShapeCount = mesh.blendShapeCount;
+            if (blendShapeCount == 0)
+            {
+                return false;
+            }
+
+            int vertexCount = mesh.vertexCount;
+            bool removed = false;
+            var preserved = new List<BlendShapeData>(blendShapeCount);
+
+            for (int shapeIndex = 0; shapeIndex < blendShapeCount; shapeIndex++)
+            {
+                string existingName = mesh.GetBlendShapeName(shapeIndex);
+                if (string.IsNullOrEmpty(existingName))
+                {
+                    continue;
+                }
+
+                if (existingName == shapeName)
+                {
+                    removed = true;
+                    continue;
+                }
+
+                int frameCount = mesh.GetBlendShapeFrameCount(shapeIndex);
+                var frames = new List<BlendShapeFrameData>(frameCount);
+                for (int frameIndex = 0; frameIndex < frameCount; frameIndex++)
+                {
+                    float frameWeight = mesh.GetBlendShapeFrameWeight(shapeIndex, frameIndex);
+                    var deltaVertices = new Vector3[vertexCount];
+                    var deltaNormals = new Vector3[vertexCount];
+                    var deltaTangents = new Vector3[vertexCount];
+
+                    mesh.GetBlendShapeFrameVertices(
+                        shapeIndex,
+                        frameIndex,
+                        deltaVertices,
+                        deltaNormals,
+                        deltaTangents);
+
+                    frames.Add(new BlendShapeFrameData(
+                        frameWeight,
+                        deltaVertices,
+                        deltaNormals,
+                        deltaTangents));
+                }
+
+                preserved.Add(new BlendShapeData(existingName, frames));
+            }
+
+            if (!removed)
+            {
+                return false;
+            }
+
+            mesh.ClearBlendShapes();
+            foreach (var shape in preserved)
+            {
+                foreach (var frame in shape.Frames)
+                {
+                    mesh.AddBlendShapeFrame(
+                        shape.Name,
+                        frame.Weight,
+                        frame.DeltaVertices,
+                        frame.DeltaNormals,
+                        frame.DeltaTangents);
+                }
+            }
+
             return true;
         }
 

--- a/Editor/CustomMappingValidation.cs
+++ b/Editor/CustomMappingValidation.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ARKitBlendShapeGenerator
+{
+    internal static class CustomMappingValidation
+    {
+        public static List<string> GetDuplicateArkitNames(List<CustomBlendShapeMapping> customMappings)
+        {
+            var seen = new HashSet<string>();
+            var duplicates = new HashSet<string>();
+
+            if (customMappings == null)
+            {
+                return new List<string>();
+            }
+
+            foreach (var mapping in customMappings)
+            {
+                if (mapping == null || string.IsNullOrWhiteSpace(mapping.arkitName))
+                {
+                    continue;
+                }
+
+                var arkitName = mapping.arkitName.Trim();
+                if (!seen.Add(arkitName))
+                {
+                    duplicates.Add(arkitName);
+                }
+            }
+
+            return duplicates.OrderBy(name => name).ToList();
+        }
+
+        public static bool HasDuplicateArkitNames(
+            List<CustomBlendShapeMapping> customMappings,
+            out List<string> duplicates)
+        {
+            duplicates = GetDuplicateArkitNames(customMappings);
+            return duplicates.Count > 0;
+        }
+
+        public static string BuildDuplicateMessage(IEnumerable<string> duplicateArkitNames)
+        {
+            if (duplicateArkitNames == null)
+            {
+                return "カスタムマッピングに同一ARKit名の重複があります。";
+            }
+
+            var names = duplicateArkitNames
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .Select(name => name.Trim())
+                .Distinct()
+                .OrderBy(name => name)
+                .ToList();
+
+            if (names.Count == 0)
+            {
+                return "カスタムマッピングに同一ARKit名の重複があります。";
+            }
+
+            return "カスタムマッピングで同一ARKit名は複数設定できません。\n重複: " + string.Join(", ", names);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR improves NDMF preview correctness, stabilizes and speeds up `overwriteExisting=true` blendshape generation, and enforces strict duplicate handling for custom ARKit mappings.
## What Changed
- Refactored `BlendShapeGenerationEngine` flow
- Introduced a plan-first generation flow, then apply in bulk
- Replaced per-shape overwrite removal with bulk replacement when `overwriteExisting=true` to reduce cost
- Added hard stop when duplicate custom ARKit names are detected
- Strengthened preview refresh logic in `ARKitBlendShapeGeneratorPreview`
- Added observation for:
  - `intensityMultiplier`
  - `enableLeftRightSplit`
  - `blendWidth`
  - `overwriteExisting`
  - `targetRenderer`
  - `customMappings` signature
- Updated duplicate blendshape index resolution to use last occurrence (latest generated index)
- Improved custom mapping UI in `ARKitBlendShapeGeneratorEditor`
- Prevented selecting the same ARKit name across multiple custom rows
- Added explicit error UI when duplicates exist (preview/build stop until resolved)
- New mapping now picks the first unused ARKit name; shows dialog when none remain
- Added duplicate guards in both build and preview entry points
- Added shared validator: `CustomMappingValidation`
## Issues Addressed
- `ArgumentException: Blend shape name already exists` when `overwriteExisting=true`
- Stale preview meshes after configuration changes
- Incorrect index targeting when duplicate blendshape names are present
- Ambiguous behavior from duplicate custom ARKit mapping definitions
- Heavy overwrite replacement cost causing long UI stalls during preview
## Scope
- Editor-only changes (no Runtime API contract change)
## Manual Validation Checklist
- Duplicate custom ARKit names cannot be created via inspector UI
- If duplicates exist, preview/build stop with clear error messages
- `overwriteExisting=true/false` behavior matches expected spec
- NDMF Preview ON/OFF works correctly and refreshes on config changes