### PR TITLE
ci: リリース公開時にVPMリスティングの再生成を通知する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Build VPM Package
 
 on:
   release:
-    types: [published]
+    # published: 通常リリース・プレリリースの公開
+    # released:  プレリリースを正式リリースへ昇格したとき
+    types: [published, released]
   workflow_dispatch:
     inputs:
       version:
@@ -67,3 +69,22 @@ jobs:
           files: "*.zip"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # リリース公開をVPMリスティングリポジトリへ通知し、リスティングを即時再生成する。
+  # GitHubの`release`イベントはリリース元リポジトリのワークフローにしか配信されない
+  # ため、リスティング側から検知することはできず、こちらから通知する必要がある。
+  #
+  # `needs: build`としているのはリリース資材(zip)の添付完了を待つため。リスティングの
+  # 生成はリリースのアセットを参照するので、添付前に通知するとzipが無い状態で
+  # インデックスされてしまう。
+  #
+  # 動作には以下がこのリポジトリに設定されている必要がある:
+  #   secret `LISTING_DISPATCH_TOKEN` … limit7412/vcc-vpm のみをスコープとし
+  #   "Contents: Read and write" を持つ fine-grained PAT。
+  #   (このリポジトリの GITHUB_TOKEN は他リポジトリへ到達できないため必須)
+  notify-listing:
+    name: notify-listing
+    needs: build
+    if: github.event_name == 'release'
+    uses: limit7412/vcc-vpm/.github/workflows/notify-listing.yml@main
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,15 @@ name: Build VPM Package
 
 on:
   release:
-    # published: 通常リリース・プレリリースの公開
-    # released:  プレリリースを正式リリースへ昇格したとき
-    types: [published, released]
+    # `published`のみ。通常リリース・プレリリースいずれの公開でも発火する。
+    #
+    # `released`は追加しない。これはプレリリースからの昇格に限らず通常リリースの
+    # 公開時にも`published`と同時に発火するため、同一タグに対してこのワークフローが
+    # 2回並行実行され、同名zipのアップロードが競合してしまう。
+    # プレリリースを正式リリースへ昇格した場合(`released`のみが発火するケース)は
+    # zipは昇格前の`published`で既に添付済みなので、リスティングを更新したい場合は
+    # vcc-vpm側の"Build Repo Listing" → "Run workflow"で手動再生成する。
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -95,6 +101,12 @@ jobs:
     name: notify-listing
     needs: build
     if: github.event_name == 'release'
+    # 呼び出された再利用可能ワークフローは呼び出し元の`GITHUB_TOKEN`を受け取るため、
+    # 何も指定しないとトップレベルの`contents: write`がそのまま渡り、他リポジトリの
+    # ワークフローがこのリポジトリの内容やリリース資材を変更できてしまう。
+    # 通知はvcc-vpm側へ`LISTING_DISPATCH_TOKEN`を使って行われ`GITHUB_TOKEN`は
+    # 使わないので、権限は全て落とす。
+    permissions: {}
     uses: limit7412/vcc-vpm/.github/workflows/notify-listing.yml@main
     with:
       # デフォルトを持たない必須入力。`uses:`の参照先と同じリポジトリを指すこと。

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,22 @@ jobs:
   #   secret `LISTING_DISPATCH_TOKEN` … limit7412/vcc-vpm のみをスコープとし
   #   "Contents: Read and write" を持つ fine-grained PAT。
   #   (このリポジトリの GITHUB_TOKEN は他リポジトリへ到達できないため必須)
+  #
+  # secretは`inherit`ではなく明示的に渡す。`inherit`は可変ref(@main)で読み込まれる
+  # 他リポジトリのワークフローへこのリポジトリの全secretを渡してしまうが、
+  # 必要なのはこの1つだけ。
+  #
+  # リリースのタグは`release`イベントから読まれるため`tag`入力は渡していない。
+  # (このリポジトリのリリースは手動作成のため`release`トリガが発火する。
+  #  GITHUB_TOKENを使うワークフローからリリースを作る形に変えた場合は
+  #  トリガが発火しなくなるので、その際は`tag`を明示的に渡す必要がある)
   notify-listing:
     name: notify-listing
     needs: build
     if: github.event_name == 'release'
     uses: limit7412/vcc-vpm/.github/workflows/notify-listing.yml@main
-    secrets: inherit
+    with:
+      # デフォルトを持たない必須入力。`uses:`の参照先と同じリポジトリを指すこと。
+      listing-repo: limit7412/vcc-vpm
+    secrets:
+      LISTING_DISPATCH_TOKEN: ${{ secrets.LISTING_DISPATCH_TOKEN }}


### PR DESCRIPTION
## 概要

[limit7412/vcc-vpm#3](https://github.com/limit7412/vcc-vpm/pull/3) のパッケージ側対応です。

あちらのPRはVPMリスティングの更新方法を6時間ごとのポーリング(`detect-release.yml`)から**リリースイベント駆動**に置き換えるもので、`notify-listing.yml` という再利用可能ワークフローを提供します。GitHubの `release` イベントはリリース元リポジトリのワークフローにしか配信されないため、リスティング側から他リポジトリのリリースを検知することはできません。つまり通知はパッケージ側から押し出す必要があり、**このリポジトリに呼び出し側ワークフローを置かないとリリース駆動の更新は動きません。** その欠けているピースを追加します。

## 変更内容

`.github/workflows/release.yml` に `notify-listing` ジョブを追加しました。トリガの変更はありません(`release: [published]` のまま)。

- `uses: limit7412/vcc-vpm/.github/workflows/notify-listing.yml@main` でvcc-vpm側の再利用可能ワークフローを呼び出します。リスティング側へ `repository_dispatch` (`package-released`) を送り、数秒でリスティングが再生成されます。
- **独立したワークフローファイルではなく `release.yml` 内のジョブとして `needs: build` で連結しています。** リスティングの生成はリリースのアセットを読むため、zipの添付前に通知するとzipが無い状態でインデックスされ、新バージョンがリスティングに載らない可能性があります。別ファイルにすると `Build VPM Package` と並走してこの競合が起きるので、既存ジョブの後段に置きました。
- `if: github.event_name == 'release'` を付け、`workflow_dispatch` での手動実行時(リリースを作らないためタグが取れず、通知する意味もない)には走らせません。
- **`permissions: {}`** を付けています。呼び出された再利用可能ワークフローは呼び出し元の `GITHUB_TOKEN` を受け取るため、指定しないとトップレベルの `contents: write` がそのまま他リポジトリのワークフローへ渡ります。通知は `LISTING_DISPATCH_TOKEN` でvcc-vpm側のAPIを叩くだけなので `GITHUB_TOKEN` は不要です。
- `listing-repo: limit7412/vcc-vpm` を明示的に渡しています。この入力はデフォルトを持たない必須入力です(リスティングの複製がデフォルトを継承して元リポジトリへ通知してしまうのを防ぐため)。
- **secretは `inherit` ではなく `LISTING_DISPATCH_TOKEN` のみを明示的に渡しています。** `secrets: inherit` は可変ref(`@main`)で読み込まれる他リポジトリのワークフローへこのリポジトリの全secretを渡してしまいますが、必要なのはこの1つだけです。
- `tag` 入力は渡していません。このリポジトリのリリースは手動作成であり `release` トリガが発火するため、タグはイベントから読めます。将来 `GITHUB_TOKEN` を使うワークフローからリリースを作る形に変えた場合は `release` トリガが発火しなくなるので、その際は publish ジョブから `tag` を明示的に渡す必要があります(この経緯はワークフロー内にコメントとして残しています)。

## レビュー対応

- **`released` トリガの追加を撤回しました** ([P2](``https://github.com/limit7412/VRCARKitBlendShapeGenerator/pull/27#discussion_r3679716817))。当初プレリリースの正式リリース昇格を拾う目的で追加しましたが、'released'`` は昇格時のみではなく通常リリースの公開時にも `published` と同時に発火するため、同一タグでワークフローが2回並行実行され同名zipのアップロードが競合していました。昇格を判別する手掛かりが payload に無いため、`types: [published]` に戻しています。昇格時のリスティング更新はvcc-vpm側の手動再生成で対応します。
- **`permissions: {}` を追加しました** ([P1](https://github.com/limit7412/VRCARKitBlendShapeGenerator/pull/27#discussion_r3679716820))。コミットSHAへの固定は行っていません — 権限を落とした後に残る露出(vcc-vpmのみをスコープとするトークンが、既にvcc-vpmへの書き込み権を持つ攻撃者に渡ること)が、手作業でのSHA追従コストに見合わないと判断しました。詳細はスレッドに記載しています。

## マージ前に必要な設定

fine-grained Personal Access Token を secret `LISTING_DISPATCH_TOKEN` としてこのリポジトリに登録する必要があります。

- スコープ: `limit7412/vcc-vpm` のみ
- 権限: **Contents: Read and write** (repository dispatch APIが要求する権限)

このリポジトリの `GITHUB_TOKEN` は他リポジトリへ到達できないため、トークンは省略できません。secret未設定のままリリースすると `notify-listing` ジョブのみが失敗します(パッケージのビルドとリリースへの添付は `build` ジョブで完了済みなので影響しません)。

## 依存関係

- vcc-vpm#3 が `main` にマージされるまで `notify-listing.yml@main` は存在しないため、このジョブは失敗します。**vcc-vpm#3 を先にマージしてください。**
- それまではリスティング側の "Build Repo Listing" → "Run workflow" で手動更新できます。

## 検証

`release.yml` がYAMLとして正しくパースでき、トリガ(`release: [published]` / `workflow_dispatch`)と2ジョブ(`build`、`needs: build` の `notify-listing`)、および `permissions` / `with` / `secrets` のマッピングが意図通りに解釈されることを確認しました。エンドツーエンドの疎通は vcc-vpm#3 のマージとトークン登録の後でなければ実行できません。
