### PR TITLE
feat: 生成した口関連BlendShapeに打ち消し成分を焼き込む機能を追加

### DIFF
--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -21,6 +21,7 @@ namespace ARKitBlendShapeGenerator
         private bool _showPreviewCategoryOriginal = true;
         private Vector2 _scrollPosition;
         private Vector2 _previewScrollPosition;
+        private Vector2 _mouthCancellationTargetScrollPosition;
         private int _cachedPreviewConfigRevision = -1;
         private int _cachedPreviewRendererInstanceId;
         private int _cachedPreviewMeshInstanceId;
@@ -95,6 +96,18 @@ namespace ARKitBlendShapeGenerator
             using (new EditorGUI.DisabledScope(!enableProceduralProperty.boolValue))
             {
                 EditorGUILayout.PropertyField(serializedObject.FindProperty("proceduralMouthIntensity"), G("prop.procedural_mouth_intensity"));
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField(S("inspector.section.mouth_cancellation"), EditorStyles.boldLabel);
+            EditorGUILayout.HelpBox(S("inspector.mouth_cancellation.description"), MessageType.Info);
+            var enableCancellationProperty = serializedObject.FindProperty("enableMouthCancellation");
+            EditorGUILayout.PropertyField(enableCancellationProperty, G("prop.enable_mouth_cancellation"));
+            if (enableCancellationProperty.boolValue)
+            {
+                EditorGUI.indentLevel++;
+                DrawMouthCancellationUI();
+                EditorGUI.indentLevel--;
             }
 
             EditorGUILayout.Space();
@@ -507,16 +520,16 @@ namespace ARKitBlendShapeGenerator
             EditorGUI.indentLevel++;
             for (int j = 0; j < mapping.sources.Count; j++)
             {
-                DrawSourceItem(mapping, j);
+                DrawSourceItem(mapping.sources, j);
             }
             EditorGUI.indentLevel--;
 
             EditorGUILayout.EndVertical();
         }
 
-        private void DrawSourceItem(CustomBlendShapeMapping mapping, int sourceIndex)
+        private void DrawSourceItem(List<BlendShapeSource> sources, int sourceIndex)
         {
-            var source = mapping.sources[sourceIndex];
+            var source = sources[sourceIndex];
 
             EditorGUILayout.BeginHorizontal();
 
@@ -585,11 +598,116 @@ namespace ARKitBlendShapeGenerator
             // 削除ボタン
             if (GUILayout.Button("－", GUILayout.Width(25)))
             {
-                mapping.sources.RemoveAt(sourceIndex);
+                sources.RemoveAt(sourceIndex);
                 MarkComponentChanged();
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawMouthCancellationUI()
+        {
+            EditorGUILayout.PropertyField(
+                serializedObject.FindProperty("mouthCancellationStrength"),
+                G("prop.mouth_cancellation_strength"));
+
+            // 打ち消し対象（アバター側で常時適用しているBlendShape）
+            EditorGUILayout.Space(4);
+            EditorGUILayout.LabelField(S("mouth_cancellation.sources.label"), EditorStyles.miniBoldLabel);
+            EditorGUILayout.LabelField(S("mouth_cancellation.sources.hint"), EditorStyles.miniLabel);
+
+            if (_component.mouthCancellationSources == null)
+            {
+                _component.mouthCancellationSources = new List<BlendShapeSource>();
+            }
+
+            var sources = _component.mouthCancellationSources;
+            if (sources.Count == 0)
+            {
+                EditorGUILayout.LabelField(S("mouth_cancellation.sources.empty"), EditorStyles.miniLabel);
+            }
+
+            for (int i = 0; i < sources.Count; i++)
+            {
+                DrawSourceItem(sources, i);
+            }
+
+            if (GUILayout.Button(S("mouth_cancellation.sources.add")))
+            {
+                sources.Add(new BlendShapeSource());
+                MarkComponentChanged();
+            }
+
+            // 焼き込み先のARKit BlendShape
+            EditorGUILayout.Space(4);
+            EditorGUILayout.LabelField(S("mouth_cancellation.targets.label"), EditorStyles.miniBoldLabel);
+            DrawMouthCancellationTargets();
+        }
+
+        private void DrawMouthCancellationTargets()
+        {
+            if (_component.mouthCancellationTargets == null)
+            {
+                _component.mouthCancellationTargets = new List<string>();
+            }
+
+            var targets = _component.mouthCancellationTargets;
+            var selectableNames = ARKitBlendShapeNames.Mouth;
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button(S("mouth_cancellation.targets.select_all"), EditorStyles.miniButton))
+            {
+                targets.Clear();
+                targets.AddRange(selectableNames);
+                MarkComponentChanged();
+            }
+            if (GUILayout.Button(S("mouth_cancellation.targets.clear"), EditorStyles.miniButton))
+            {
+                targets.Clear();
+                MarkComponentChanged();
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.LabelField(
+                S("mouth_cancellation.targets.count", targets.Count, selectableNames.Length),
+                EditorStyles.miniLabel);
+
+            if (targets.Count == 0)
+            {
+                EditorGUILayout.HelpBox(S("mouth_cancellation.targets.none_warning"), MessageType.Warning);
+            }
+            else if (targets.Count > 1)
+            {
+                // 同時適用時は打ち消しが重なって過剰になるため、対象は絞ることを推奨する
+                EditorGUILayout.HelpBox(S("mouth_cancellation.targets.overshoot_warning"), MessageType.Warning);
+            }
+
+            _mouthCancellationTargetScrollPosition = EditorGUILayout.BeginScrollView(
+                _mouthCancellationTargetScrollPosition,
+                GUILayout.Height(150f));
+
+            foreach (var arkitName in selectableNames)
+            {
+                bool isSelected = targets.Contains(arkitName);
+                bool newSelected = EditorGUILayout.ToggleLeft(arkitName, isSelected);
+                if (newSelected == isSelected)
+                {
+                    continue;
+                }
+
+                if (newSelected)
+                {
+                    targets.Add(arkitName);
+                }
+                else
+                {
+                    targets.Remove(arkitName);
+                }
+
+                MarkComponentChanged();
+            }
+
+            EditorGUILayout.EndScrollView();
         }
 
         private void AddNewMapping()

--- a/Editor/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/ARKitBlendShapeGeneratorEditor.cs
@@ -799,6 +799,13 @@ namespace ARKitBlendShapeGenerator
         private void MarkComponentChanged()
         {
             EditorUtility.SetDirty(_component);
+            // Prefabインスタンス上での直接変更はSetDirtyだけではオーバーライドとして記録されず、
+            // シーンの再読み込み等で設定が失われるため明示的に記録する
+            if (PrefabUtility.IsPartOfPrefabInstance(_component))
+            {
+                PrefabUtility.RecordPrefabInstancePropertyModifications(_component);
+            }
+
             ARKitBlendShapeGeneratorPreviewState.NotifyComponentConfigurationChanged();
         }
 

--- a/Editor/ARKitBlendShapeGeneratorPlugin.cs
+++ b/Editor/ARKitBlendShapeGeneratorPlugin.cs
@@ -83,14 +83,8 @@ namespace ARKitBlendShapeGenerator
 
             var generator = new BlendShapeProcessor(
                 renderer,
-                component.intensityMultiplier,
-                component.enableLeftRightSplit,
-                component.blendWidth,
-                component.overwriteExisting,
                 component.customMappings,
-                component.debugMode,
-                component.enableProceduralMouthShapes,
-                component.proceduralMouthIntensity
+                BlendShapeGenerationOptions.FromComponent(component)
             );
 
             generator.Process();
@@ -105,14 +99,9 @@ namespace ARKitBlendShapeGenerator
         private readonly SkinnedMeshRenderer _renderer;
         private readonly Mesh _mesh;
         private readonly Mesh _originalMesh;  // 元のメッシュ（BlendShapeデータ取得用）
-        private readonly float _intensity;
-        private readonly bool _enableSplit;
-        private readonly float _blendWidth;
-        private readonly bool _overwrite;
         private readonly List<CustomBlendShapeMapping> _customMappings;
+        private readonly BlendShapeGenerationOptions _options;
         private readonly bool _debug;
-        private readonly bool _enableProceduralMouthShapes;
-        private readonly float _proceduralMouthIntensity;
 
         private List<string> _generatedShapes = new List<string>();
 
@@ -126,18 +115,30 @@ namespace ARKitBlendShapeGenerator
             bool debug,
             bool enableProceduralMouthShapes = false,
             float proceduralMouthIntensity = 1.0f)
+            : this(renderer, customMappings, new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = intensity,
+                EnableLeftRightSplit = enableSplit,
+                BlendWidth = blendWidth,
+                OverwriteExisting = overwrite,
+                EnableProceduralMouthShapes = enableProceduralMouthShapes,
+                ProceduralMouthIntensity = proceduralMouthIntensity,
+                Debug = debug
+            })
+        {
+        }
+
+        internal BlendShapeProcessor(
+            SkinnedMeshRenderer renderer,
+            List<CustomBlendShapeMapping> customMappings,
+            BlendShapeGenerationOptions options)
         {
             _renderer = renderer;
             _originalMesh = renderer.sharedMesh;  // 元のメッシュを保持
             _mesh = UnityEngine.Object.Instantiate(renderer.sharedMesh);
-            _intensity = intensity;
-            _enableSplit = enableSplit;
-            _blendWidth = blendWidth;
-            _overwrite = overwrite;
             _customMappings = customMappings ?? new List<CustomBlendShapeMapping>();
-            _debug = debug;
-            _enableProceduralMouthShapes = enableProceduralMouthShapes;
-            _proceduralMouthIntensity = proceduralMouthIntensity;
+            _options = options ?? new BlendShapeGenerationOptions();
+            _debug = _options.Debug;
         }
 
         public void Process()
@@ -150,16 +151,7 @@ namespace ARKitBlendShapeGenerator
                 _mesh,
                 _customMappings,
                 GetMappingTable(),
-                new BlendShapeGenerationOptions
-                {
-                    IntensityMultiplier = _intensity,
-                    EnableLeftRightSplit = _enableSplit,
-                    BlendWidth = _blendWidth,
-                    OverwriteExisting = _overwrite,
-                    EnableProceduralMouthShapes = _enableProceduralMouthShapes,
-                    ProceduralMouthIntensity = _proceduralMouthIntensity,
-                    Debug = _debug
-                });
+                _options);
             _generatedShapes = result.GeneratedShapes.ToList();
 
             // メッシュを適用

--- a/Editor/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/ARKitBlendShapeGeneratorPreview.cs
@@ -140,6 +140,9 @@ namespace ARKitBlendShapeGenerator
             private readonly bool _observedOverwriteExisting;
             private readonly bool _observedEnableProceduralMouthShapes;
             private readonly float _observedProceduralMouthIntensity;
+            private readonly bool _observedEnableMouthCancellation;
+            private readonly float _observedMouthCancellationStrength;
+            private readonly int _observedMouthCancellationSignature;
             private readonly int _observedTargetRendererInstanceId;
             private readonly int _observedCustomMappingsSignature;
             private readonly Dictionary<string, int> _shapeIndices = new Dictionary<string, int>();
@@ -165,6 +168,9 @@ namespace ARKitBlendShapeGenerator
                 bool observedOverwriteExisting = false;
                 bool observedEnableProceduralMouthShapes = false;
                 float observedProceduralMouthIntensity = 0f;
+                bool observedEnableMouthCancellation = false;
+                float observedMouthCancellationStrength = 0f;
+                int observedMouthCancellationSignature = 0;
                 int observedCustomMappingsSignature = 0;
                 SkinnedMeshRenderer observedTargetRenderer = null;
                 if (component != null)
@@ -176,6 +182,9 @@ namespace ARKitBlendShapeGenerator
                     observedOverwriteExisting = context.Observe(component, c => c.overwriteExisting);
                     observedEnableProceduralMouthShapes = context.Observe(component, c => c.enableProceduralMouthShapes);
                     observedProceduralMouthIntensity = context.Observe(component, c => c.proceduralMouthIntensity);
+                    observedEnableMouthCancellation = context.Observe(component, c => c.enableMouthCancellation);
+                    observedMouthCancellationStrength = context.Observe(component, c => c.mouthCancellationStrength);
+                    observedMouthCancellationSignature = BuildMouthCancellationSignature(component);
                     observedCustomMappingsSignature = BuildCustomMappingsSignature(component.customMappings);
                     observedTargetRenderer = context.Observe(component, c => c.targetRenderer);
                 }
@@ -186,6 +195,9 @@ namespace ARKitBlendShapeGenerator
                 _observedOverwriteExisting = observedOverwriteExisting;
                 _observedEnableProceduralMouthShapes = observedEnableProceduralMouthShapes;
                 _observedProceduralMouthIntensity = observedProceduralMouthIntensity;
+                _observedEnableMouthCancellation = observedEnableMouthCancellation;
+                _observedMouthCancellationStrength = observedMouthCancellationStrength;
+                _observedMouthCancellationSignature = observedMouthCancellationSignature;
                 _observedCustomMappingsSignature = observedCustomMappingsSignature;
                 _observedTargetRendererInstanceId = observedTargetRenderer != null ? observedTargetRenderer.GetInstanceID() : 0;
 
@@ -272,6 +284,24 @@ namespace ARKitBlendShapeGenerator
 
                 float currentProceduralMouthIntensity = context.Observe(_component, c => c.proceduralMouthIntensity);
                 if (!Mathf.Approximately(currentProceduralMouthIntensity, _observedProceduralMouthIntensity))
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                bool currentEnableMouthCancellation = context.Observe(_component, c => c.enableMouthCancellation);
+                if (currentEnableMouthCancellation != _observedEnableMouthCancellation)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                float currentMouthCancellationStrength = context.Observe(_component, c => c.mouthCancellationStrength);
+                if (!Mathf.Approximately(currentMouthCancellationStrength, _observedMouthCancellationStrength))
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                int currentMouthCancellationSignature = BuildMouthCancellationSignature(_component);
+                if (currentMouthCancellationSignature != _observedMouthCancellationSignature)
                 {
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
@@ -390,27 +420,62 @@ namespace ARKitBlendShapeGenerator
 
                         hash = (hash * 31) + (mapping.enabled ? 1 : 0);
                         hash = (hash * 31) + HashString(mapping.arkitName);
+                        hash = HashSources(hash, mapping.sources);
+                    }
 
-                        var sources = mapping.sources;
-                        if (sources == null)
+                    return hash;
+                }
+            }
+
+            private static int BuildMouthCancellationSignature(ARKitBlendShapeGeneratorComponent component)
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    if (component == null)
+                    {
+                        return hash;
+                    }
+
+                    hash = HashSources(hash, component.mouthCancellationSources);
+
+                    var targets = component.mouthCancellationTargets;
+                    if (targets == null)
+                    {
+                        return (hash * 31) + 2;
+                    }
+
+                    hash = (hash * 31) + targets.Count;
+                    foreach (var target in targets)
+                    {
+                        hash = (hash * 31) + HashString(target);
+                    }
+
+                    return hash;
+                }
+            }
+
+            private static int HashSources(int hash, List<BlendShapeSource> sources)
+            {
+                unchecked
+                {
+                    if (sources == null)
+                    {
+                        return (hash * 31) + 2;
+                    }
+
+                    hash = (hash * 31) + sources.Count;
+                    foreach (var source in sources)
+                    {
+                        if (source == null)
                         {
-                            hash = (hash * 31) + 2;
+                            hash = (hash * 31) + 3;
                             continue;
                         }
 
-                        hash = (hash * 31) + sources.Count;
-                        foreach (var source in sources)
-                        {
-                            if (source == null)
-                            {
-                                hash = (hash * 31) + 3;
-                                continue;
-                            }
-
-                            hash = (hash * 31) + HashString(source.blendShapeName);
-                            hash = (hash * 31) + source.weight.GetHashCode();
-                            hash = (hash * 31) + (int)source.side;
-                        }
+                        hash = (hash * 31) + HashString(source.blendShapeName);
+                        hash = (hash * 31) + source.weight.GetHashCode();
+                        hash = (hash * 31) + (int)source.side;
                     }
 
                     return hash;

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -408,7 +408,8 @@ namespace ARKitBlendShapeGenerator
             if (upperIndex == 0)
             {
                 // 最小ウェイトのフレームより下は、変形なし（0）との線形補間になる
-                float scale = upperWeight > Mathf.Epsilon ? targetWeight / upperWeight : 0f;
+                // （負ウェイトのフレームも扱えるよう、分母の判定は絶対値で行う）
+                float scale = Mathf.Abs(upperWeight) > Mathf.Epsilon ? targetWeight / upperWeight : 0f;
                 if (!Mathf.Approximately(scale, 1f))
                 {
                     for (int i = 0; i < vertexCount; i++)

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -312,15 +312,9 @@ namespace ARKitBlendShapeGenerator
                     continue;
                 }
 
-                int frameCount = sourceMesh.GetBlendShapeFrameCount(srcIndex);
-                if (frameCount == 0)
-                {
-                    continue;
-                }
-
-                // 打ち消し量はアバター側での適用量に合わせるため、生成強度（IntensityMultiplier）は掛けない
-                float adjustedWeight = -source.weight * strength;
-                if (Mathf.Abs(adjustedWeight) <= Mathf.Epsilon)
+                // アバター側での適用ウェイト（1.0 = ウェイト100）時点の変形を打ち消す
+                float targetWeight = source.weight * 100f;
+                if (Mathf.Abs(targetWeight) <= Mathf.Epsilon)
                 {
                     continue;
                 }
@@ -328,15 +322,26 @@ namespace ARKitBlendShapeGenerator
                 var srcDeltaV = new Vector3[vertexCount];
                 var srcDeltaN = new Vector3[vertexCount];
                 var srcDeltaT = new Vector3[vertexCount];
-                sourceMesh.GetBlendShapeFrameVertices(srcIndex, frameCount - 1, srcDeltaV, srcDeltaN, srcDeltaT);
+                if (!TryEvaluateBlendShapeAtWeight(
+                        sourceMesh,
+                        srcIndex,
+                        targetWeight,
+                        srcDeltaV,
+                        srcDeltaN,
+                        srcDeltaT))
+                {
+                    continue;
+                }
+
+                // 評価済みの変形をそのまま反転する（生成強度 IntensityMultiplier は掛けない）
+                float adjustedWeight = -strength;
 
                 for (int i = 0; i < vertexCount; i++)
                 {
-                    float sideMultiplier = 1.0f;
-                    if (options.EnableLeftRightSplit && source.side != BlendShapeSide.Both)
-                    {
-                        sideMultiplier = CalculateSideMultiplier(vertices[i].x, source.side, blendWidth);
-                    }
+                    // 打ち消し元の左右指定はアバター側での適用範囲を表すため、生成側の左右分割設定とは独立に適用する
+                    float sideMultiplier = source.side != BlendShapeSide.Both
+                        ? CalculateSideMultiplier(vertices[i].x, source.side, blendWidth)
+                        : 1.0f;
 
                     if (sideMultiplier <= 0.0f)
                     {
@@ -364,6 +369,81 @@ namespace ARKitBlendShapeGenerator
                 deltaNormals,
                 deltaTangents,
                 new HashSet<string>(targets));
+        }
+
+        /// <summary>
+        /// 指定ウェイト（0-100基準）時点のBlendShapeの変形を、フレーム間を補間して取得する。
+        /// フレームを持たない場合はfalse。
+        /// </summary>
+        private static bool TryEvaluateBlendShapeAtWeight(
+            Mesh sourceMesh,
+            int shapeIndex,
+            float targetWeight,
+            Vector3[] deltaVertices,
+            Vector3[] deltaNormals,
+            Vector3[] deltaTangents)
+        {
+            int frameCount = sourceMesh.GetBlendShapeFrameCount(shapeIndex);
+            if (frameCount == 0)
+            {
+                return false;
+            }
+
+            // フレームウェイトは昇順のため、目標ウェイト以上になる最初のフレームが上側の境界になる
+            int upperIndex = frameCount - 1;
+            for (int i = 0; i < frameCount; i++)
+            {
+                if (sourceMesh.GetBlendShapeFrameWeight(shapeIndex, i) >= targetWeight)
+                {
+                    upperIndex = i;
+                    break;
+                }
+            }
+
+            float upperWeight = sourceMesh.GetBlendShapeFrameWeight(shapeIndex, upperIndex);
+            sourceMesh.GetBlendShapeFrameVertices(shapeIndex, upperIndex, deltaVertices, deltaNormals, deltaTangents);
+
+            int vertexCount = sourceMesh.vertexCount;
+
+            if (upperIndex == 0)
+            {
+                // 最小ウェイトのフレームより下は、変形なし（0）との線形補間になる
+                float scale = upperWeight > Mathf.Epsilon ? targetWeight / upperWeight : 0f;
+                if (!Mathf.Approximately(scale, 1f))
+                {
+                    for (int i = 0; i < vertexCount; i++)
+                    {
+                        deltaVertices[i] *= scale;
+                        deltaNormals[i] *= scale;
+                        deltaTangents[i] *= scale;
+                    }
+                }
+
+                return true;
+            }
+
+            float lowerWeight = sourceMesh.GetBlendShapeFrameWeight(shapeIndex, upperIndex - 1);
+            float range = upperWeight - lowerWeight;
+            if (range <= Mathf.Epsilon)
+            {
+                return true;
+            }
+
+            var lowerDeltaV = new Vector3[vertexCount];
+            var lowerDeltaN = new Vector3[vertexCount];
+            var lowerDeltaT = new Vector3[vertexCount];
+            sourceMesh.GetBlendShapeFrameVertices(shapeIndex, upperIndex - 1, lowerDeltaV, lowerDeltaN, lowerDeltaT);
+
+            // 最終フレームを超えるウェイトはクランプせず、Unityの評価に合わせて外挿する
+            float t = (targetWeight - lowerWeight) / range;
+            for (int i = 0; i < vertexCount; i++)
+            {
+                deltaVertices[i] = lowerDeltaV[i] + ((deltaVertices[i] - lowerDeltaV[i]) * t);
+                deltaNormals[i] = lowerDeltaN[i] + ((deltaNormals[i] - lowerDeltaN[i]) * t);
+                deltaTangents[i] = lowerDeltaT[i] + ((deltaTangents[i] - lowerDeltaT[i]) * t);
+            }
+
+            return true;
         }
 
         private static void GenerateProceduralMouthShapes(

--- a/Editor/BlendShapeGenerationEngine.cs
+++ b/Editor/BlendShapeGenerationEngine.cs
@@ -13,6 +13,10 @@ namespace ARKitBlendShapeGenerator
         public bool OverwriteExisting { get; set; }
         public bool EnableProceduralMouthShapes { get; set; }
         public float ProceduralMouthIntensity { get; set; } = 1.0f;
+        public bool EnableMouthCancellation { get; set; }
+        public List<BlendShapeSource> MouthCancellationSources { get; set; }
+        public float MouthCancellationStrength { get; set; } = 1.0f;
+        public HashSet<string> MouthCancellationTargets { get; set; }
         public bool Debug { get; set; }
 
         public static BlendShapeGenerationOptions FromComponent(ARKitBlendShapeGeneratorComponent component)
@@ -25,8 +29,31 @@ namespace ARKitBlendShapeGenerator
                 OverwriteExisting = component.overwriteExisting,
                 EnableProceduralMouthShapes = component.enableProceduralMouthShapes,
                 ProceduralMouthIntensity = component.proceduralMouthIntensity,
+                EnableMouthCancellation = component.enableMouthCancellation,
+                MouthCancellationSources = component.mouthCancellationSources,
+                MouthCancellationStrength = component.mouthCancellationStrength,
+                MouthCancellationTargets = BuildTargetSet(component.mouthCancellationTargets),
                 Debug = component.debugMode
             };
+        }
+
+        private static HashSet<string> BuildTargetSet(List<string> targets)
+        {
+            var result = new HashSet<string>();
+            if (targets == null)
+            {
+                return result;
+            }
+
+            foreach (var target in targets)
+            {
+                if (!string.IsNullOrWhiteSpace(target))
+                {
+                    result.Add(target.Trim());
+                }
+            }
+
+            return result;
         }
     }
 
@@ -85,6 +112,34 @@ namespace ARKitBlendShapeGenerator
             {
                 ArkitName = arkitName;
                 Sources = sources;
+            }
+        }
+
+        /// <summary>
+        /// 生成した口関連BlendShapeに焼き込む打ち消し用のデルタ（対象BlendShapeの逆方向の変形）
+        /// </summary>
+        private sealed class MouthCancellationDelta
+        {
+            public readonly Vector3[] DeltaVertices;
+            public readonly Vector3[] DeltaNormals;
+            public readonly Vector3[] DeltaTangents;
+            public readonly HashSet<string> TargetArkitNames;
+
+            public MouthCancellationDelta(
+                Vector3[] deltaVertices,
+                Vector3[] deltaNormals,
+                Vector3[] deltaTangents,
+                HashSet<string> targetArkitNames)
+            {
+                DeltaVertices = deltaVertices;
+                DeltaNormals = deltaNormals;
+                DeltaTangents = deltaTangents;
+                TargetArkitNames = targetArkitNames;
+            }
+
+            public bool AppliesTo(string arkitName)
+            {
+                return !string.IsNullOrEmpty(arkitName) && TargetArkitNames.Contains(arkitName);
             }
         }
 
@@ -168,9 +223,11 @@ namespace ARKitBlendShapeGenerator
                 }
             }
 
+            var cancellation = BuildMouthCancellationDelta(sourceMesh, existingShapes, options);
+
             foreach (var planned in plannedBlendShapes)
             {
-                if (TryAddBlendShape(sourceMesh, targetMesh, planned.ArkitName, planned.Sources, options))
+                if (TryAddBlendShape(sourceMesh, targetMesh, planned.ArkitName, planned.Sources, options, cancellation))
                 {
                     existingShapes[planned.ArkitName] = targetMesh.blendShapeCount - 1;
                     generatedShapes.Add(planned.ArkitName);
@@ -179,7 +236,13 @@ namespace ARKitBlendShapeGenerator
 
             if (options.EnableProceduralMouthShapes)
             {
-                GenerateProceduralMouthShapes(sourceMesh, targetMesh, options, customMappedNames, generatedShapes);
+                GenerateProceduralMouthShapes(
+                    sourceMesh,
+                    targetMesh,
+                    options,
+                    customMappedNames,
+                    generatedShapes,
+                    cancellation);
             }
 
             // 生成・削除後の最終状態からインデックスを再構築する
@@ -196,12 +259,120 @@ namespace ARKitBlendShapeGenerator
             return new BlendShapeGenerationResult(generatedShapes, shapeIndices);
         }
 
+        /// <summary>
+        /// 打ち消し対象BlendShapeの逆方向デルタを合成する。
+        /// 対象や強度が未設定の場合はnull（打ち消しなし）。
+        /// </summary>
+        private static MouthCancellationDelta BuildMouthCancellationDelta(
+            Mesh sourceMesh,
+            Dictionary<string, int> existingShapes,
+            BlendShapeGenerationOptions options)
+        {
+            if (!options.EnableMouthCancellation)
+            {
+                return null;
+            }
+
+            if (options.MouthCancellationSources == null || options.MouthCancellationSources.Count == 0)
+            {
+                return null;
+            }
+
+            var targets = options.MouthCancellationTargets;
+            if (targets == null || targets.Count == 0)
+            {
+                Log(options, "Skip cancellation (no target shape selected)");
+                return null;
+            }
+
+            float strength = Mathf.Clamp01(options.MouthCancellationStrength);
+            if (strength <= Mathf.Epsilon)
+            {
+                return null;
+            }
+
+            int vertexCount = sourceMesh.vertexCount;
+            var deltaVertices = new Vector3[vertexCount];
+            var deltaNormals = new Vector3[vertexCount];
+            var deltaTangents = new Vector3[vertexCount];
+            var vertices = sourceMesh.vertices;
+            float blendWidth = Mathf.Max(0.0001f, options.BlendWidth);
+            bool hasDelta = false;
+
+            foreach (var source in options.MouthCancellationSources)
+            {
+                if (source == null || string.IsNullOrEmpty(source.blendShapeName))
+                {
+                    continue;
+                }
+
+                if (!TryGetSourceIndex(existingShapes, sourceMesh, source.blendShapeName, out int srcIndex))
+                {
+                    Log(options, $"Warning: Cancellation source not found: {source.blendShapeName}");
+                    continue;
+                }
+
+                int frameCount = sourceMesh.GetBlendShapeFrameCount(srcIndex);
+                if (frameCount == 0)
+                {
+                    continue;
+                }
+
+                // 打ち消し量はアバター側での適用量に合わせるため、生成強度（IntensityMultiplier）は掛けない
+                float adjustedWeight = -source.weight * strength;
+                if (Mathf.Abs(adjustedWeight) <= Mathf.Epsilon)
+                {
+                    continue;
+                }
+
+                var srcDeltaV = new Vector3[vertexCount];
+                var srcDeltaN = new Vector3[vertexCount];
+                var srcDeltaT = new Vector3[vertexCount];
+                sourceMesh.GetBlendShapeFrameVertices(srcIndex, frameCount - 1, srcDeltaV, srcDeltaN, srcDeltaT);
+
+                for (int i = 0; i < vertexCount; i++)
+                {
+                    float sideMultiplier = 1.0f;
+                    if (options.EnableLeftRightSplit && source.side != BlendShapeSide.Both)
+                    {
+                        sideMultiplier = CalculateSideMultiplier(vertices[i].x, source.side, blendWidth);
+                    }
+
+                    if (sideMultiplier <= 0.0f)
+                    {
+                        continue;
+                    }
+
+                    float finalWeight = adjustedWeight * sideMultiplier;
+                    deltaVertices[i] += srcDeltaV[i] * finalWeight;
+                    deltaNormals[i] += srcDeltaN[i] * finalWeight;
+                    deltaTangents[i] += srcDeltaT[i] * finalWeight;
+                }
+
+                hasDelta = true;
+            }
+
+            if (!hasDelta)
+            {
+                Log(options, "Skip cancellation (no valid source)");
+                return null;
+            }
+
+            Log(options, $"Cancellation targets: {string.Join(", ", targets.OrderBy(name => name))}");
+            return new MouthCancellationDelta(
+                deltaVertices,
+                deltaNormals,
+                deltaTangents,
+                new HashSet<string>(targets));
+        }
+
         private static void GenerateProceduralMouthShapes(
             Mesh sourceMesh,
             Mesh targetMesh,
             BlendShapeGenerationOptions options,
             HashSet<string> customMappedNames,
-            List<string> generatedShapes)
+            List<string> generatedShapes,
+            MouthCancellationDelta cancellation)
         {
             if (sourceMesh.vertexCount != targetMesh.vertexCount)
             {
@@ -256,17 +427,33 @@ namespace ARKitBlendShapeGenerator
             }
 
             // 生成できなかったシェイプの既存データを消さないよう、先にデルタを確定させる
-            var plannedDeltas = new List<(string arkitName, Vector3[] deltaVertices)>();
+            var plannedDeltas = new List<(string arkitName, Vector3[] deltaVertices, Vector3[] deltaNormals, Vector3[] deltaTangents)>();
             foreach (var arkitName in namesToGenerate)
             {
-                if (ProceduralMouthShapeGenerator.TryBuildDeltaVertices(context, arkitName, options, out var deltaVertices))
-                {
-                    plannedDeltas.Add((arkitName, deltaVertices));
-                }
-                else
+                if (!ProceduralMouthShapeGenerator.TryBuildDeltaVertices(context, arkitName, options, out var deltaVertices))
                 {
                     namesToReplace.Remove(arkitName);
+                    continue;
                 }
+
+                // 手続き的生成は平行移動のみのため、打ち消しを焼き込まない限り法線・接線のデルタは不要
+                Vector3[] deltaNormals = null;
+                Vector3[] deltaTangents = null;
+                if (cancellation != null && cancellation.AppliesTo(arkitName))
+                {
+                    deltaNormals = new Vector3[deltaVertices.Length];
+                    deltaTangents = new Vector3[deltaVertices.Length];
+                    for (int i = 0; i < deltaVertices.Length; i++)
+                    {
+                        deltaVertices[i] += cancellation.DeltaVertices[i];
+                        deltaNormals[i] = cancellation.DeltaNormals[i];
+                        deltaTangents[i] = cancellation.DeltaTangents[i];
+                    }
+
+                    Log(options, $"Applied cancellation (procedural): {arkitName}");
+                }
+
+                plannedDeltas.Add((arkitName, deltaVertices, deltaNormals, deltaTangents));
             }
 
             if (plannedDeltas.Count == 0)
@@ -283,15 +470,14 @@ namespace ARKitBlendShapeGenerator
                 }
             }
 
-            foreach (var (arkitName, deltaVertices) in plannedDeltas)
+            foreach (var (arkitName, deltaVertices, deltaNormals, deltaTangents) in plannedDeltas)
             {
-                // 平行移動のみのため法線・接線のデルタは不要（nullで省略可能）
                 targetMesh.AddBlendShapeFrame(
                     arkitName,
                     100f,
                     deltaVertices,
-                    null,
-                    null);
+                    deltaNormals,
+                    deltaTangents);
                 generatedShapes.Add(arkitName);
                 Log(options, $"Generated (procedural): {arkitName}");
             }
@@ -461,7 +647,8 @@ namespace ARKitBlendShapeGenerator
             Mesh targetMesh,
             string arkitName,
             List<(int index, float weight, BlendShapeSide side)> sources,
-            BlendShapeGenerationOptions options)
+            BlendShapeGenerationOptions options,
+            MouthCancellationDelta cancellation)
         {
             int vertexCount = sourceMesh.vertexCount;
             var deltaVertices = new Vector3[vertexCount];
@@ -516,6 +703,19 @@ namespace ARKitBlendShapeGenerator
             if (sourceCount == 0)
             {
                 return false;
+            }
+
+            // 打ち消しのみのBlendShapeを作らないよう、ソースから生成できた場合だけ焼き込む
+            if (cancellation != null && cancellation.AppliesTo(arkitName))
+            {
+                for (int i = 0; i < vertexCount; i++)
+                {
+                    deltaVertices[i] += cancellation.DeltaVertices[i];
+                    deltaNormals[i] += cancellation.DeltaNormals[i];
+                    deltaTangents[i] += cancellation.DeltaTangents[i];
+                }
+
+                Log(options, $"Applied cancellation: {arkitName}");
             }
 
             targetMesh.AddBlendShapeFrame(arkitName, 100f, deltaVertices, deltaNormals, deltaTangents);

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -80,6 +80,18 @@ msgstr "Deformation Intensity"
 msgid "prop.procedural_mouth_intensity.tooltip"
 msgstr "Deformation intensity for procedural generation"
 
+msgid "prop.enable_mouth_cancellation"
+msgstr "Enable Cancellation"
+
+msgid "prop.enable_mouth_cancellation.tooltip"
+msgstr "Bake a cancelling deformation of the specified blend shapes into the generated mouth blend shapes"
+
+msgid "prop.mouth_cancellation_strength"
+msgstr "Cancellation Strength"
+
+msgid "prop.mouth_cancellation_strength.tooltip"
+msgstr "Overall multiplier for the cancellation (1.0 cancels exactly the specified amount)"
+
 msgid "prop.debug_mode"
 msgstr "Debug Mode"
 
@@ -92,6 +104,43 @@ msgstr "Procedural Mouth Generation"
 
 msgid "inspector.procedural_mouth.description"
 msgstr "Procedurally generates mouth-related blend shapes (mouthLeft/Right, jaw*, etc.) that cannot be derived from existing blend shapes, by moving vertices in the mouth region. Existing blend shapes are only used to detect the mouth region."
+
+# Mouth cancellation
+msgid "inspector.section.mouth_cancellation"
+msgstr "Mouth Cancellation"
+
+msgid "inspector.mouth_cancellation.description"
+msgstr "Bakes a cancelling deformation (inverted delta) of the specified blend shapes into the generated mouth blend shapes. Intended to keep an always-on mouth adjustment blend shape from stacking on top of face-tracked mouth movement.\nThis setting is unnecessary when the source blend shapes are already corrected (authored without the deformation you want to cancel)."
+
+msgid "mouth_cancellation.sources.label"
+msgstr "Blend Shapes to Cancel"
+
+msgid "mouth_cancellation.sources.hint"
+msgstr "The weight is how strongly the blend shape is applied on the avatar (1.0 = weight 100)."
+
+msgid "mouth_cancellation.sources.add"
+msgstr "Add Blend Shape to Cancel"
+
+msgid "mouth_cancellation.sources.empty"
+msgstr "(not set - no cancellation is applied)"
+
+msgid "mouth_cancellation.targets.label"
+msgstr "ARKit Blend Shapes to Bake Into"
+
+msgid "mouth_cancellation.targets.select_all"
+msgstr "Select All"
+
+msgid "mouth_cancellation.targets.clear"
+msgstr "Clear All"
+
+msgid "mouth_cancellation.targets.count"
+msgstr "Selected: {0}/{1}"
+
+msgid "mouth_cancellation.targets.none_warning"
+msgstr "No target is selected, so no cancellation is applied."
+
+msgid "mouth_cancellation.targets.overshoot_warning"
+msgstr "Multiple targets are selected. When the selected blend shapes are applied at the same time, the cancellations stack and deform past the original shape in the opposite direction. Keep the targets to the minimum needed (e.g. jawOpen only)."
 
 # Custom mappings
 msgid "inspector.section.custom_mappings"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -80,6 +80,18 @@ msgstr "変形量係数"
 msgid "prop.procedural_mouth_intensity.tooltip"
 msgstr "手続き的生成の変形量係数"
 
+msgid "prop.enable_mouth_cancellation"
+msgstr "打ち消しを有効化"
+
+msgid "prop.enable_mouth_cancellation.tooltip"
+msgstr "生成した口関連BlendShapeに、指定したBlendShapeの変形を打ち消す成分を焼き込む"
+
+msgid "prop.mouth_cancellation_strength"
+msgstr "打ち消し強度"
+
+msgid "prop.mouth_cancellation_strength.tooltip"
+msgstr "打ち消し量の全体係数（1.0で指定した適用量をちょうど打ち消す）"
+
 msgid "prop.debug_mode"
 msgstr "デバッグモード"
 
@@ -92,6 +104,43 @@ msgstr "口の手続き的生成"
 
 msgid "inspector.procedural_mouth.description"
 msgstr "既存のBlendShapeから生成できない口周りのBlendShape（mouthLeft/Right、jaw系等）を、口領域の頂点移動で自動生成します。既存のBlendShapeは口領域の検出にのみ使用されます。"
+
+# 口の打ち消し
+msgid "inspector.section.mouth_cancellation"
+msgstr "口の打ち消し"
+
+msgid "inspector.mouth_cancellation.description"
+msgstr "生成した口関連BlendShapeに、指定したBlendShapeの変形を打ち消す成分（逆方向のデルタ）を焼き込みます。常時適用している口元の調整用BlendShapeが、フェイストラッキングによる口の動きと二重に適用されるのを防ぐ用途を想定しています。\n生成元のBlendShapeの側で既に修正済み（打ち消したい変形を含まない形で作られている）の場合、この設定は不要です。"
+
+msgid "mouth_cancellation.sources.label"
+msgstr "打ち消すBlendShape"
+
+msgid "mouth_cancellation.sources.hint"
+msgstr "重みはアバター側での適用量（1.0 = ウェイト100）を指定します。"
+
+msgid "mouth_cancellation.sources.add"
+msgstr "打ち消すBlendShapeを追加"
+
+msgid "mouth_cancellation.sources.empty"
+msgstr "(未設定 - 打ち消しは行われません)"
+
+msgid "mouth_cancellation.targets.label"
+msgstr "焼き込み先のARKit BlendShape"
+
+msgid "mouth_cancellation.targets.select_all"
+msgstr "全て選択"
+
+msgid "mouth_cancellation.targets.clear"
+msgstr "全て解除"
+
+msgid "mouth_cancellation.targets.count"
+msgstr "選択: {0}/{1}"
+
+msgid "mouth_cancellation.targets.none_warning"
+msgstr "焼き込み先が選択されていないため、打ち消しは行われません。"
+
+msgid "mouth_cancellation.targets.overshoot_warning"
+msgstr "複数の焼き込み先が選択されています。選択したBlendShapeが同時に適用されると打ち消しが重なり、対象の変形を通り越して逆向きに変形します。対象は必要最小限（例: jawOpenのみ）に絞ることを推奨します。"
 
 # カスタムマッピング
 msgid "inspector.section.custom_mappings"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 | **Overwrite Existing** | 既存のARKit BlendShapeを上書きする |
 | **Enable Procedural Mouth Shapes** | 既存シェイプキーから生成できない口周りのBlendShapeを頂点移動で自動生成する（デフォルト: 無効） |
 | **Procedural Mouth Intensity** | 手続き的生成の変形量係数（0.1〜2.0） |
+| **Enable Mouth Cancellation** | 生成した口関連BlendShapeに、指定したBlendShapeの打ち消し成分を焼き込む（デフォルト: 無効） |
+| **Mouth Cancellation Strength** | 打ち消し量の全体係数（0.0〜1.0） |
 | **Custom Mappings** | 自動マッピングできないBlendShapeを手動で指定 |
 | **Debug Mode** | デバッグログを出力する |
 
@@ -90,6 +92,21 @@ VRChat/MMDの標準的なBlendShape名（vrc.blink, まばたき, あ, い, う�
 - mouthUpperUpLeft/Right, mouthLowerDownLeft/Right
 
 シェイプキーから生成できた場合はそちらが優先され、手続き的生成はフォールバックとして動作します。デフォルトでは無効です。変形量は `Procedural Mouth Intensity` で調整できます。変形は口の前面（唇側）が最も大きく、奥の頂点ほど減衰するため、単純な平行移動よりも自然な動きになります。
+
+### 口の打ち消し
+
+`Enable Mouth Cancellation` を有効にすると、生成した口関連BlendShapeに、指定したBlendShapeの変形を打ち消す成分（逆方向のデルタ）を焼き込みます。
+口角調整などのBlendShapeを常時適用しているアバターで、その変形とフェイストラッキングによる口の動きが二重に適用されるのを防ぐ用途を想定しています。
+
+**生成元のBlendShapeの側で既に修正済み（打ち消したい変形を含まない形で作られている）の場合、この設定は不要です。**
+
+設定手順:
+
+1. `Enable Mouth Cancellation` を有効化
+2. 「打ち消すBlendShape」に対象のBlendShapeを追加し、重みにアバター側での適用量を指定（1.0 = ウェイト100）
+3. 「焼き込み先のARKit BlendShape」で、打ち消しを入れるARKit名を選択（デフォルト: `jawOpen`）
+
+BlendShapeは線形合成されるため、焼き込み先を複数選ぶと、それらが同時に適用されたときに打ち消しが重なって対象の変形を通り越し、逆向きに変形します。焼き込み先は必要最小限（多くの場合は `jawOpen` のみ）に絞ってください。打ち消し量は `Mouth Cancellation Strength` で弱めることもできます。
 
 ## ライセンス
 

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -47,6 +47,20 @@ namespace ARKitBlendShapeGenerator
         [Range(0.1f, 2.0f)]
         public float proceduralMouthIntensity = 1.0f;
 
+        [Header("Mouth Cancellation")]
+        [Tooltip("Bake a cancelling deformation (inverted delta) of the specified blend shapes into the generated mouth blend shapes")]
+        public bool enableMouthCancellation = false;
+
+        [Tooltip("Blend shapes to cancel out. Weight represents how strongly each one is applied on the avatar (1.0 = 100)")]
+        public List<BlendShapeSource> mouthCancellationSources = new List<BlendShapeSource>();
+
+        [Tooltip("Overall strength of the cancellation")]
+        [Range(0f, 1f)]
+        public float mouthCancellationStrength = 1.0f;
+
+        [Tooltip("ARKit mouth blend shapes the cancellation is baked into")]
+        public List<string> mouthCancellationTargets = new List<string> { "jawOpen" };
+
         [Header("Custom Mappings")]
         [Tooltip("Manually specify blend shapes that cannot be mapped automatically")]
         public List<CustomBlendShapeMapping> customMappings = new List<CustomBlendShapeMapping>();


### PR DESCRIPTION
## 概要

生成した口関連BlendShapeに、指定したBlendShapeの変形を打ち消す成分（逆方向のデルタ）を焼き込む機能を追加します。

口角調整などのBlendShapeを常時適用しているアバターでは、その変形とフェイストラッキングによる口の動きが単純加算され、唇のめり込みや二重変形が起きます。コミュニティで「打ち消しシェイプキー」と呼ばれる手法（対象の逆変形を混ぜて相殺する）を、生成時に自動で組み込めるようにしたものです。

## 変更内容

### 設定項目（`ARKitBlendShapeGeneratorComponent`）

| フィールド | 内容 |
| ---- | ---- |
| `enableMouthCancellation` | 機能の有効化（デフォルト: 無効） |
| `mouthCancellationSources` | 打ち消すBlendShape。既存の `BlendShapeSource` を流用し、名前・適用量（1.0 = ウェイト100）・左右フィルタを指定 |
| `mouthCancellationStrength` | 打ち消し量の全体係数（0.0〜1.0） |
| `mouthCancellationTargets` | 焼き込み先のARKit名（デフォルト: `jawOpen`） |

### エンジン（`BlendShapeGenerationEngine`）

- `BuildMouthCancellationDelta()` で打ち消しデルタ（頂点・法線・接線）を生成前に一度だけ構築
- シェイプキー由来（`TryAddBlendShape`）と手続き的生成（`GenerateProceduralMouthShapes`）の両経路に適用
  - 手続き的生成は従来 法線・接線を `null` で省略していたが、打ち消しを焼き込む場合のみ配列を渡すよう変更
- 打ち消しのみのBlendShapeを作らないよう、ソースから生成できた場合だけ焼き込む
- 打ち消し量はアバター側での適用量に合わせるため、`IntensityMultiplier` は掛けない

`BlendShapeProcessor` は引数が増えすぎるのを避けるため、`BlendShapeGenerationOptions` を受け取るコンストラクタを追加しました。既存の public コンストラクタは委譲する形で残しています。

### 同時適用時のオーバーシュートについて

BlendShapeは線形合成されるため、複数の生成シェイプに-100%分の打ち消しを焼き込むと、`jawOpen` と `mouthSmileLeft` の同時適用のようなケースで合計-200%となり、対象の変形を通り越して逆向きに変形します。焼き込み方式では原理的に回避できないため、**焼き込み先をユーザーが選択する方式**とし、以下で緩和しています。

- デフォルトは `jawOpen` のみ
- 複数選択時はインスペクタに警告を表示
- `Mouth Cancellation Strength` で打ち消し量を弱められる
- READMEに制限として明記

### UI・ドキュメント

- インスペクタに「口の打ち消し」セクションを追加（打ち消し対象リスト、強度、焼き込み先のトグル一覧＋全選択/全解除）
- **生成元のBlendShape側で既に修正済み（打ち消したい変形を含まない形で作られている）の場合はこの設定が不要である旨**を、セクションの説明文とREADMEに明記
- ja-jp / en-us のローカライズを追加
- NDMFプレビューが新設定の変更に追従するよう監視対象を追加

## 動作確認

Unityが無い環境のため、実機での生成結果の確認は未実施です。ローカライズキーの過不足（コードで参照している全キーが両.poに存在すること、両.po間でキー集合が一致すること）は確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRGzi8YmcmoVGPCDB2fTDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRGzi8YmcmoVGPCDB2fTDH)_