### PR TITLE
fix: ビルド時にコンポーネントを削除しAAOの「未知のコンポーネント」警告を解消

### DIFF
--- a/Editor/ARKitBlendShapeGeneratorPlugin.cs
+++ b/Editor/ARKitBlendShapeGeneratorPlugin.cs
@@ -37,6 +37,11 @@ namespace ARKitBlendShapeGenerator
                     {
                         ProcessComponent(primaryComponent, ctx);
                     }
+
+                    // ビルド時にのみ意味を持つコンポーネントなので、生成の成否にかかわらず取り除く。
+                    // ビルド終盤で動作するAvatar Optimizer等から「未知のコンポーネント」として
+                    // 検出されないようにするため、Optimizing Phaseより前のここで削除する。
+                    RemoveComponents(components);
                 })
                 .PreviewingWith(new ARKitBlendShapeGeneratorPreview());
         }
@@ -57,6 +62,24 @@ namespace ARKitBlendShapeGenerator
             }
 
             return components[0];
+        }
+
+        private static void RemoveComponents(ARKitBlendShapeGeneratorComponent[] components)
+        {
+            if (components == null)
+            {
+                return;
+            }
+
+            foreach (var component in components)
+            {
+                if (component == null)
+                {
+                    continue;
+                }
+
+                UnityEngine.Object.DestroyImmediate(component);
+            }
         }
 
         private void ProcessComponent(ARKitBlendShapeGeneratorComponent component, BuildContext ctx)


### PR DESCRIPTION
Closes #28

## 概要

Avatar Optimizer (AAO) が `ARKitBlendShapeGeneratorComponent` を「未知のコンポーネント」として警告する問題を、AAO が動作する前にコンポーネントを削除することで解消する。

## 原因

AAO は「ビルドの最後に走る」前提で設計されており、処理開始時点でアバター上に残っている未登録の型をすべて警告対象にする。

- `ARKitBlendShapeGeneratorComponent` は `IEditorOnly` を実装しているだけで、AAO の `ComponentInformation<T>` には登録していない。AAO は `IEditorOnly` を実装しているだけでは既知として扱わない。
- `IEditorOnly` を実際に剥がすのは VRCSDK の `RemoveAvatarEditorOnly` (NDMF Optimizing フェーズ `-1025` の直後) だが、AAO は Optimizing フェーズかつ NDMF パイプラインの可能な限り最後で動作するため、AAO の処理時点では本コンポーネントがまだ残っていた。

## 変更内容

`Editor/ARKitBlendShapeGeneratorPlugin.cs`

- Generating フェーズの生成処理の最後に `RemoveComponents` を追加し、収集した `ARKitBlendShapeGeneratorComponent` を `DestroyImmediate` で削除する。
- 削除は `ProcessComponent` の外側で行うため、カスタムマッピングの ARKit 名重複や Renderer 未検出で生成を中断した場合も確実に削除される。
- primary として選ばれなかった重複コンポーネントもまとめて削除する。

AAO 公式ドキュメントが挙げる 3 つの選択肢のうち「AAO より前にコンポーネントを削除する」を採用した。本コンポーネントはランタイムでは何も行わないビルド時専用コンポーネントであり、この方法なら AAO への依存を追加せずに済む（API 登録は AAO 処理後もコンポーネントを残したい場合の手段、Asset Description はビルド時処理を行うツールには非推奨）。

## 影響範囲

- BlendShape の生成結果および Jerry's Templates との実行順序 (`BeforePlugin("com.adjerry91.vrcft-templates")`) は変更なし。
- プレビュー (`PreviewingWith`) はエディットモードのプロキシ上で動作するため、ビルド時の削除の影響を受けない。
- ビルドは複製されたアバターに対して行われるため、シーン上の元のコンポーネントは削除されない。

## 確認

- [ ] AAO 導入環境でのビルドで「未知のコンポーネント」警告が出ないこと
- [ ] 生成される ARKit BlendShape が従来と同一であること
- [ ] エディットモードのプレビューが従来どおり動作すること

Unity 環境がないため、実機での動作確認は未実施。

---
_Generated by [Claude Code](https://claude.ai/code/session_018tH8ubZcRsk5ityegjTmbb)_