### PR TITLE
コンポーネント周りの文言整理とi18n対応

### DIFF
--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEditor;
+using nadena.dev.ndmf.ui;
+using static ARKitBlendShapeGenerator.Localization;
 
 namespace ARKitBlendShapeGenerator
 {
@@ -60,50 +62,46 @@ namespace ARKitBlendShapeGenerator
         {
             serializedObject.Update();
 
-            // ヘッダー
+            // 言語切替 + ヘッダー
+            LanguageSwitcher.DrawImmediate();
             EditorGUILayout.LabelField("ARKit BlendShape Generator", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox(
-                "VRChat/MMDのBlendShapeからARKit用BlendShapeを自動生成します。",
-                MessageType.Info);
+            EditorGUILayout.HelpBox(S("inspector.description"), MessageType.Info);
 
             EditorGUILayout.Space();
 
             // 基本設定
-            EditorGUILayout.LabelField("基本設定", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("targetRenderer"));
+            EditorGUILayout.LabelField(S("inspector.section.basic"), EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("targetRenderer"), G("prop.target_renderer"));
 
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("BlendShapeリストを更新"))
+            if (GUILayout.Button(S("inspector.refresh_list")))
             {
                 RefreshBlendShapeList();
             }
-            EditorGUILayout.LabelField($"検出: {_availableBlendShapes.Count}個", GUILayout.Width(80));
+            EditorGUILayout.LabelField(S("inspector.detected_count", _availableBlendShapes.Count), GUILayout.Width(80));
             EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.Space();
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("intensityMultiplier"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("enableLeftRightSplit"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("blendWidth"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("overwriteExisting"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("intensityMultiplier"), G("prop.intensity_multiplier"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("enableLeftRightSplit"), G("prop.enable_left_right_split"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("blendWidth"), G("prop.blend_width"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("overwriteExisting"), G("prop.overwrite_existing"));
 
             EditorGUILayout.Space();
-            EditorGUILayout.LabelField("口の手続き的生成", EditorStyles.boldLabel);
-            EditorGUILayout.HelpBox(
-                "既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、" +
-                "口領域の頂点移動で自動生成します。既存のBlendShapeは口領域の検出にのみ使用されます。",
-                MessageType.Info);
+            EditorGUILayout.LabelField(S("inspector.section.procedural_mouth"), EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(S("inspector.procedural_mouth.description"), MessageType.Info);
             var enableProceduralProperty = serializedObject.FindProperty("enableProceduralMouthShapes");
-            EditorGUILayout.PropertyField(enableProceduralProperty);
+            EditorGUILayout.PropertyField(enableProceduralProperty, G("prop.enable_procedural_mouth"));
             using (new EditorGUI.DisabledScope(!enableProceduralProperty.boolValue))
             {
-                EditorGUILayout.PropertyField(serializedObject.FindProperty("proceduralMouthIntensity"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("proceduralMouthIntensity"), G("prop.procedural_mouth_intensity"));
             }
 
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
             // カスタムマッピング
-            _showCustomMappings = EditorGUILayout.Foldout(_showCustomMappings, "カスタムマッピング", true);
+            _showCustomMappings = EditorGUILayout.Foldout(_showCustomMappings, S("inspector.section.custom_mappings"), true);
             if (_showCustomMappings)
             {
                 EditorGUI.indentLevel++;
@@ -115,7 +113,7 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
             // プレビュー
-            _showPreview = EditorGUILayout.Foldout(_showPreview, "プレビュー", true);
+            _showPreview = EditorGUILayout.Foldout(_showPreview, S("inspector.section.preview"), true);
             if (_showPreview)
             {
                 EditorGUI.indentLevel++;
@@ -127,7 +125,7 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
 
             // 自動マッピング情報
-            _showAutoMappings = EditorGUILayout.Foldout(_showAutoMappings, "自動マッピング一覧（参照用）", true);
+            _showAutoMappings = EditorGUILayout.Foldout(_showAutoMappings, S("inspector.section.auto_mappings"), true);
             if (_showAutoMappings)
             {
                 EditorGUI.indentLevel++;
@@ -136,11 +134,11 @@ namespace ARKitBlendShapeGenerator
             }
 
             EditorGUILayout.Space();
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("debugMode"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("debugMode"), G("prop.debug_mode"));
 
             // デバッグ: 全SkinnedMeshRendererを表示
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("全メッシュのBlendShape数を表示", EditorStyles.miniButton))
+            if (GUILayout.Button(S("debug.show_all_meshes"), EditorStyles.miniButton))
             {
                 var allRenderers = _component.GetComponentsInChildren<SkinnedMeshRenderer>(true);
                 Debug.Log($"=== 全SkinnedMeshRenderer ({allRenderers.Length}個) ===");
@@ -150,7 +148,7 @@ namespace ARKitBlendShapeGenerator
                     Debug.Log($"  {smr.gameObject.name}: {count} BlendShapes");
                 }
             }
-            if (GUILayout.Button("対象メッシュのBlendShape名を表示", EditorStyles.miniButton))
+            if (GUILayout.Button(S("debug.show_target_shapes"), EditorStyles.miniButton))
             {
                 if (_component.targetRenderer != null && _component.targetRenderer.sharedMesh != null)
                 {
@@ -163,7 +161,7 @@ namespace ARKitBlendShapeGenerator
                 }
                 else
                 {
-                    Debug.LogWarning("[ARKitGenerator] Target Rendererが設定されていません。");
+                    Debug.LogWarning("[ARKitGenerator] " + S("log.target_renderer_not_set"));
                 }
             }
             EditorGUILayout.EndHorizontal();
@@ -200,31 +198,27 @@ namespace ARKitBlendShapeGenerator
 
         private void DrawCustomMappingsUI()
         {
-            EditorGUILayout.HelpBox(
-                "自動マッピングできないBlendShape（視線など）を手動で指定できます。\n" +
-                "ソースBlendShapeを複数指定して合成することも可能です。",
-                MessageType.Info
-            );
+            EditorGUILayout.HelpBox(S("custom_mappings.description"), MessageType.Info);
 
             var duplicateArkitNames = CustomMappingValidation.GetDuplicateArkitNames(_component.customMappings);
             if (duplicateArkitNames.Count > 0)
             {
                 EditorGUILayout.HelpBox(
                     CustomMappingValidation.BuildDuplicateMessage(duplicateArkitNames) +
-                    "\n重複を解消するまでプレビュー/生成は停止されます。",
+                    "\n" + S("custom_mappings.duplicate_blocked"),
                     MessageType.Error);
             }
 
             // VRChat標準表情のみを使用したプリセット
-            EditorGUILayout.LabelField("プリセット", EditorStyles.miniBoldLabel);
+            EditorGUILayout.LabelField(S("presets.label"), EditorStyles.miniBoldLabel);
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("VRChat標準表情のみで設定"))
+            if (GUILayout.Button(S("presets.vrchat_standard")))
             {
                 if (EditorUtility.DisplayDialog(
-                    "VRChat標準表情プリセット",
-                    "MMD用BlendShapeが存在しないアバター向けに、VRChat標準の表情（vrc.v_aa, vrc.v_ih, vrc.v_ou等）のみを使用したマッピングを設定します。\n\n現在のカスタムマッピングは上書きされます。",
-                    "設定する",
-                    "キャンセル"))
+                    S("dialog.title"),
+                    S("dialog.vrchat_preset.message"),
+                    S("dialog.vrchat_preset.apply"),
+                    S("common.cancel")))
                 {
                     ApplyVRChatStandardPreset();
                 }
@@ -234,33 +228,33 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.Space(5);
 
             // カテゴリ別クイック追加ボタン
-            EditorGUILayout.LabelField("カテゴリ別追加", EditorStyles.miniBoldLabel);
+            EditorGUILayout.LabelField(S("category_add.label"), EditorStyles.miniBoldLabel);
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("視線", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.eye_look"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.EyeLook);
             }
-            if (GUILayout.Button("目", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.eye"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Eye);
             }
-            if (GUILayout.Button("眉毛", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.brow"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Brow);
             }
-            if (GUILayout.Button("口", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.mouth"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Mouth);
             }
-            if (GUILayout.Button("頬", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.cheek"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Cheek);
             }
-            if (GUILayout.Button("鼻", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.nose"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Nose);
             }
-            if (GUILayout.Button("舌", EditorStyles.miniButton))
+            if (GUILayout.Button(S("category.tongue"), EditorStyles.miniButton))
             {
                 AddCategoryMappings(ARKitBlendShapeNames.Tongue);
             }
@@ -270,7 +264,7 @@ namespace ARKitBlendShapeGenerator
 
             // 検索フィルタ
             EditorGUILayout.BeginHorizontal();
-            EditorGUILayout.LabelField("検索:", GUILayout.Width(40));
+            EditorGUILayout.LabelField(S("inspector.search"), GUILayout.Width(60));
             _searchFilter = EditorGUILayout.TextField(_searchFilter);
             if (GUILayout.Button("×", GUILayout.Width(20)))
             {
@@ -280,13 +274,13 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.EndHorizontal();
 
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("新規マッピング追加"))
+            if (GUILayout.Button(S("custom_mappings.add_new")))
             {
                 AddNewMapping();
             }
-            if (GUILayout.Button("全て削除", GUILayout.Width(80)))
+            if (GUILayout.Button(S("custom_mappings.delete_all"), GUILayout.Width(80)))
             {
-                if (EditorUtility.DisplayDialog("ARKit BlendShape Generator", "全てのカスタムマッピングを削除しますか？", "はい", "いいえ"))
+                if (EditorUtility.DisplayDialog(S("dialog.title"), S("dialog.delete_all.message"), S("common.yes"), S("common.no")))
                 {
                     _component.customMappings.Clear();
                     MarkComponentChanged();
@@ -298,7 +292,7 @@ namespace ARKitBlendShapeGenerator
 
             // マッピング数表示
             int enabledCount = _component.customMappings.Count(m => m.enabled);
-            EditorGUILayout.LabelField($"マッピング: {enabledCount}/{_component.customMappings.Count} 有効");
+            EditorGUILayout.LabelField(S("custom_mappings.count", enabledCount, _component.customMappings.Count));
 
             // マッピングリスト表示
             string normalizedFilter = string.IsNullOrWhiteSpace(_searchFilter)
@@ -321,7 +315,7 @@ namespace ARKitBlendShapeGenerator
 
             if (visibleCount == 0)
             {
-                EditorGUILayout.LabelField("該当するマッピングはありません。", EditorStyles.miniLabel);
+                EditorGUILayout.LabelField(S("custom_mappings.none_matching"), EditorStyles.miniLabel);
                 return;
             }
 
@@ -473,7 +467,7 @@ namespace ARKitBlendShapeGenerator
             var selectableArkitNames = GetSelectableArkitNames(index);
             if (selectableArkitNames.Count == 0)
             {
-                EditorGUILayout.LabelField("(利用可能なARKit名なし)");
+                EditorGUILayout.LabelField(S("custom_mappings.no_available_names"));
             }
             else
             {
@@ -529,7 +523,8 @@ namespace ARKitBlendShapeGenerator
             // BlendShape名のドロップダウン
             if (_availableBlendShapes.Count > 0)
             {
-                var options = new List<string> { "(選択してください)" };
+                string notFoundSuffix = S("source.not_found_suffix");
+                var options = new List<string> { S("source.placeholder") };
                 options.AddRange(_availableBlendShapes);
 
                 int currentIdx = _availableBlendShapes.IndexOf(source.blendShapeName) + 1;
@@ -537,7 +532,7 @@ namespace ARKitBlendShapeGenerator
                 // リストにない名前が設定されている場合は末尾に追加して表示
                 if (currentIdx == 0 && !string.IsNullOrEmpty(source.blendShapeName))
                 {
-                    options.Add(source.blendShapeName + " (未検出)");
+                    options.Add(source.blendShapeName + notFoundSuffix);
                     currentIdx = options.Count - 1;
                 }
 
@@ -547,9 +542,9 @@ namespace ARKitBlendShapeGenerator
                 {
                     // 「(未検出)」付きの項目が選択された場合は元の名前を維持
                     string selectedName = options[newIdx];
-                    if (selectedName.EndsWith(" (未検出)"))
+                    if (selectedName.EndsWith(notFoundSuffix))
                     {
-                        selectedName = selectedName.Replace(" (未検出)", "");
+                        selectedName = selectedName.Replace(notFoundSuffix, "");
                     }
 
                     if (source.blendShapeName != selectedName)
@@ -579,7 +574,8 @@ namespace ARKitBlendShapeGenerator
             }
 
             // 左右適用範囲
-            BlendShapeSide newSide = (BlendShapeSide)EditorGUILayout.EnumPopup(source.side, GUILayout.Width(70));
+            var sideLabels = new[] { S("enum.side.both"), S("enum.side.left_only"), S("enum.side.right_only") };
+            BlendShapeSide newSide = (BlendShapeSide)EditorGUILayout.Popup((int)source.side, sideLabels, GUILayout.Width(70));
             if (newSide != source.side)
             {
                 source.side = newSide;
@@ -602,9 +598,9 @@ namespace ARKitBlendShapeGenerator
             if (string.IsNullOrEmpty(firstUnusedArkitName))
             {
                 EditorUtility.DisplayDialog(
-                    "ARKit BlendShape Generator",
-                    "追加可能なARKit名がありません。\n既存マッピングを削除するか、ARKit名を変更してください。",
-                    "OK");
+                    S("dialog.title"),
+                    S("dialog.no_available_name.message"),
+                    S("common.ok"));
                 return;
             }
 
@@ -678,7 +674,7 @@ namespace ARKitBlendShapeGenerator
 
             if (_component.debugMode)
             {
-                Debug.Log("[ARKitGenerator] VRChat標準表情プリセットを適用しました");
+                Debug.Log("[ARKitGenerator] " + S("log.preset_applied"));
             }
         }
 
@@ -745,7 +741,7 @@ namespace ARKitBlendShapeGenerator
             var isNdmfPreviewEnabled = ARKitBlendShapeGeneratorPreview.EnableNode.IsEnabled.Value;
 
             EditorGUILayout.Space(5);
-            EditorGUILayout.LabelField("リアルタイムプレビュー", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(S("preview.realtime"), EditorStyles.boldLabel);
 
             int componentId = _component.GetInstanceID();
             ARKitBlendShapeGeneratorPreviewState.BeginEdit(componentId);
@@ -759,13 +755,13 @@ namespace ARKitBlendShapeGenerator
 
             EditorGUILayout.BeginHorizontal();
             GUI.enabled = isActive;
-            if (GUILayout.Button("リセット"))
+            if (GUILayout.Button(S("preview.reset")))
             {
                 ARKitBlendShapeGeneratorPreviewState.SetAllWeights(componentId, new string[0], 0f);
                 previewState = ARKitBlendShapeGeneratorPreviewState.Current;
                 SceneView.RepaintAll();
             }
-            if (GUILayout.Button("カテゴリ", GUILayout.Width(90)))
+            if (GUILayout.Button(S("preview.categories"), GUILayout.Width(90)))
             {
                 ShowPreviewCategoryDropdown();
             }
@@ -780,16 +776,14 @@ namespace ARKitBlendShapeGenerator
 
             if (_showNdmfOffWarning && !isNdmfPreviewEnabled)
             {
-                EditorGUILayout.HelpBox(
-                    "NDMF PreviewがOFFのため、値の変更は見た目に反映されません。",
-                    MessageType.Warning);
+                EditorGUILayout.HelpBox(S("preview.ndmf_off_warning"), MessageType.Warning);
             }
 
             _previewScrollPosition = EditorGUILayout.BeginScrollView(_previewScrollPosition, GUILayout.MaxHeight(260));
             if (_showPreviewCategoryCustom)
             {
                 DrawPreviewCategory(
-                    "カスタム",
+                    S("preview.category.custom"),
                     previewCategories.Custom,
                     componentId,
                     ref previewState,
@@ -798,7 +792,7 @@ namespace ARKitBlendShapeGenerator
             if (_showPreviewCategoryAuto)
             {
                 DrawPreviewCategory(
-                    "自動生成",
+                    S("preview.category.auto"),
                     previewCategories.AutoGenerated,
                     componentId,
                     ref previewState,
@@ -807,7 +801,7 @@ namespace ARKitBlendShapeGenerator
             if (_showPreviewCategoryOriginal)
             {
                 DrawPreviewCategory(
-                    "元からあるBlendShape",
+                    S("preview.category.original"),
                     previewCategories.Original,
                     componentId,
                     ref previewState,
@@ -820,17 +814,17 @@ namespace ARKitBlendShapeGenerator
         {
             var menu = new GenericMenu();
 
-            menu.AddItem(new GUIContent("カスタム"), _showPreviewCategoryCustom, () =>
+            menu.AddItem(new GUIContent(S("preview.category.custom")), _showPreviewCategoryCustom, () =>
             {
                 _showPreviewCategoryCustom = !_showPreviewCategoryCustom;
                 Repaint();
             });
-            menu.AddItem(new GUIContent("自動生成"), _showPreviewCategoryAuto, () =>
+            menu.AddItem(new GUIContent(S("preview.category.auto")), _showPreviewCategoryAuto, () =>
             {
                 _showPreviewCategoryAuto = !_showPreviewCategoryAuto;
                 Repaint();
             });
-            menu.AddItem(new GUIContent("元からあるBlendShape"), _showPreviewCategoryOriginal, () =>
+            menu.AddItem(new GUIContent(S("preview.category.original")), _showPreviewCategoryOriginal, () =>
             {
                 _showPreviewCategoryOriginal = !_showPreviewCategoryOriginal;
                 Repaint();
@@ -901,7 +895,7 @@ namespace ARKitBlendShapeGenerator
 
             if (shapeNames == null || shapeNames.Count == 0)
             {
-                EditorGUILayout.LabelField("なし", EditorStyles.miniLabel);
+                EditorGUILayout.LabelField(S("preview.category.empty"), EditorStyles.miniLabel);
                 return;
             }
 
@@ -1053,86 +1047,82 @@ namespace ARKitBlendShapeGenerator
 
         private void DrawAutoMappingsInfo()
         {
-            EditorGUILayout.HelpBox(
-                "以下のBlendShapeは自動的にマッピングされます。\n" +
-                "カスタムマッピングで同じARKit名を指定した場合、カスタム設定が優先されます。",
-                MessageType.Info
-            );
+            EditorGUILayout.HelpBox(S("auto_mappings.description"), MessageType.Info);
 
             // 目
-            _foldEye = EditorGUILayout.Foldout(_foldEye, "目 (Eye)");
+            _foldEye = EditorGUILayout.Foldout(_foldEye, S("auto_mappings.fold.eye"));
             if (_foldEye)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("eyeBlinkLeft/Right", "← vrc.blink_left/right, まばたき, ウィンク");
-                EditorGUILayout.LabelField("eyeSquintLeft/Right", "← 笑い, にこり, ><");
-                EditorGUILayout.LabelField("eyeWideLeft/Right", "← びっくり, 見開き");
+                EditorGUILayout.LabelField("eyeBlinkLeft/Right", S("auto_mappings.row.eye_blink"));
+                EditorGUILayout.LabelField("eyeSquintLeft/Right", S("auto_mappings.row.eye_squint"));
+                EditorGUILayout.LabelField("eyeWideLeft/Right", S("auto_mappings.row.eye_wide"));
                 EditorGUI.indentLevel--;
             }
 
             // 視線
-            _foldEyeLook = EditorGUILayout.Foldout(_foldEyeLook, "視線 (Eye Look) ※通常は手動設定が必要");
+            _foldEyeLook = EditorGUILayout.Foldout(_foldEyeLook, S("auto_mappings.fold.eye_look"));
             if (_foldEyeLook)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("eyeLookUpLeft/Right", "← (手動設定推奨)");
-                EditorGUILayout.LabelField("eyeLookDownLeft/Right", "← (手動設定推奨)");
-                EditorGUILayout.LabelField("eyeLookInLeft/Right", "← より目");
-                EditorGUILayout.LabelField("eyeLookOutLeft/Right", "← (手動設定推奨)");
+                EditorGUILayout.LabelField("eyeLookUpLeft/Right", S("auto_mappings.row.manual"));
+                EditorGUILayout.LabelField("eyeLookDownLeft/Right", S("auto_mappings.row.manual"));
+                EditorGUILayout.LabelField("eyeLookInLeft/Right", S("auto_mappings.row.eye_look_in"));
+                EditorGUILayout.LabelField("eyeLookOutLeft/Right", S("auto_mappings.row.manual"));
                 EditorGUI.indentLevel--;
             }
 
             // 眉毛
-            _foldBrow = EditorGUILayout.Foldout(_foldBrow, "眉毛 (Brow)");
+            _foldBrow = EditorGUILayout.Foldout(_foldBrow, S("auto_mappings.fold.brow"));
             if (_foldBrow)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("browDownLeft/Right", "← 怒り, 真面目, 困る");
-                EditorGUILayout.LabelField("browInnerUp", "← 困る, 上, 悲しい");
-                EditorGUILayout.LabelField("browOuterUpLeft/Right", "← 上, 驚き");
+                EditorGUILayout.LabelField("browDownLeft/Right", S("auto_mappings.row.brow_down"));
+                EditorGUILayout.LabelField("browInnerUp", S("auto_mappings.row.brow_inner_up"));
+                EditorGUILayout.LabelField("browOuterUpLeft/Right", S("auto_mappings.row.brow_outer_up"));
                 EditorGUI.indentLevel--;
             }
 
             // 口
-            _foldMouth = EditorGUILayout.Foldout(_foldMouth, "口 (Mouth)");
+            _foldMouth = EditorGUILayout.Foldout(_foldMouth, S("auto_mappings.fold.mouth"));
             if (_foldMouth)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("jawOpen", "← vrc.v_aa, あ (70%)");
-                EditorGUILayout.LabelField("mouthFunnel", "← vrc.v_ou, う");
-                EditorGUILayout.LabelField("mouthPucker", "← vrc.v_ou, う, ω (120%)");
-                EditorGUILayout.LabelField("mouthSmileLeft/Right", "← にやり, ∧, にっこり");
-                EditorGUILayout.LabelField("mouthFrownLeft/Right", "← への字, 悲しみ");
-                EditorGUILayout.LabelField("mouthLeft/Right", "← 手続き的生成（口領域を頂点移動）");
-                EditorGUILayout.LabelField("jawLeft/Right/Forward", "← 手続き的生成（口領域を頂点移動）");
+                EditorGUILayout.LabelField("jawOpen", S("auto_mappings.row.jaw_open"));
+                EditorGUILayout.LabelField("mouthFunnel", S("auto_mappings.row.mouth_funnel"));
+                EditorGUILayout.LabelField("mouthPucker", S("auto_mappings.row.mouth_pucker"));
+                EditorGUILayout.LabelField("mouthSmileLeft/Right", S("auto_mappings.row.mouth_smile"));
+                EditorGUILayout.LabelField("mouthFrownLeft/Right", S("auto_mappings.row.mouth_frown"));
+                EditorGUILayout.LabelField("mouthLeft/Right", S("auto_mappings.row.procedural"));
+                EditorGUILayout.LabelField("jawLeft/Right/Forward", S("auto_mappings.row.procedural"));
                 EditorGUI.indentLevel--;
             }
 
             // 頬
-            _foldCheek = EditorGUILayout.Foldout(_foldCheek, "頬 (Cheek)");
+            _foldCheek = EditorGUILayout.Foldout(_foldCheek, S("auto_mappings.fold.cheek"));
             if (_foldCheek)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("cheekPuff", "← ぷく, 膨らみ");
-                EditorGUILayout.LabelField("cheekSquintLeft/Right", "← 笑い, にこり");
+                EditorGUILayout.LabelField("cheekPuff", S("auto_mappings.row.cheek_puff"));
+                EditorGUILayout.LabelField("cheekSquintLeft/Right", S("auto_mappings.row.cheek_squint"));
                 EditorGUI.indentLevel--;
             }
 
             // 鼻
-            _foldNose = EditorGUILayout.Foldout(_foldNose, "鼻 (Nose)");
+            _foldNose = EditorGUILayout.Foldout(_foldNose, S("auto_mappings.fold.nose"));
             if (_foldNose)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("noseSneerLeft/Right", "← 怒り");
+                EditorGUILayout.LabelField("noseSneerLeft/Right", S("auto_mappings.row.nose_sneer"));
                 EditorGUI.indentLevel--;
             }
 
             // 舌
-            _foldTongue = EditorGUILayout.Foldout(_foldTongue, "舌 (Tongue)");
+            _foldTongue = EditorGUILayout.Foldout(_foldTongue, S("auto_mappings.fold.tongue"));
             if (_foldTongue)
             {
                 EditorGUI.indentLevel++;
-                EditorGUILayout.LabelField("tongueOut", "← べー, 舌");
+                EditorGUILayout.LabelField("tongueOut", S("auto_mappings.row.tongue_out"));
                 EditorGUI.indentLevel--;
             }
         }

--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -89,8 +89,8 @@ namespace ARKitBlendShapeGenerator
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("口の手続き的生成", EditorStyles.boldLabel);
             EditorGUILayout.HelpBox(
-                "既存シェイプキーから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、" +
-                "口領域の頂点移動で自動生成します。既存シェイプキーは口領域の検出にのみ使用されます。",
+                "既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、" +
+                "口領域の頂点移動で自動生成します。既存のBlendShapeは口領域の検出にのみ使用されます。",
                 MessageType.Info);
             var enableProceduralProperty = serializedObject.FindProperty("enableProceduralMouthShapes");
             EditorGUILayout.PropertyField(enableProceduralProperty);
@@ -150,7 +150,7 @@ namespace ARKitBlendShapeGenerator
                     Debug.Log($"  {smr.gameObject.name}: {count} BlendShapes");
                 }
             }
-            if (GUILayout.Button("特定メッシュのBlendShape名を表示", EditorStyles.miniButton))
+            if (GUILayout.Button("対象メッシュのBlendShape名を表示", EditorStyles.miniButton))
             {
                 if (_component.targetRenderer != null && _component.targetRenderer.sharedMesh != null)
                 {
@@ -163,7 +163,7 @@ namespace ARKitBlendShapeGenerator
                 }
                 else
                 {
-                    Debug.LogWarning("Target Renderer not set");
+                    Debug.LogWarning("[ARKitGenerator] Target Rendererが設定されていません。");
                 }
             }
             EditorGUILayout.EndHorizontal();
@@ -222,7 +222,7 @@ namespace ARKitBlendShapeGenerator
             {
                 if (EditorUtility.DisplayDialog(
                     "VRChat標準表情プリセット",
-                    "MMD用シェイプキーが存在しないアバター向けに、VRChat標準の表情（vrc.v_aa, vrc.v_ih, vrc.v_ou等）のみを使用したマッピングを設定します。\n\n現在のカスタムマッピングは上書きされます。",
+                    "MMD用BlendShapeが存在しないアバター向けに、VRChat標準の表情（vrc.v_aa, vrc.v_ih, vrc.v_ou等）のみを使用したマッピングを設定します。\n\n現在のカスタムマッピングは上書きされます。",
                     "設定する",
                     "キャンセル"))
                 {
@@ -286,7 +286,7 @@ namespace ARKitBlendShapeGenerator
             }
             if (GUILayout.Button("全て削除", GUILayout.Width(80)))
             {
-                if (EditorUtility.DisplayDialog("確認", "全てのカスタムマッピングを削除しますか？", "はい", "いいえ"))
+                if (EditorUtility.DisplayDialog("ARKit BlendShape Generator", "全てのカスタムマッピングを削除しますか？", "はい", "いいえ"))
                 {
                     _component.customMappings.Clear();
                     MarkComponentChanged();
@@ -807,7 +807,7 @@ namespace ARKitBlendShapeGenerator
             if (_showPreviewCategoryOriginal)
             {
                 DrawPreviewCategory(
-                    "このツールで生成されるシェイプキー以外の元からあるシェイプキー",
+                    "元からあるBlendShape",
                     previewCategories.Original,
                     componentId,
                     ref previewState,
@@ -830,7 +830,7 @@ namespace ARKitBlendShapeGenerator
                 _showPreviewCategoryAuto = !_showPreviewCategoryAuto;
                 Repaint();
             });
-            menu.AddItem(new GUIContent("元からあるシェイプキー"), _showPreviewCategoryOriginal, () =>
+            menu.AddItem(new GUIContent("元からあるBlendShape"), _showPreviewCategoryOriginal, () =>
             {
                 _showPreviewCategoryOriginal = !_showPreviewCategoryOriginal;
                 Repaint();

--- a/Editor/ARKitBlendShapeGeneratorPlugin.cs
+++ b/Editor/ARKitBlendShapeGeneratorPlugin.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using nadena.dev.ndmf;
+using static ARKitBlendShapeGenerator.Localization;
 
 [assembly: ExportsPlugin(typeof(ARKitBlendShapeGenerator.ARKitBlendShapeGeneratorPlugin))]
 
@@ -28,7 +29,7 @@ namespace ARKitBlendShapeGenerator
                     if (components.Length > 1 && primaryComponent != null)
                     {
                         Debug.LogWarning(
-                            $"[ARKitGenerator] 同一アバター内で複数のARKitBlendShapeGeneratorComponentが検出されました。\"{primaryComponent.name}\" のみ処理します。",
+                            "[ARKitGenerator] " + S("log.multiple_components", primaryComponent.name),
                             primaryComponent);
                     }
 
@@ -63,8 +64,7 @@ namespace ARKitBlendShapeGenerator
             if (CustomMappingValidation.HasDuplicateArkitNames(component.customMappings, out var duplicateArkitNames))
             {
                 Debug.LogError(
-                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しているため、生成を中止しました。\n" +
-                    $"重複: {string.Join(", ", duplicateArkitNames)}",
+                    "[ARKitGenerator] " + S("log.duplicate_abort", string.Join(", ", duplicateArkitNames)),
                     component);
                 return;
             }
@@ -77,7 +77,7 @@ namespace ARKitBlendShapeGenerator
 
             if (renderer == null || renderer.sharedMesh == null)
             {
-                Debug.LogWarning("[ARKitGenerator] SkinnedMeshRendererが見つかりません。");
+                Debug.LogWarning("[ARKitGenerator] " + S("log.renderer_not_found"));
                 return;
             }
 

--- a/Editor/ARKitBlendShapeGeneratorPlugin.cs
+++ b/Editor/ARKitBlendShapeGeneratorPlugin.cs
@@ -77,7 +77,7 @@ namespace ARKitBlendShapeGenerator
 
             if (renderer == null || renderer.sharedMesh == null)
             {
-                Debug.LogWarning("[ARKitGenerator] SkinnedMeshRenderer not found");
+                Debug.LogWarning("[ARKitGenerator] SkinnedMeshRendererが見つかりません。");
                 return;
             }
 

--- a/Editor/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/ARKitBlendShapeGeneratorPreview.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using nadena.dev.ndmf;
 using nadena.dev.ndmf.preview;
 using UnityEngine;
+using static ARKitBlendShapeGenerator.Localization;
 
 namespace ARKitBlendShapeGenerator
 {
@@ -109,8 +110,7 @@ namespace ARKitBlendShapeGenerator
             if (CustomMappingValidation.HasDuplicateArkitNames(component.customMappings, out var duplicateArkitNames))
             {
                 Debug.LogError(
-                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しています。重複を解消するまでプレビューを停止します。\n" +
-                    $"重複: {string.Join(", ", duplicateArkitNames)}",
+                    "[ARKitGenerator] " + S("log.duplicate_preview_stop", string.Join(", ", duplicateArkitNames)),
                     component);
                 return Task.FromResult<IRenderFilterNode>(null);
             }

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using static ARKitBlendShapeGenerator.Localization;
 
 namespace ARKitBlendShapeGenerator
 {
@@ -119,8 +120,7 @@ namespace ARKitBlendShapeGenerator
             if (CustomMappingValidation.HasDuplicateArkitNames(customMappings, out var duplicateArkitNames))
             {
                 Debug.LogError(
-                    "[ARKitGenerator] カスタムマッピングで同一ARKit名が重複しているため、生成を中止しました。\n" +
-                    $"重複: {string.Join(", ", duplicateArkitNames)}");
+                    "[ARKitGenerator] " + S("log.duplicate_abort", string.Join(", ", duplicateArkitNames)));
                 return new BlendShapeGenerationResult(
                     new List<string>(),
                     new Dictionary<string, int>());

--- a/Editor/CustomMappingValidation.cs
+++ b/Editor/CustomMappingValidation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using static ARKitBlendShapeGenerator.Localization;
 
 namespace ARKitBlendShapeGenerator
 {
@@ -44,7 +45,7 @@ namespace ARKitBlendShapeGenerator
         {
             if (duplicateArkitNames == null)
             {
-                return "カスタムマッピングに同一ARKit名の重複があります。";
+                return S("validation.duplicate.generic");
             }
 
             var names = duplicateArkitNames
@@ -56,10 +57,10 @@ namespace ARKitBlendShapeGenerator
 
             if (names.Count == 0)
             {
-                return "カスタムマッピングに同一ARKit名の重複があります。";
+                return S("validation.duplicate.generic");
             }
 
-            return "カスタムマッピングで同一ARKit名は複数設定できません。\n重複: " + string.Join(", ", names);
+            return S("validation.duplicate.message", string.Join(", ", names));
         }
     }
 }

--- a/Editor/DuplicateComponentGuard.cs
+++ b/Editor/DuplicateComponentGuard.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator
+{
+    /// <summary>
+    /// 同一アバター内にARKitBlendShapeGeneratorComponentが複数配置された場合、
+    /// 後から追加されたコンポーネントを自動削除するガード
+    /// RuntimeコンポーネントのOnValidateフック経由で呼び出される
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class DuplicateComponentGuard
+    {
+        private static readonly HashSet<int> PendingRemoval = new HashSet<int>();
+
+        static DuplicateComponentGuard()
+        {
+            ARKitBlendShapeGeneratorComponent.EditorOnValidateHook = EnforceSingleComponentPerAvatar;
+        }
+
+        private static void EnforceSingleComponentPerAvatar(ARKitBlendShapeGeneratorComponent component)
+        {
+            if (component == null)
+            {
+                return;
+            }
+
+            var avatarRoot = FindAvatarRootForUniqueness(component);
+            if (avatarRoot == null)
+            {
+                return;
+            }
+
+            var components = avatarRoot.GetComponentsInChildren<ARKitBlendShapeGeneratorComponent>(true)
+                .Where(c => c != null)
+                .ToArray();
+
+            int instanceId = component.GetInstanceID();
+            if (components.Length <= 1)
+            {
+                PendingRemoval.Remove(instanceId);
+                return;
+            }
+
+            var primary = SelectPrimaryComponent(avatarRoot, components);
+            if (primary == component)
+            {
+                PendingRemoval.Remove(instanceId);
+                return;
+            }
+
+            if (!PendingRemoval.Add(instanceId))
+            {
+                return;
+            }
+
+            Debug.LogWarning("[ARKitGenerator] " + S("guard.log.duplicate"), component);
+
+            EditorApplication.delayCall += () =>
+            {
+                PendingRemoval.Remove(instanceId);
+
+                if (component == null || avatarRoot == null)
+                {
+                    return;
+                }
+
+                var refreshed = avatarRoot.GetComponentsInChildren<ARKitBlendShapeGeneratorComponent>(true)
+                    .Where(c => c != null)
+                    .ToArray();
+                var refreshedPrimary = SelectPrimaryComponent(avatarRoot, refreshed);
+
+                if (refreshedPrimary != component)
+                {
+                    Object.DestroyImmediate(component);
+
+                    if (!Application.isBatchMode)
+                    {
+                        EditorUtility.DisplayDialog(
+                            S("dialog.title"),
+                            S("guard.dialog.duplicate_removed"),
+                            S("common.ok"));
+                    }
+                }
+            };
+        }
+
+        private static Transform FindAvatarRootForUniqueness(ARKitBlendShapeGeneratorComponent component)
+        {
+            Transform lastDescriptorRoot = null;
+            var cursor = component.transform;
+
+            while (cursor != null)
+            {
+                if (HasAvatarDescriptor(cursor.gameObject))
+                {
+                    lastDescriptorRoot = cursor;
+                }
+
+                cursor = cursor.parent;
+            }
+
+            if (lastDescriptorRoot != null)
+            {
+                return lastDescriptorRoot;
+            }
+
+            return component.transform.root;
+        }
+
+        private static bool HasAvatarDescriptor(GameObject go)
+        {
+            if (go == null)
+            {
+                return false;
+            }
+
+            var components = go.GetComponents<Component>();
+            foreach (var component in components)
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                if (component.GetType().Name == "VRCAvatarDescriptor")
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ARKitBlendShapeGeneratorComponent SelectPrimaryComponent(
+            Transform avatarRoot,
+            ARKitBlendShapeGeneratorComponent[] components)
+        {
+            if (components == null || components.Length == 0)
+            {
+                return null;
+            }
+
+            if (avatarRoot != null)
+            {
+                var onRoot = components.FirstOrDefault(c => c != null && c.transform == avatarRoot);
+                if (onRoot != null)
+                {
+                    return onRoot;
+                }
+            }
+
+            return components[0];
+        }
+    }
+}

--- a/Editor/DuplicateComponentGuard.cs
+++ b/Editor/DuplicateComponentGuard.cs
@@ -75,7 +75,7 @@ namespace ARKitBlendShapeGenerator
 
                 if (refreshedPrimary != component)
                 {
-                    Object.DestroyImmediate(component);
+                    Undo.DestroyObjectImmediate(component);
 
                     if (!Application.isBatchMode)
                     {
@@ -113,26 +113,9 @@ namespace ARKitBlendShapeGenerator
 
         private static bool HasAvatarDescriptor(GameObject go)
         {
-            if (go == null)
-            {
-                return false;
-            }
-
-            var components = go.GetComponents<Component>();
-            foreach (var component in components)
-            {
-                if (component == null)
-                {
-                    continue;
-                }
-
-                if (component.GetType().Name == "VRCAvatarDescriptor")
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            // 文字列指定のGetComponentは配列アロケーションなしで型名一致を判定できる
+            // （EditorアセンブリはVRC SDKを参照していないため型名での判定が必要）
+            return go != null && go.GetComponent("VRCAvatarDescriptor") != null;
         }
 
         private static ARKitBlendShapeGeneratorComponent SelectPrimaryComponent(

--- a/Editor/Localization/Localization.cs
+++ b/Editor/Localization/Localization.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+using nadena.dev.ndmf.localization;
+
+namespace ARKitBlendShapeGenerator
+{
+    /// <summary>
+    /// NDMFのローカライズ機構を利用した文言管理
+    /// 翻訳ファイルは Editor/Localization/*.po に配置する
+    /// </summary>
+    internal static class Localization
+    {
+        private const string DefaultLanguage = "ja-jp";
+        private const string FallbackLocalizationRoot =
+            "Packages/com.qazx7412.kx-vrc-arkit-blendshape-generator/Editor/Localization";
+
+        private static readonly string[] SupportedLanguages = { "ja-jp", "en-us" };
+
+        internal static readonly Localizer Localizer = new Localizer(DefaultLanguage, LoadLocalizationAssets);
+
+        private static List<LocalizationAsset> LoadLocalizationAssets()
+        {
+            var assets = new List<LocalizationAsset>();
+            var root = GetLocalizationRoot();
+
+            foreach (var language in SupportedLanguages)
+            {
+                var asset = AssetDatabase.LoadAssetAtPath<LocalizationAsset>($"{root}/{language}.po");
+                if (asset != null)
+                {
+                    assets.Add(asset);
+                }
+            }
+
+            return assets;
+        }
+
+        private static string GetLocalizationRoot()
+        {
+            // Assets/配下・Packages/配下のどちらに置かれても解決できるよう、asmdefの位置から辿る
+            var asmdefPath = CompilationPipeline.GetAssemblyDefinitionFilePathFromAssemblyName(
+                "ARKitBlendShapeGenerator.Editor");
+            if (string.IsNullOrEmpty(asmdefPath))
+            {
+                return FallbackLocalizationRoot;
+            }
+
+            var directory = Path.GetDirectoryName(asmdefPath);
+            if (string.IsNullOrEmpty(directory))
+            {
+                return FallbackLocalizationRoot;
+            }
+
+            return directory.Replace('\\', '/') + "/Localization";
+        }
+
+        internal static string S(string key)
+        {
+            return Localizer.GetLocalizedString(key);
+        }
+
+        internal static string S(string key, params object[] args)
+        {
+            return string.Format(S(key), args);
+        }
+
+        internal static GUIContent G(string key)
+        {
+            return Localizer.TryGetLocalizedString(key + ".tooltip", out var tooltip)
+                ? new GUIContent(S(key), tooltip)
+                : new GUIContent(S(key));
+        }
+    }
+}

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -299,6 +299,26 @@ msgstr "Target Renderer is not set."
 msgid "log.preset_applied"
 msgstr "Applied the VRChat standard viseme preset"
 
+# Build / preview logs
+msgid "log.multiple_components"
+msgstr "Multiple ARKitBlendShapeGeneratorComponents were found on the same avatar. Only \"{0}\" will be processed."
+
+msgid "log.duplicate_abort"
+msgstr "Generation was aborted because the same ARKit name is duplicated in the custom mappings.\nDuplicates: {0}"
+
+msgid "log.duplicate_preview_stop"
+msgstr "The same ARKit name is duplicated in the custom mappings. Preview is suspended until the duplicates are resolved.\nDuplicates: {0}"
+
+msgid "log.renderer_not_found"
+msgstr "SkinnedMeshRenderer not found."
+
+# Duplicate component guard
+msgid "guard.log.duplicate"
+msgstr "Only one ARKitBlendShapeGeneratorComponent can be placed per avatar. The duplicate component will be removed."
+
+msgid "guard.dialog.duplicate_removed"
+msgstr "Only one ARKitBlendShapeGeneratorComponent can be placed per avatar.\n\nThe duplicate component that was added has been removed."
+
 # Validation
 msgid "validation.duplicate.generic"
 msgstr "There are duplicate ARKit names in the custom mappings."

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -1,0 +1,307 @@
+msgid ""
+msgstr ""
+"Language: en-us\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# Common
+msgid "common.ok"
+msgstr "OK"
+
+msgid "common.yes"
+msgstr "Yes"
+
+msgid "common.no"
+msgstr "No"
+
+msgid "common.cancel"
+msgstr "Cancel"
+
+msgid "dialog.title"
+msgstr "ARKit BlendShape Generator"
+
+# Inspector: header / basic settings
+msgid "inspector.description"
+msgstr "Automatically generates ARKit blend shapes from VRChat/MMD blend shapes."
+
+msgid "inspector.section.basic"
+msgstr "Basic Settings"
+
+msgid "inspector.refresh_list"
+msgstr "Refresh BlendShape List"
+
+msgid "inspector.detected_count"
+msgstr "Found: {0}"
+
+msgid "inspector.search"
+msgstr "Search:"
+
+# Properties
+msgid "prop.target_renderer"
+msgstr "Target Renderer"
+
+msgid "prop.target_renderer.tooltip"
+msgstr "Target SkinnedMeshRenderer (auto-detects the Body mesh when empty)"
+
+msgid "prop.intensity_multiplier"
+msgstr "Intensity Multiplier"
+
+msgid "prop.intensity_multiplier.tooltip"
+msgstr "Intensity multiplier for generation (0.5-1.5 recommended)"
+
+msgid "prop.enable_left_right_split"
+msgstr "Left/Right Split"
+
+msgid "prop.enable_left_right_split.tooltip"
+msgstr "Generate left/right variants separately (e.g. blink)"
+
+msgid "prop.blend_width"
+msgstr "Blend Width"
+
+msgid "prop.blend_width.tooltip"
+msgstr "Width of the gradient around the center where left and right are blended when splitting"
+
+msgid "prop.overwrite_existing"
+msgstr "Overwrite Existing"
+
+msgid "prop.overwrite_existing.tooltip"
+msgstr "Overwrite existing ARKit blend shapes"
+
+msgid "prop.enable_procedural_mouth"
+msgstr "Enable Procedural Generation"
+
+msgid "prop.enable_procedural_mouth.tooltip"
+msgstr "Procedurally generate mouth-related blend shapes (mouthLeft/Right, jaw*, etc.) that cannot be derived from existing blend shapes, by moving vertices in the mouth region"
+
+msgid "prop.procedural_mouth_intensity"
+msgstr "Deformation Intensity"
+
+msgid "prop.procedural_mouth_intensity.tooltip"
+msgstr "Deformation intensity for procedural generation"
+
+msgid "prop.debug_mode"
+msgstr "Debug Mode"
+
+msgid "prop.debug_mode.tooltip"
+msgstr "Output debug logs"
+
+# Procedural mouth generation
+msgid "inspector.section.procedural_mouth"
+msgstr "Procedural Mouth Generation"
+
+msgid "inspector.procedural_mouth.description"
+msgstr "Procedurally generates mouth-related blend shapes (mouthLeft/Right, jaw*, etc.) that cannot be derived from existing blend shapes, by moving vertices in the mouth region. Existing blend shapes are only used to detect the mouth region."
+
+# Custom mappings
+msgid "inspector.section.custom_mappings"
+msgstr "Custom Mappings"
+
+msgid "custom_mappings.description"
+msgstr "Manually map blend shapes that cannot be mapped automatically (e.g. eye look).\nMultiple source blend shapes can be combined."
+
+msgid "custom_mappings.duplicate_blocked"
+msgstr "Preview/generation is suspended until the duplicates are resolved."
+
+msgid "custom_mappings.add_new"
+msgstr "Add New Mapping"
+
+msgid "custom_mappings.delete_all"
+msgstr "Delete All"
+
+msgid "custom_mappings.count"
+msgstr "Mappings: {0}/{1} enabled"
+
+msgid "custom_mappings.none_matching"
+msgstr "No mappings match the filter."
+
+msgid "custom_mappings.no_available_names"
+msgstr "(no available ARKit names)"
+
+msgid "presets.label"
+msgstr "Presets"
+
+msgid "presets.vrchat_standard"
+msgstr "Use VRChat Standard Visemes Only"
+
+msgid "dialog.vrchat_preset.message"
+msgstr "Sets up mappings that use only VRChat standard visemes (vrc.v_aa, vrc.v_ih, vrc.v_ou, etc.), intended for avatars without MMD blend shapes.\n\nYour current custom mappings will be overwritten."
+
+msgid "dialog.vrchat_preset.apply"
+msgstr "Apply"
+
+msgid "dialog.delete_all.message"
+msgstr "Delete all custom mappings?"
+
+msgid "dialog.no_available_name.message"
+msgstr "There are no ARKit names left to add.\nDelete an existing mapping or change its ARKit name."
+
+msgid "category_add.label"
+msgstr "Add by Category"
+
+msgid "category.eye_look"
+msgstr "Eye Look"
+
+msgid "category.eye"
+msgstr "Eye"
+
+msgid "category.brow"
+msgstr "Brow"
+
+msgid "category.mouth"
+msgstr "Mouth"
+
+msgid "category.cheek"
+msgstr "Cheek"
+
+msgid "category.nose"
+msgstr "Nose"
+
+msgid "category.tongue"
+msgstr "Tongue"
+
+msgid "source.placeholder"
+msgstr "(select)"
+
+msgid "source.not_found_suffix"
+msgstr " (not found)"
+
+msgid "enum.side.both"
+msgstr "Both"
+
+msgid "enum.side.left_only"
+msgstr "Left Only"
+
+msgid "enum.side.right_only"
+msgstr "Right Only"
+
+# Preview
+msgid "inspector.section.preview"
+msgstr "Preview"
+
+msgid "preview.realtime"
+msgstr "Realtime Preview"
+
+msgid "preview.reset"
+msgstr "Reset"
+
+msgid "preview.categories"
+msgstr "Categories"
+
+msgid "preview.ndmf_off_warning"
+msgstr "NDMF Preview is OFF, so value changes are not reflected in the scene view."
+
+msgid "preview.category.custom"
+msgstr "Custom"
+
+msgid "preview.category.auto"
+msgstr "Auto-generated"
+
+msgid "preview.category.original"
+msgstr "Original BlendShapes"
+
+msgid "preview.category.empty"
+msgstr "None"
+
+# Auto mapping list
+msgid "inspector.section.auto_mappings"
+msgstr "Auto Mapping List (Reference)"
+
+msgid "auto_mappings.description"
+msgstr "The following blend shapes are mapped automatically.\nIf the same ARKit name is specified in a custom mapping, the custom mapping takes precedence."
+
+msgid "auto_mappings.fold.eye"
+msgstr "Eye"
+
+msgid "auto_mappings.fold.eye_look"
+msgstr "Eye Look (usually requires manual setup)"
+
+msgid "auto_mappings.fold.brow"
+msgstr "Brow"
+
+msgid "auto_mappings.fold.mouth"
+msgstr "Mouth"
+
+msgid "auto_mappings.fold.cheek"
+msgstr "Cheek"
+
+msgid "auto_mappings.fold.nose"
+msgstr "Nose"
+
+msgid "auto_mappings.fold.tongue"
+msgstr "Tongue"
+
+msgid "auto_mappings.row.eye_blink"
+msgstr "← vrc.blink_left/right, まばたき, ウィンク"
+
+msgid "auto_mappings.row.eye_squint"
+msgstr "← 笑い, にこり, ><"
+
+msgid "auto_mappings.row.eye_wide"
+msgstr "← びっくり, 見開き"
+
+msgid "auto_mappings.row.manual"
+msgstr "← (manual setup recommended)"
+
+msgid "auto_mappings.row.eye_look_in"
+msgstr "← より目"
+
+msgid "auto_mappings.row.brow_down"
+msgstr "← 怒り, 真面目, 困る"
+
+msgid "auto_mappings.row.brow_inner_up"
+msgstr "← 困る, 上, 悲しい"
+
+msgid "auto_mappings.row.brow_outer_up"
+msgstr "← 上, 驚き"
+
+msgid "auto_mappings.row.jaw_open"
+msgstr "← vrc.v_aa, あ (70%)"
+
+msgid "auto_mappings.row.mouth_funnel"
+msgstr "← vrc.v_ou, う"
+
+msgid "auto_mappings.row.mouth_pucker"
+msgstr "← vrc.v_ou, う, ω (120%)"
+
+msgid "auto_mappings.row.mouth_smile"
+msgstr "← にやり, ∧, にっこり"
+
+msgid "auto_mappings.row.mouth_frown"
+msgstr "← への字, 悲しみ"
+
+msgid "auto_mappings.row.procedural"
+msgstr "← procedural generation (moves mouth-region vertices)"
+
+msgid "auto_mappings.row.cheek_puff"
+msgstr "← ぷく, 膨らみ"
+
+msgid "auto_mappings.row.cheek_squint"
+msgstr "← 笑い, にこり"
+
+msgid "auto_mappings.row.nose_sneer"
+msgstr "← 怒り"
+
+msgid "auto_mappings.row.tongue_out"
+msgstr "← べー, 舌"
+
+# Debug
+msgid "debug.show_all_meshes"
+msgstr "Log BlendShape Counts of All Meshes"
+
+msgid "debug.show_target_shapes"
+msgstr "Log BlendShape Names of Target Mesh"
+
+# Logs
+msgid "log.target_renderer_not_set"
+msgstr "Target Renderer is not set."
+
+msgid "log.preset_applied"
+msgstr "Applied the VRChat standard viseme preset"
+
+# Validation
+msgid "validation.duplicate.generic"
+msgstr "There are duplicate ARKit names in the custom mappings."
+
+msgid "validation.duplicate.message"
+msgstr "The same ARKit name cannot be used in multiple custom mappings.\nDuplicates: {0}"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -299,6 +299,26 @@ msgstr "Target Rendererが設定されていません。"
 msgid "log.preset_applied"
 msgstr "VRChat標準表情プリセットを適用しました"
 
+# ビルド・プレビュー時ログ
+msgid "log.multiple_components"
+msgstr "同一アバター内で複数のARKitBlendShapeGeneratorComponentが検出されました。\"{0}\" のみ処理します。"
+
+msgid "log.duplicate_abort"
+msgstr "カスタムマッピングで同一ARKit名が重複しているため、生成を中止しました。\n重複: {0}"
+
+msgid "log.duplicate_preview_stop"
+msgstr "カスタムマッピングで同一ARKit名が重複しています。重複を解消するまでプレビューを停止します。\n重複: {0}"
+
+msgid "log.renderer_not_found"
+msgstr "SkinnedMeshRendererが見つかりません。"
+
+# 重複コンポーネントガード
+msgid "guard.log.duplicate"
+msgstr "同一アバター内にはARKitBlendShapeGeneratorComponentを1つだけ設定できます。重複コンポーネントを削除します。"
+
+msgid "guard.dialog.duplicate_removed"
+msgstr "同一アバター内には ARKitBlendShapeGeneratorComponent を1つだけ設定できます。\n\n重複して追加されたコンポーネントを削除しました。"
+
 # バリデーション
 msgid "validation.duplicate.generic"
 msgstr "カスタムマッピングに同一ARKit名の重複があります。"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -1,0 +1,307 @@
+msgid ""
+msgstr ""
+"Language: ja-jp\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+# 共通
+msgid "common.ok"
+msgstr "OK"
+
+msgid "common.yes"
+msgstr "はい"
+
+msgid "common.no"
+msgstr "いいえ"
+
+msgid "common.cancel"
+msgstr "キャンセル"
+
+msgid "dialog.title"
+msgstr "ARKit BlendShape Generator"
+
+# インスペクタ: ヘッダー・基本設定
+msgid "inspector.description"
+msgstr "VRChat/MMDのBlendShapeからARKit用BlendShapeを自動生成します。"
+
+msgid "inspector.section.basic"
+msgstr "基本設定"
+
+msgid "inspector.refresh_list"
+msgstr "BlendShapeリストを更新"
+
+msgid "inspector.detected_count"
+msgstr "検出: {0}個"
+
+msgid "inspector.search"
+msgstr "検索:"
+
+# プロパティ
+msgid "prop.target_renderer"
+msgstr "対象Renderer"
+
+msgid "prop.target_renderer.tooltip"
+msgstr "対象のSkinnedMeshRenderer（空の場合はBodyを自動検出）"
+
+msgid "prop.intensity_multiplier"
+msgstr "強度係数"
+
+msgid "prop.intensity_multiplier.tooltip"
+msgstr "生成時の強度係数（0.5-1.5推奨）"
+
+msgid "prop.enable_left_right_split"
+msgstr "左右分割"
+
+msgid "prop.enable_left_right_split.tooltip"
+msgstr "左右分割を有効にする（まばたき等を左右別々に生成）"
+
+msgid "prop.blend_width"
+msgstr "グラデーション幅"
+
+msgid "prop.blend_width.tooltip"
+msgstr "左右分割時のグラデーション幅（中央付近で左右をブレンドする範囲）"
+
+msgid "prop.overwrite_existing"
+msgstr "既存を上書き"
+
+msgid "prop.overwrite_existing.tooltip"
+msgstr "既存のARKit BlendShapeを上書きする"
+
+msgid "prop.enable_procedural_mouth"
+msgstr "手続き的生成を有効化"
+
+msgid "prop.enable_procedural_mouth.tooltip"
+msgstr "既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成する"
+
+msgid "prop.procedural_mouth_intensity"
+msgstr "変形量係数"
+
+msgid "prop.procedural_mouth_intensity.tooltip"
+msgstr "手続き的生成の変形量係数"
+
+msgid "prop.debug_mode"
+msgstr "デバッグモード"
+
+msgid "prop.debug_mode.tooltip"
+msgstr "デバッグログを出力する"
+
+# 口の手続き的生成
+msgid "inspector.section.procedural_mouth"
+msgstr "口の手続き的生成"
+
+msgid "inspector.procedural_mouth.description"
+msgstr "既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成します。既存のBlendShapeは口領域の検出にのみ使用されます。"
+
+# カスタムマッピング
+msgid "inspector.section.custom_mappings"
+msgstr "カスタムマッピング"
+
+msgid "custom_mappings.description"
+msgstr "自動マッピングできないBlendShape（視線など）を手動で指定できます。\nソースBlendShapeを複数指定して合成することも可能です。"
+
+msgid "custom_mappings.duplicate_blocked"
+msgstr "重複を解消するまでプレビュー/生成は停止されます。"
+
+msgid "custom_mappings.add_new"
+msgstr "新規マッピング追加"
+
+msgid "custom_mappings.delete_all"
+msgstr "全て削除"
+
+msgid "custom_mappings.count"
+msgstr "マッピング: {0}/{1} 有効"
+
+msgid "custom_mappings.none_matching"
+msgstr "該当するマッピングはありません。"
+
+msgid "custom_mappings.no_available_names"
+msgstr "(利用可能なARKit名なし)"
+
+msgid "presets.label"
+msgstr "プリセット"
+
+msgid "presets.vrchat_standard"
+msgstr "VRChat標準表情のみで設定"
+
+msgid "dialog.vrchat_preset.message"
+msgstr "MMD用BlendShapeが存在しないアバター向けに、VRChat標準の表情（vrc.v_aa, vrc.v_ih, vrc.v_ou等）のみを使用したマッピングを設定します。\n\n現在のカスタムマッピングは上書きされます。"
+
+msgid "dialog.vrchat_preset.apply"
+msgstr "設定する"
+
+msgid "dialog.delete_all.message"
+msgstr "全てのカスタムマッピングを削除しますか？"
+
+msgid "dialog.no_available_name.message"
+msgstr "追加可能なARKit名がありません。\n既存マッピングを削除するか、ARKit名を変更してください。"
+
+msgid "category_add.label"
+msgstr "カテゴリ別追加"
+
+msgid "category.eye_look"
+msgstr "視線"
+
+msgid "category.eye"
+msgstr "目"
+
+msgid "category.brow"
+msgstr "眉毛"
+
+msgid "category.mouth"
+msgstr "口"
+
+msgid "category.cheek"
+msgstr "頬"
+
+msgid "category.nose"
+msgstr "鼻"
+
+msgid "category.tongue"
+msgstr "舌"
+
+msgid "source.placeholder"
+msgstr "(選択してください)"
+
+msgid "source.not_found_suffix"
+msgstr " (未検出)"
+
+msgid "enum.side.both"
+msgstr "両側"
+
+msgid "enum.side.left_only"
+msgstr "左のみ"
+
+msgid "enum.side.right_only"
+msgstr "右のみ"
+
+# プレビュー
+msgid "inspector.section.preview"
+msgstr "プレビュー"
+
+msgid "preview.realtime"
+msgstr "リアルタイムプレビュー"
+
+msgid "preview.reset"
+msgstr "リセット"
+
+msgid "preview.categories"
+msgstr "カテゴリ"
+
+msgid "preview.ndmf_off_warning"
+msgstr "NDMF PreviewがOFFのため、値の変更は見た目に反映されません。"
+
+msgid "preview.category.custom"
+msgstr "カスタム"
+
+msgid "preview.category.auto"
+msgstr "自動生成"
+
+msgid "preview.category.original"
+msgstr "元からあるBlendShape"
+
+msgid "preview.category.empty"
+msgstr "なし"
+
+# 自動マッピング一覧
+msgid "inspector.section.auto_mappings"
+msgstr "自動マッピング一覧（参照用）"
+
+msgid "auto_mappings.description"
+msgstr "以下のBlendShapeは自動的にマッピングされます。\nカスタムマッピングで同じARKit名を指定した場合、カスタム設定が優先されます。"
+
+msgid "auto_mappings.fold.eye"
+msgstr "目 (Eye)"
+
+msgid "auto_mappings.fold.eye_look"
+msgstr "視線 (Eye Look) ※通常は手動設定が必要"
+
+msgid "auto_mappings.fold.brow"
+msgstr "眉毛 (Brow)"
+
+msgid "auto_mappings.fold.mouth"
+msgstr "口 (Mouth)"
+
+msgid "auto_mappings.fold.cheek"
+msgstr "頬 (Cheek)"
+
+msgid "auto_mappings.fold.nose"
+msgstr "鼻 (Nose)"
+
+msgid "auto_mappings.fold.tongue"
+msgstr "舌 (Tongue)"
+
+msgid "auto_mappings.row.eye_blink"
+msgstr "← vrc.blink_left/right, まばたき, ウィンク"
+
+msgid "auto_mappings.row.eye_squint"
+msgstr "← 笑い, にこり, ><"
+
+msgid "auto_mappings.row.eye_wide"
+msgstr "← びっくり, 見開き"
+
+msgid "auto_mappings.row.manual"
+msgstr "← (手動設定推奨)"
+
+msgid "auto_mappings.row.eye_look_in"
+msgstr "← より目"
+
+msgid "auto_mappings.row.brow_down"
+msgstr "← 怒り, 真面目, 困る"
+
+msgid "auto_mappings.row.brow_inner_up"
+msgstr "← 困る, 上, 悲しい"
+
+msgid "auto_mappings.row.brow_outer_up"
+msgstr "← 上, 驚き"
+
+msgid "auto_mappings.row.jaw_open"
+msgstr "← vrc.v_aa, あ (70%)"
+
+msgid "auto_mappings.row.mouth_funnel"
+msgstr "← vrc.v_ou, う"
+
+msgid "auto_mappings.row.mouth_pucker"
+msgstr "← vrc.v_ou, う, ω (120%)"
+
+msgid "auto_mappings.row.mouth_smile"
+msgstr "← にやり, ∧, にっこり"
+
+msgid "auto_mappings.row.mouth_frown"
+msgstr "← への字, 悲しみ"
+
+msgid "auto_mappings.row.procedural"
+msgstr "← 手続き的生成（口領域を頂点移動）"
+
+msgid "auto_mappings.row.cheek_puff"
+msgstr "← ぷく, 膨らみ"
+
+msgid "auto_mappings.row.cheek_squint"
+msgstr "← 笑い, にこり"
+
+msgid "auto_mappings.row.nose_sneer"
+msgstr "← 怒り"
+
+msgid "auto_mappings.row.tongue_out"
+msgstr "← べー, 舌"
+
+# デバッグ
+msgid "debug.show_all_meshes"
+msgstr "全メッシュのBlendShape数を表示"
+
+msgid "debug.show_target_shapes"
+msgstr "対象メッシュのBlendShape名を表示"
+
+# ログ
+msgid "log.target_renderer_not_set"
+msgstr "Target Rendererが設定されていません。"
+
+msgid "log.preset_applied"
+msgstr "VRChat標準表情プリセットを適用しました"
+
+# バリデーション
+msgid "validation.duplicate.generic"
+msgstr "カスタムマッピングに同一ARKit名の重複があります。"
+
+msgid "validation.duplicate.message"
+msgstr "カスタムマッピングで同一ARKit名は複数設定できません。\n重複: {0}"

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -1,11 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using VRC.SDKBase;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace ARKitBlendShapeGenerator
 {
@@ -22,44 +18,49 @@ namespace ARKitBlendShapeGenerator
     [AddComponentMenu("KxVRCARKitBlendShapeGenerator/Kx VRC ARKit BlendShape Generator")]
     public class ARKitBlendShapeGeneratorComponent : MonoBehaviour, IEditorOnly
     {
-        [Header("対象設定")]
-        [Tooltip("対象のSkinnedMeshRenderer（空の場合はBodyを自動検出）")]
+        // インスペクタ表示用の文言はEditorアセンブリ側でローカライズされる
+        // （以下の属性はカスタムエディタが無効な場合のフォールバック表示）
+        [Header("Target")]
+        [Tooltip("Target SkinnedMeshRenderer (auto-detects the Body mesh when empty)")]
         public SkinnedMeshRenderer targetRenderer;
 
-        [Header("生成設定")]
-        [Tooltip("生成時の強度係数（0.5-1.5推奨）")]
+        [Header("Generation")]
+        [Tooltip("Intensity multiplier for generation (0.5-1.5 recommended)")]
         [Range(0.1f, 2.0f)]
         public float intensityMultiplier = 1.0f;
 
-        [Tooltip("左右分割を有効にする（まばたき等を左右別々に生成）")]
+        [Tooltip("Generate left/right variants separately (e.g. blink)")]
         public bool enableLeftRightSplit = true;
 
-        [Tooltip("左右分割時のグラデーション幅（中央付近で左右をブレンドする範囲）")]
+        [Tooltip("Width of the gradient around the center where left and right are blended when splitting")]
         [Range(0.001f, 0.1f)]
         public float blendWidth = 0.02f;
 
-        [Tooltip("既存のARKit BlendShapeを上書きする")]
+        [Tooltip("Overwrite existing ARKit blend shapes")]
         public bool overwriteExisting = false;
 
-        [Header("口の手続き的生成")]
-        [Tooltip("既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成する")]
+        [Header("Procedural Mouth Generation")]
+        [Tooltip("Procedurally generate mouth-related blend shapes (mouthLeft/Right, jaw*, etc.) that cannot be derived from existing blend shapes, by moving vertices in the mouth region")]
         public bool enableProceduralMouthShapes = false;
 
-        [Tooltip("手続き的生成の変形量係数")]
+        [Tooltip("Deformation intensity for procedural generation")]
         [Range(0.1f, 2.0f)]
         public float proceduralMouthIntensity = 1.0f;
 
-        [Header("カスタムマッピング")]
-        [Tooltip("自動マッピングできないBlendShapeを手動で指定")]
+        [Header("Custom Mappings")]
+        [Tooltip("Manually specify blend shapes that cannot be mapped automatically")]
         public List<CustomBlendShapeMapping> customMappings = new List<CustomBlendShapeMapping>();
 
-        [Header("デバッグ")]
-        [Tooltip("デバッグログを出力する")]
+        [Header("Debug")]
+        [Tooltip("Output debug logs")]
         public bool debugMode = false;
 
 #if UNITY_EDITOR
-        [NonSerialized]
-        private bool _pendingDuplicateRemoval;
+        /// <summary>
+        /// Editorアセンブリ側から差し込まれるOnValidateフック
+        /// （同一アバター内の重複コンポーネント排除に使用）
+        /// </summary>
+        internal static Action<ARKitBlendShapeGeneratorComponent> EditorOnValidateHook;
 #endif
 
         private void Reset()
@@ -74,7 +75,7 @@ namespace ARKitBlendShapeGenerator
         private void OnValidate()
         {
 #if UNITY_EDITOR
-            EnforceSingleComponentPerAvatar();
+            EditorOnValidateHook?.Invoke(this);
 #endif
         }
 
@@ -132,142 +133,6 @@ namespace ARKitBlendShapeGenerator
 
             return result;
         }
-
-#if UNITY_EDITOR
-        private void EnforceSingleComponentPerAvatar()
-        {
-            var avatarRoot = FindAvatarRootForUniqueness();
-            if (avatarRoot == null)
-            {
-                return;
-            }
-
-            var components = avatarRoot.GetComponentsInChildren<ARKitBlendShapeGeneratorComponent>(true)
-                .Where(c => c != null)
-                .ToArray();
-
-            if (components.Length <= 1)
-            {
-                _pendingDuplicateRemoval = false;
-                return;
-            }
-
-            var primary = SelectPrimaryComponent(avatarRoot, components);
-            if (primary == this)
-            {
-                _pendingDuplicateRemoval = false;
-                return;
-            }
-
-            if (_pendingDuplicateRemoval)
-            {
-                return;
-            }
-
-            _pendingDuplicateRemoval = true;
-
-            Debug.LogWarning(
-                "[ARKitGenerator] 同一アバター内にはARKitBlendShapeGeneratorComponentを1つだけ設定できます。重複コンポーネントを削除します。",
-                this);
-
-            EditorApplication.delayCall += () =>
-            {
-                _pendingDuplicateRemoval = false;
-
-                if (this == null || avatarRoot == null)
-                {
-                    return;
-                }
-
-                var refreshed = avatarRoot.GetComponentsInChildren<ARKitBlendShapeGeneratorComponent>(true)
-                    .Where(c => c != null)
-                    .ToArray();
-                var refreshedPrimary = SelectPrimaryComponent(avatarRoot, refreshed);
-
-                if (refreshedPrimary != this)
-                {
-                    DestroyImmediate(this);
-
-                    if (!Application.isBatchMode)
-                    {
-                        EditorUtility.DisplayDialog(
-                            "ARKit BlendShape Generator",
-                            "同一アバター内には ARKitBlendShapeGeneratorComponent を1つだけ設定できます。\n\n" +
-                            "重複して追加されたコンポーネントを削除しました。",
-                            "OK");
-                    }
-                }
-            };
-        }
-
-        private Transform FindAvatarRootForUniqueness()
-        {
-            Transform lastDescriptorRoot = null;
-            var cursor = transform;
-
-            while (cursor != null)
-            {
-                if (HasAvatarDescriptor(cursor.gameObject))
-                {
-                    lastDescriptorRoot = cursor;
-                }
-
-                cursor = cursor.parent;
-            }
-
-            if (lastDescriptorRoot != null)
-            {
-                return lastDescriptorRoot;
-            }
-
-            return transform.root;
-        }
-
-        private static bool HasAvatarDescriptor(GameObject go)
-        {
-            if (go == null)
-            {
-                return false;
-            }
-
-            var components = go.GetComponents<Component>();
-            foreach (var component in components)
-            {
-                if (component == null)
-                {
-                    continue;
-                }
-
-                if (component.GetType().Name == "VRCAvatarDescriptor")
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static ARKitBlendShapeGeneratorComponent SelectPrimaryComponent(
-            Transform avatarRoot,
-            ARKitBlendShapeGeneratorComponent[] components)
-        {
-            if (components == null || components.Length == 0)
-            {
-                return null;
-            }
-
-            if (avatarRoot != null)
-            {
-                var onRoot = components.FirstOrDefault(c => c != null && c.transform == avatarRoot);
-                if (onRoot != null)
-                {
-                    return onRoot;
-                }
-            }
-
-            return components[0];
-        }
-#endif
     }
 
     /// <summary>
@@ -276,13 +141,13 @@ namespace ARKitBlendShapeGenerator
     [Serializable]
     public class CustomBlendShapeMapping
     {
-        [Tooltip("生成するARKit BlendShape名")]
+        [Tooltip("ARKit blend shape name to generate")]
         public string arkitName;
 
-        [Tooltip("このマッピングを有効にする")]
+        [Tooltip("Enable this mapping")]
         public bool enabled = true;
 
-        [Tooltip("ソースBlendShapeのリスト")]
+        [Tooltip("List of source blend shapes")]
         public List<BlendShapeSource> sources = new List<BlendShapeSource>();
     }
 
@@ -292,14 +157,14 @@ namespace ARKitBlendShapeGenerator
     [Serializable]
     public class BlendShapeSource
     {
-        [Tooltip("ソースBlendShape名")]
+        [Tooltip("Source blend shape name")]
         public string blendShapeName;
 
-        [Tooltip("適用する重み（-2.0〜2.0）")]
+        [Tooltip("Weight to apply (-2.0 to 2.0)")]
         [Range(-2f, 2f)]
         public float weight = 1.0f;
 
-        [Tooltip("適用範囲（左右分かれていないBlendShapeを片側だけ使用する場合）")]
+        [Tooltip("Side to apply (for using one side of a non-split blend shape)")]
         public BlendShapeSide side = BlendShapeSide.Both;
     }
 
@@ -308,11 +173,11 @@ namespace ARKitBlendShapeGenerator
     /// </summary>
     public enum BlendShapeSide
     {
-        [Tooltip("両側に適用")]
+        [Tooltip("Apply to both sides")]
         Both,
-        [Tooltip("左側（X > 0）のみ適用")]
+        [Tooltip("Apply to the left side (X > 0) only")]
         LeftOnly,
-        [Tooltip("右側（X < 0）のみ適用")]
+        [Tooltip("Apply to the right side (X < 0) only")]
         RightOnly
     }
 

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -42,7 +42,7 @@ namespace ARKitBlendShapeGenerator
         public bool overwriteExisting = false;
 
         [Header("口の手続き的生成")]
-        [Tooltip("既存シェイプキーから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成する")]
+        [Tooltip("既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成する")]
         public bool enableProceduralMouthShapes = false;
 
         [Tooltip("手続き的生成の変形量係数")]

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// Editorアセンブリからinternalメンバー（EditorOnValidateHook）へアクセスするため
+[assembly: InternalsVisibleTo("ARKitBlendShapeGenerator.Editor")]


### PR DESCRIPTION
Closes #25

## 概要

コンポーネント周りのユーザー向け文言を整理し、NDMF標準のローカライズ機構による i18n(ja/en)対応を追加しました。
実装プランは #25 のコメント参照。

## 変更内容

### 1. 文言整理(挙動変更なし)
- UI上の「シェイプキー」/「BlendShape」の表記ゆれを「BlendShape」に統一
- プレビューカテゴリ名「このツールで生成されるシェイプキー以外の元からあるシェイプキー」をドロップダウンと同じ「元からあるBlendShape」に統一
- ダイアログタイトルを「ARKit BlendShape Generator」に統一
- 英語のままだった警告ログを日本語化し `[ARKitGenerator]` プレフィックスを付与

### 2. i18n基盤 + Editorインスペクタ対応
- `Editor/Localization/Localization.cs`: NDMFの `Localizer` を利用した文言管理(`S(key)` / `S(key, args)` / `G(key)`(tooltip付きGUIContent)ヘルパー)
- `Editor/Localization/ja-jp.po` / `en-us.po`: 翻訳ファイル(各103キー)。Unityが `.po` を `LocalizationAsset` としてインポートし、NDMFの `Localizer(string, Func<List<LocalizationAsset>>)` で読み込み
- インスペクタの全文言をローカライズキー経由に置換し、最上部にNDMF共通の言語切替(`LanguageSwitcher.DrawImmediate()`)を追加(Modular Avatar等と言語設定を共有)
- 適用範囲(Both/LeftOnly/RightOnly)のドロップダウンもローカライズ表示化
- 翻訳ファイルは `Assets/` 配下・`Packages/` 配下のどちらに配置されても asmdef の位置から解決

### 3. Runtime整理 + ビルドログ対応
- 重複コンポーネント排除ロジック(約140行)をRuntimeからEditorの `DuplicateComponentGuard` へ移動。Runtimeには `OnValidate` フックのみ残し、`InternalsVisibleTo` で接続(Runtime asmdefはNDMFを参照できないため)
- Runtimeの `[Header]`/`[Tooltip]` はフォールバック用の英語表記に変更(通常はカスタムエディタのローカライズ済み文言が表示される)
- Plugin/Preview/Engineの警告・エラーログをローカライズキー経由に置換

### 対象外(データのため翻訳しない)
- マッピングテーブル内のMMDシェイプキー名(「まばたき」「笑い」等)・ARKit BlendShape名
- `debugMode` 有効時の診断ダンプログ

## 検証
- 全ローカライズキーの使用箇所⇔ja/en両.poの突き合わせで過不足なしを確認(103キー)
- `G()` で参照する全キーに `.tooltip` が両言語で存在することを確認
- .po構文(msgid/msgstr対・重複キーなし)とC#の括弧整合を機械チェック
- `LanguageSwitcher.DrawImmediate()` / `Localizer(string, Func<List<LocalizationAsset>>)` が依存最小バージョンのNDMF 1.4.0に存在することをソースで確認
- ⚠️ Unity Editor上での表示確認(ja/en切替・ダイアログ・ビルドログ)は未実施のため、マージ前に実機確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xhedu5uNcdwaW7Ajxhjmsj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xhedu5uNcdwaW7Ajxhjmsj)_