### PR TITLE
ci: issue/PR作成時にlimit7412を自動アサイン

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,24 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign limit7412
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/issues/$NUMBER/assignees" \
+            -f "assignees[]=limit7412"


### PR DESCRIPTION
## 概要

issue または PR が作成（opened）されたときに、自動的に `limit7412` をアサインする GitHub Actions ワークフローを追加します。

## 変更内容

- `.github/workflows/auto-assign.yml` を新規追加
  - トリガー: `issues` の `opened`、`pull_request_target` の `opened`
  - REST API (`repos/{repo}/issues/{number}/assignees`) を直接呼び出すことで issue / PR の両方に対応
  - 権限は `issues: write` / `pull-requests: write` のみに限定

## 補足

- フォークからの PR にも対応するため `pull_request` ではなく `pull_request_target` を使用しています（チェックアウトは行わず assignee 追加のみのため安全）。
- 自動アサインに使う `GITHUB_TOKEN` は標準提供のもので、追加シークレットの設定は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCt3rKZ5ChS4eDcWk7b2if)_