### PR TITLE
docs: NDMFプレビューのメニュー名を実際のUIに合わせて修正

### DIFF
--- a/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
@@ -14,13 +14,14 @@ namespace ARKitBlendShapeGenerator.Handler
 {
     /// <summary>
     /// NDMFプレビューシステム統合
-    /// Tools > NDMf > Preview でON/OFFを切り替え可能
+    /// Tools > NDM Framework > Configure Previews、または
+    /// コンポーネントのインスペクタ上のトグルでON/OFFを切り替え可能
     /// </summary>
     public class ARKitBlendShapeGeneratorPreview : IRenderFilter
     {
         /// <summary>
         /// プレビューのON/OFFを制御するノード
-        /// NDMFのPreviewメニューに表示される
+        /// NDMFのConfigure Previewsウィンドウに表示される
         /// </summary>
         public static readonly TogglablePreviewNode EnableNode = TogglablePreviewNode.Create(
             () => "ARKit BlendShape Generator",

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 
 NDMFのプレビュー機能を使用して、生成結果をリアルタイムで確認できます。
 
-1. Unityメニュー > Tools > NDMFを開く
+1. Unityメニュー > Tools > NDM Framework > Configure Previews を開く
 2. 「Kx VRC ARKit BlendShape Generator」のプレビューを有効化
 3. 生成されるBlendShapeをシーンビューで確認
+
+コンポーネントのインスペクタにある「NDMF Preview」のON/OFFボタンからも同じ設定を切り替えられます。
 
 ## 対応BlendShape
 


### PR DESCRIPTION
## 概要

`ARKitBlendShapeGeneratorPreview.cs` のコメントにある `Tools > NDMf > Preview` が現状に即しているか確認したところ、NDMF 側の実際のメニューと一致していなかったため修正しました。

## 確認内容

NDMF 本体（bdunderscore/ndmf）のソースを確認した結果、プレビューのON/OFF UI を開くメニューは以下の1つだけでした。

- `Editor/PreviewSystem/UI/PreviewPrefsUI.cs`: `[MenuItem("Tools/NDM Framework/Configure Previews")]`

既存コメントとのずれは3点です。

| 既存の記述 | 実際 |
| --- | --- |
| `NDMf` | メニュー名は `NDM Framework` |
| `Preview` | 項目名は `Configure Previews` |
| メニューで直接ON/OFF | メニューは *Configure Previews* ウィンドウを開くだけで、その中のチェックボックスで切り替える |

この menu item 文字列は NDMF 1.5.0 から最新（1.14.4）まで変わっていないため、仕様変更の名残ではなく単純な誤記でした。

## 変更内容

- `Editor/Handler/ARKitBlendShapeGeneratorPreview.cs`
  - クラスコメントを `Tools > NDM Framework > Configure Previews` に修正
  - `EnableNode` のコメントを「NDMFのConfigure Previewsウィンドウに表示される」に修正
  - 実際にはインスペクタ上のトグル（`ARKitBlendShapeGeneratorEditor.DrawNdmfPreviewToggle`）からも切り替えられるため、その旨を追記
- `README.md`
  - 「Unityメニュー > Tools > NDMFを開く」という同様の誤記を修正し、インスペクタからも切り替えられる旨を追記

コメント・ドキュメントのみの変更で、挙動の変更はありません。

## スコープ外

確認過程で `package.json` の NDMF 依存バージョン指定（`>=1.4.0` だがプレビュー機能には 1.5.0 以降が必要）に問題が見つかったため、#36 として起票しました。