### PR TITLE
ci: PRマージ時にヘッドブランチを自動削除

### DIFF
--- a/.github/workflows/delete-merged-branch.yml
+++ b/.github/workflows/delete-merged-branch.yml
@@ -1,0 +1,21 @@
+name: Delete Merged Branch
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  delete-branch:
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete head branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          gh api --method DELETE "repos/$REPO/git/refs/heads/$BRANCH"


### PR DESCRIPTION
## 概要

PR がマージされたときに、そのヘッドブランチを自動的に削除する GitHub Actions ワークフローを追加します。

## 変更内容

- `.github/workflows/delete-merged-branch.yml` を新規追加
  - トリガー: `pull_request` の `closed`
  - 条件: `merged == true` かつ 同一リポジトリ内のブランチ（フォークからのPRは対象外）
  - REST API (`DELETE repos/{repo}/git/refs/heads/{branch}`) でブランチを削除
  - 権限は `contents: write` のみに限定

## 補足

- リポジトリ設定の Settings → General → **「Automatically delete head branches」** を有効にすれば、ワークフローなしで同等の挙動になります。そちらを使う場合はこのワークフローは不要です。
- フォークのブランチは削除できない（＆削除すべきでない）ため、同一リポジトリのブランチのみを対象にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCt3rKZ5ChS4eDcWk7b2if)_