### PR TITLE
Add advanced dropdowns for ARKit and BlendShape selection

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -164,8 +164,14 @@ msgstr "Mappings: {0}/{1} enabled"
 msgid "custom_mappings.none_matching"
 msgstr "No mappings match the filter."
 
-msgid "custom_mappings.no_available_names"
-msgstr "(no available ARKit names)"
+msgid "arkit_name.dropdown.title"
+msgstr "Select ARKit BlendShape"
+
+msgid "arkit_name.placeholder"
+msgstr "(select)"
+
+msgid "arkit_name.used_suffix"
+msgstr " (in use)"
 
 msgid "presets.label"
 msgstr "Presets"
@@ -214,6 +220,9 @@ msgstr "(select)"
 
 msgid "source.not_found_suffix"
 msgstr " (not found)"
+
+msgid "source.dropdown.title"
+msgstr "Select BlendShape"
 
 msgid "enum.side.both"
 msgstr "Both"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -164,8 +164,14 @@ msgstr "マッピング: {0}/{1} 有効"
 msgid "custom_mappings.none_matching"
 msgstr "該当するマッピングはありません。"
 
-msgid "custom_mappings.no_available_names"
-msgstr "(利用可能なARKit名なし)"
+msgid "arkit_name.dropdown.title"
+msgstr "ARKit BlendShapeを選択"
+
+msgid "arkit_name.placeholder"
+msgstr "(選択してください)"
+
+msgid "arkit_name.used_suffix"
+msgstr " (使用済み)"
 
 msgid "presets.label"
 msgstr "プリセット"
@@ -214,6 +220,9 @@ msgstr "(選択してください)"
 
 msgid "source.not_found_suffix"
 msgstr " (未検出)"
+
+msgid "source.dropdown.title"
+msgstr "BlendShapeを選択"
 
 msgid "enum.side.both"
 msgstr "両側"

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -661,7 +661,14 @@ namespace ARKitBlendShapeGenerator.Presentation
         private static bool DrawDropdownButton(string label, out Rect buttonRect)
         {
             var content = new GUIContent(label, label);
-            buttonRect = GUILayoutUtility.GetRect(content, EditorStyles.popup, GUILayout.ExpandWidth(true));
+
+            // BlendShape名のラベルによって右側のコントロールが範囲外に押し出されるのを防ぐ
+            buttonRect = GUILayoutUtility.GetRect(
+                content,
+                EditorStyles.popup,
+                GUILayout.ExpandWidth(true),
+                GUILayout.MinWidth(EditorGUIUtility.fieldWidth));
+
             return EditorGUI.DropdownButton(buttonRect, content, FocusType.Keyboard, EditorStyles.popup);
         }
 

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -47,6 +47,9 @@ namespace ARKitBlendShapeGenerator.Presentation
         // マッピング行チェックボックスの幅
         private const float MappingToggleWidth = 20f;
 
+        // インデントレベル
+        private const float IndentWidth = 15f;
+
         private string _pendingSelectionPropertyPath;
         private string _pendingSelectionValue;
 
@@ -764,9 +767,12 @@ namespace ARKitBlendShapeGenerator.Presentation
                 EditorGUILayout.LabelField(S("mouth_cancellation.sources.empty"), EditorStyles.miniLabel);
             }
 
+            // DrawSourceItemは行内のインデントを無効にするため周囲の要素と揃うようにインデントさせる
+            float indentSpace = EditorGUI.indentLevel * IndentWidth;
+
             for (int i = 0; i < sourcesProperty.arraySize; i++)
             {
-                if (!DrawSourceItem(sourcesProperty, i))
+                if (!DrawSourceItem(sourcesProperty, i, indentSpace))
                 {
                     // 要素を削除したため、以降のインデックスがずれる。この描画パスは打ち切る
                     break;

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -47,9 +47,6 @@ namespace ARKitBlendShapeGenerator.Presentation
         // マッピング行チェックボックスの幅
         private const float MappingToggleWidth = 20f;
 
-        // 名前選択ドロップダウンの状態（キーはSerializedPropertyのパス = 行ごとに保持する）
-        private readonly Dictionary<string, AdvancedDropdownState> _dropdownStates =
-            new Dictionary<string, AdvancedDropdownState>();
         private string _pendingSelectionPropertyPath;
         private string _pendingSelectionValue;
 
@@ -67,7 +64,6 @@ namespace ARKitBlendShapeGenerator.Presentation
             int componentId = _component != null ? _component.GetInstanceID() : 0;
             ARKitBlendShapeGeneratorPreviewState.ReleaseIfActive(componentId);
             InvalidatePreviewCategoryCache();
-            _dropdownStates.Clear();
         }
 
         private void OnUndoRedoPerformed()
@@ -673,14 +669,10 @@ namespace ARKitBlendShapeGenerator.Presentation
         {
             RefreshBlendShapeList();
 
-            string currentValue = blendShapeNameProperty.stringValue;
-            bool isMissing = BlendShapeSearchDropdown.ResolveState(currentValue, _availableBlendShapes) ==
-                             BlendShapeSearchDropdown.SourceValueState.Missing;
-
             var dropdown = new BlendShapeSearchDropdown(
-                GetDropdownState(blendShapeNameProperty),
+                new AdvancedDropdownState(),
                 _availableBlendShapes,
-                isMissing ? currentValue : null,
+                blendShapeNameProperty.stringValue,
                 CreateSelectionCallback(blendShapeNameProperty));
 
             dropdown.Open(buttonRect);
@@ -693,24 +685,13 @@ namespace ARKitBlendShapeGenerator.Presentation
             SerializedProperty arkitNameProperty)
         {
             var dropdown = new ArkitNameSearchDropdown(
-                GetDropdownState(arkitNameProperty),
+                new AdvancedDropdownState(),
                 ARKitBlendShapeNames.GetAll(),
                 GetArkitNamesUsedByOtherMappings(customMappingsProperty, mappingIndex),
+                arkitNameProperty.stringValue,
                 CreateSelectionCallback(arkitNameProperty));
 
             dropdown.Open(buttonRect);
-        }
-
-        private AdvancedDropdownState GetDropdownState(SerializedProperty property)
-        {
-            string propertyPath = property.propertyPath;
-            if (!_dropdownStates.TryGetValue(propertyPath, out var state))
-            {
-                state = new AdvancedDropdownState();
-                _dropdownStates[propertyPath] = state;
-            }
-
-            return state;
         }
 
         private Action<string> CreateSelectionCallback(SerializedProperty property)

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using UnityEditor;
+using UnityEditor.IMGUI.Controls;
 using nadena.dev.ndmf.ui;
 using ARKitBlendShapeGenerator.Domain;
 using ARKitBlendShapeGenerator.Handler;
@@ -42,6 +44,12 @@ namespace ARKitBlendShapeGenerator.Presentation
         // 検索
         private string _searchFilter = "";
 
+        // 名前選択ドロップダウンの状態（キーはSerializedPropertyのパス = 行ごとに保持する）
+        private readonly Dictionary<string, AdvancedDropdownState> _dropdownStates =
+            new Dictionary<string, AdvancedDropdownState>();
+        private string _pendingSelectionPropertyPath;
+        private string _pendingSelectionValue;
+
         private void OnEnable()
         {
             _component = (ARKitBlendShapeGeneratorComponent)target;
@@ -56,6 +64,7 @@ namespace ARKitBlendShapeGenerator.Presentation
             int componentId = _component != null ? _component.GetInstanceID() : 0;
             ARKitBlendShapeGeneratorPreviewState.ReleaseIfActive(componentId);
             InvalidatePreviewCategoryCache();
+            _dropdownStates.Clear();
         }
 
         private void OnUndoRedoPerformed()
@@ -76,6 +85,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
+            ApplyPendingDropdownSelection();
 
             // 言語切替 + ヘッダー
             LanguageSwitcher.DrawImmediate();
@@ -442,7 +452,9 @@ namespace ARKitBlendShapeGenerator.Presentation
             }
         }
 
-        private List<string> GetSelectableArkitNames(SerializedProperty customMappingsProperty, int mappingIndex)
+        private static HashSet<string> GetArkitNamesUsedByOtherMappings(
+            SerializedProperty customMappingsProperty,
+            int mappingIndex)
         {
             var usedByOthers = new HashSet<string>();
             for (int i = 0; i < customMappingsProperty.arraySize; i++)
@@ -460,27 +472,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                 }
             }
 
-            var options = ARKitBlendShapeNames.GetAll()
-                .Where(name => !usedByOthers.Contains(name))
-                .ToList();
-
-            if (mappingIndex < 0 || mappingIndex >= customMappingsProperty.arraySize)
-            {
-                return options;
-            }
-
-            var currentName = customMappingsProperty.GetArrayElementAtIndex(mappingIndex)
-                .FindPropertyRelative("arkitName").stringValue;
-            if (!string.IsNullOrWhiteSpace(currentName))
-            {
-                var trimmedCurrentName = currentName.Trim();
-                if (!options.Contains(trimmedCurrentName))
-                {
-                    options.Insert(0, trimmedCurrentName);
-                }
-            }
-
-            return options;
+            return usedByOthers;
         }
 
         private string GetFirstUnusedArkitName(SerializedProperty customMappingsProperty)
@@ -546,26 +538,11 @@ namespace ARKitBlendShapeGenerator.Presentation
                 enabledProperty.boolValue = newEnabled;
             }
 
-            // ARKit名のドロップダウン（同一ARKit名の重複は選択不可）
-            var selectableArkitNames = GetSelectableArkitNames(customMappingsProperty, index);
-            if (selectableArkitNames.Count == 0)
+            // ARKit名の選択
+            string arkitNameLabel = ArkitNameSearchDropdown.BuildButtonLabel(arkitNameProperty.stringValue);
+            if (DrawDropdownButton(arkitNameLabel, out var arkitNameRect))
             {
-                EditorGUILayout.LabelField(S("custom_mappings.no_available_names"));
-            }
-            else
-            {
-                string currentArkitName = string.IsNullOrWhiteSpace(arkitNameProperty.stringValue)
-                    ? null
-                    : arkitNameProperty.stringValue.Trim();
-                int currentIndex = selectableArkitNames.IndexOf(currentArkitName);
-                if (currentIndex < 0) currentIndex = 0;
-
-                int newIndex = EditorGUILayout.Popup(currentIndex, selectableArkitNames.ToArray());
-                string selectedArkitName = selectableArkitNames[newIndex];
-                if (!string.Equals(arkitNameProperty.stringValue, selectedArkitName))
-                {
-                    arkitNameProperty.stringValue = selectedArkitName;
-                }
+                ShowArkitNameDropdown(arkitNameRect, customMappingsProperty, index, arkitNameProperty);
             }
 
             if (GUILayout.Button("+", GUILayout.Width(25)))
@@ -615,37 +592,14 @@ namespace ARKitBlendShapeGenerator.Presentation
 
             EditorGUILayout.BeginHorizontal();
 
-            // BlendShape名のドロップダウン
+            // BlendShape名の選択
             if (_availableBlendShapes.Count > 0)
             {
-                string notFoundSuffix = S("source.not_found_suffix");
-                var options = new List<string> { S("source.placeholder") };
-                options.AddRange(_availableBlendShapes);
-
-                int currentIdx = _availableBlendShapes.IndexOf(blendShapeNameProperty.stringValue) + 1;
-
-                // リストにない名前が設定されている場合は末尾に追加して表示
-                if (currentIdx == 0 && !string.IsNullOrEmpty(blendShapeNameProperty.stringValue))
+                string label = BlendShapeSearchDropdown.BuildButtonLabel(
+                    blendShapeNameProperty.stringValue, _availableBlendShapes);
+                if (DrawDropdownButton(label, out var buttonRect))
                 {
-                    options.Add(blendShapeNameProperty.stringValue + notFoundSuffix);
-                    currentIdx = options.Count - 1;
-                }
-
-                int newIdx = EditorGUILayout.Popup(currentIdx, options.ToArray());
-
-                if (newIdx > 0 && newIdx < options.Count)
-                {
-                    // 「(未検出)」付きの項目が選択された場合は元の名前を維持
-                    string selectedName = options[newIdx];
-                    if (selectedName.EndsWith(notFoundSuffix))
-                    {
-                        selectedName = selectedName.Replace(notFoundSuffix, "");
-                    }
-
-                    if (blendShapeNameProperty.stringValue != selectedName)
-                    {
-                        blendShapeNameProperty.stringValue = selectedName;
-                    }
+                    ShowBlendShapeDropdown(buttonRect, blendShapeNameProperty);
                 }
             }
             else
@@ -684,6 +638,97 @@ namespace ARKitBlendShapeGenerator.Presentation
 
             EditorGUILayout.EndHorizontal();
             return !removed;
+        }
+
+        /// <summary>
+        /// ドロップダウンを開くボタンを描画する。押された場合はtrue（buttonRectは表示位置として使う）
+        /// </summary>
+        private static bool DrawDropdownButton(string label, out Rect buttonRect)
+        {
+            var content = new GUIContent(label, label);
+
+            buttonRect = EditorGUI.IndentedRect(
+                EditorGUILayout.GetControlRect(false, EditorGUIUtility.singleLineHeight, EditorStyles.popup));
+
+            return EditorGUI.DropdownButton(buttonRect, content, FocusType.Keyboard, EditorStyles.popup);
+        }
+
+        private void ShowBlendShapeDropdown(Rect buttonRect, SerializedProperty blendShapeNameProperty)
+        {
+            RefreshBlendShapeList();
+
+            string currentValue = blendShapeNameProperty.stringValue;
+            bool isMissing = BlendShapeSearchDropdown.ResolveState(currentValue, _availableBlendShapes) ==
+                             BlendShapeSearchDropdown.SourceValueState.Missing;
+
+            var dropdown = new BlendShapeSearchDropdown(
+                GetDropdownState(blendShapeNameProperty),
+                _availableBlendShapes,
+                isMissing ? currentValue : null,
+                CreateSelectionCallback(blendShapeNameProperty));
+
+            dropdown.Show(buttonRect);
+        }
+
+        private void ShowArkitNameDropdown(
+            Rect buttonRect,
+            SerializedProperty customMappingsProperty,
+            int mappingIndex,
+            SerializedProperty arkitNameProperty)
+        {
+            var dropdown = new ArkitNameSearchDropdown(
+                GetDropdownState(arkitNameProperty),
+                ARKitBlendShapeNames.GetAll(),
+                GetArkitNamesUsedByOtherMappings(customMappingsProperty, mappingIndex),
+                CreateSelectionCallback(arkitNameProperty));
+
+            dropdown.Show(buttonRect);
+        }
+
+        private AdvancedDropdownState GetDropdownState(SerializedProperty property)
+        {
+            string propertyPath = property.propertyPath;
+            if (!_dropdownStates.TryGetValue(propertyPath, out var state))
+            {
+                state = new AdvancedDropdownState();
+                _dropdownStates[propertyPath] = state;
+            }
+
+            return state;
+        }
+
+        private Action<string> CreateSelectionCallback(SerializedProperty property)
+        {
+            string propertyPath = property.propertyPath;
+
+            return selectedValue =>
+            {
+                if (this == null)
+                {
+                    return;
+                }
+
+                _pendingSelectionPropertyPath = propertyPath;
+                _pendingSelectionValue = selectedValue;
+                Repaint();
+            };
+        }
+
+        private void ApplyPendingDropdownSelection()
+        {
+            if (_pendingSelectionPropertyPath == null)
+            {
+                return;
+            }
+
+            var property = serializedObject.FindProperty(_pendingSelectionPropertyPath);
+            if (property != null && property.propertyType == SerializedPropertyType.String)
+            {
+                property.stringValue = _pendingSelectionValue;
+            }
+
+            _pendingSelectionPropertyPath = null;
+            _pendingSelectionValue = null;
         }
 
         private static void AppendSourceElement(SerializedProperty sourcesProperty)

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -665,15 +665,8 @@ namespace ARKitBlendShapeGenerator.Presentation
         private static bool DrawDropdownButton(string label, out Rect buttonRect)
         {
             var content = new GUIContent(label, label);
-
-            if (!EditorGUILayout.DropdownButton(content, FocusType.Keyboard, EditorStyles.popup))
-            {
-                buttonRect = Rect.zero;
-                return false;
-            }
-
-            buttonRect = GUILayoutUtility.GetLastRect();
-            return true;
+            buttonRect = GUILayoutUtility.GetRect(content, EditorStyles.popup, GUILayout.ExpandWidth(true));
+            return EditorGUI.DropdownButton(buttonRect, content, FocusType.Keyboard, EditorStyles.popup);
         }
 
         private void ShowBlendShapeDropdown(Rect buttonRect, SerializedProperty blendShapeNameProperty)

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -44,6 +44,9 @@ namespace ARKitBlendShapeGenerator.Presentation
         // 検索
         private string _searchFilter = "";
 
+        // マッピング行チェックボックスの幅
+        private const float MappingToggleWidth = 20f;
+
         // 名前選択ドロップダウンの状態（キーはSerializedPropertyのパス = 行ごとに保持する）
         private readonly Dictionary<string, AdvancedDropdownState> _dropdownStates =
             new Dictionary<string, AdvancedDropdownState>();
@@ -532,7 +535,11 @@ namespace ARKitBlendShapeGenerator.Presentation
             // ヘッダー行
             EditorGUILayout.BeginHorizontal();
 
-            bool newEnabled = EditorGUILayout.Toggle(enabledProperty.boolValue, GUILayout.Width(20));
+            int outerIndentLevel = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+
+            bool newEnabled = EditorGUILayout.Toggle(
+                enabledProperty.boolValue, GUILayout.Width(MappingToggleWidth));
             if (newEnabled != enabledProperty.boolValue)
             {
                 enabledProperty.boolValue = newEnabled;
@@ -557,6 +564,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                 removed = true;
             }
 
+            EditorGUI.indentLevel = outerIndentLevel;
             EditorGUILayout.EndHorizontal();
 
             if (removed)
@@ -565,16 +573,14 @@ namespace ARKitBlendShapeGenerator.Presentation
                 return false;
             }
 
-            // ソースBlendShape
-            EditorGUI.indentLevel++;
+            // ソースBlendShape（ドロップダウンの左端をヘッダー行のARKit名に揃える）
             for (int j = 0; j < sourcesProperty.arraySize; j++)
             {
-                if (!DrawSourceItem(sourcesProperty, j))
+                if (!DrawSourceItem(sourcesProperty, j, MappingToggleWidth))
                 {
                     break;
                 }
             }
-            EditorGUI.indentLevel--;
 
             EditorGUILayout.EndVertical();
             return true;
@@ -583,7 +589,10 @@ namespace ARKitBlendShapeGenerator.Presentation
         /// <summary>
         /// ソースBlendShape1件を描画する。要素を削除した場合はfalse（呼び出し元は列挙を打ち切る）
         /// </summary>
-        private bool DrawSourceItem(SerializedProperty sourcesProperty, int sourceIndex)
+        private bool DrawSourceItem(
+            SerializedProperty sourcesProperty,
+            int sourceIndex,
+            float leadingSpace = 0f)
         {
             var sourceProperty = sourcesProperty.GetArrayElementAtIndex(sourceIndex);
             var blendShapeNameProperty = sourceProperty.FindPropertyRelative("blendShapeName");
@@ -591,6 +600,14 @@ namespace ARKitBlendShapeGenerator.Presentation
             var sideProperty = sourceProperty.FindPropertyRelative("side");
 
             EditorGUILayout.BeginHorizontal();
+
+            int outerIndentLevel = EditorGUI.indentLevel;
+            EditorGUI.indentLevel = 0;
+
+            if (leadingSpace > 0f)
+            {
+                GUILayout.Space(leadingSpace);
+            }
 
             // BlendShape名の選択
             if (_availableBlendShapes.Count > 0)
@@ -636,6 +653,8 @@ namespace ARKitBlendShapeGenerator.Presentation
                 removed = true;
             }
 
+            EditorGUI.indentLevel = outerIndentLevel;
+
             EditorGUILayout.EndHorizontal();
             return !removed;
         }
@@ -647,10 +666,14 @@ namespace ARKitBlendShapeGenerator.Presentation
         {
             var content = new GUIContent(label, label);
 
-            buttonRect = EditorGUI.IndentedRect(
-                EditorGUILayout.GetControlRect(false, EditorGUIUtility.singleLineHeight, EditorStyles.popup));
+            if (!EditorGUILayout.DropdownButton(content, FocusType.Keyboard, EditorStyles.popup))
+            {
+                buttonRect = Rect.zero;
+                return false;
+            }
 
-            return EditorGUI.DropdownButton(buttonRect, content, FocusType.Keyboard, EditorStyles.popup);
+            buttonRect = GUILayoutUtility.GetLastRect();
+            return true;
         }
 
         private void ShowBlendShapeDropdown(Rect buttonRect, SerializedProperty blendShapeNameProperty)
@@ -667,7 +690,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                 isMissing ? currentValue : null,
                 CreateSelectionCallback(blendShapeNameProperty));
 
-            dropdown.Show(buttonRect);
+            dropdown.Open(buttonRect);
         }
 
         private void ShowArkitNameDropdown(
@@ -682,7 +705,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                 GetArkitNamesUsedByOtherMappings(customMappingsProperty, mappingIndex),
                 CreateSelectionCallback(arkitNameProperty));
 
-            dropdown.Show(buttonRect);
+            dropdown.Open(buttonRect);
         }
 
         private AdvancedDropdownState GetDropdownState(SerializedProperty property)

--- a/Editor/Presentation/AdvancedDropdownReflection.cs
+++ b/Editor/Presentation/AdvancedDropdownReflection.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+
+namespace ARKitBlendShapeGenerator.Presentation
+{
+    /// <summary>
+    /// UnityEditorのAdvancedDropdown内部APIへのアクセスを集約する互換層
+    /// </summary>
+    internal static class AdvancedDropdownReflection
+    {
+        private const BindingFlags MemberFlags =
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        private static readonly FieldInfo WindowInstanceField;
+        private static readonly PropertyInfo MaximumSizeProperty;
+        private static readonly MethodInfo SetSelectedIndexMethod;
+        private static readonly Type WindowType;
+        private static readonly PropertyInfo CloseOnSelectionProperty;
+        private static readonly EventInfo SelectionChangedEvent;
+
+        static AdvancedDropdownReflection()
+        {
+            WindowInstanceField = typeof(AdvancedDropdown).GetField("m_WindowInstance", MemberFlags);
+            MaximumSizeProperty = typeof(AdvancedDropdown).GetProperty("maximumSize", MemberFlags);
+            SetSelectedIndexMethod = typeof(AdvancedDropdownState).GetMethod(
+                "SetSelectedIndex",
+                MemberFlags,
+                null,
+                new[] { typeof(AdvancedDropdownItem), typeof(int) },
+                null);
+
+            WindowType = WindowInstanceField?.FieldType;
+            CloseOnSelectionProperty = WindowType?.GetProperty("closeOnSelection", MemberFlags);
+            SelectionChangedEvent = WindowType?.GetEvent("selectionChanged", MemberFlags);
+        }
+
+        internal static bool CanSetMaximumSize =>
+            MaximumSizeProperty != null &&
+            MaximumSizeProperty.CanWrite &&
+            MaximumSizeProperty.PropertyType == typeof(Vector2);
+
+        internal static bool CanSetSelectedIndex =>
+            SetSelectedIndexMethod != null &&
+            SetSelectedIndexMethod.ReturnType == typeof(void);
+
+        internal static bool CanOverrideSelectionHandling =>
+            WindowInstanceField != null &&
+            WindowType != null &&
+            typeof(EditorWindow).IsAssignableFrom(WindowType) &&
+            CloseOnSelectionProperty != null &&
+            CloseOnSelectionProperty.CanWrite &&
+            CloseOnSelectionProperty.PropertyType == typeof(bool) &&
+            SelectionChangedEvent != null &&
+            SelectionChangedEvent.EventHandlerType == typeof(Action<AdvancedDropdownItem>);
+
+        internal static bool TrySetMaximumSize(AdvancedDropdown dropdown, Vector2 value)
+        {
+            if (dropdown == null || !CanSetMaximumSize)
+            {
+                return false;
+            }
+
+            try
+            {
+                MaximumSizeProperty.SetValue(dropdown, value);
+                return true;
+            }
+            catch (Exception exception) when (IsReflectionFailure(exception))
+            {
+                return false;
+            }
+        }
+
+        internal static bool TrySetSelectedIndex(
+            AdvancedDropdownState state,
+            AdvancedDropdownItem root,
+            int index)
+        {
+            if (state == null || root == null || index < 0 || !CanSetSelectedIndex)
+            {
+                return false;
+            }
+
+            try
+            {
+                SetSelectedIndexMethod.Invoke(state, new object[] { root, index });
+                return true;
+            }
+            catch (Exception exception) when (IsReflectionFailure(exception))
+            {
+                return false;
+            }
+        }
+
+        internal static bool TryOverrideSelectionHandling(
+            AdvancedDropdown dropdown,
+            Action<AdvancedDropdownItem> handler,
+            out EditorWindow window)
+        {
+            window = null;
+            if (dropdown == null || handler == null || !CanOverrideSelectionHandling)
+            {
+                return false;
+            }
+
+            bool changedCloseBehavior = false;
+            try
+            {
+                window = WindowInstanceField.GetValue(dropdown) as EditorWindow;
+                if (window == null)
+                {
+                    return false;
+                }
+
+                CloseOnSelectionProperty.SetValue(window, false);
+                changedCloseBehavior = true;
+                SelectionChangedEvent.AddEventHandler(window, handler);
+                return true;
+            }
+            catch (Exception exception) when (IsReflectionFailure(exception))
+            {
+                if (changedCloseBehavior && window != null)
+                {
+                    RestoreCloseBehaviorOrClose(window);
+                }
+
+                window = null;
+                return false;
+            }
+        }
+
+        private static void RestoreCloseBehaviorOrClose(EditorWindow window)
+        {
+            try
+            {
+                CloseOnSelectionProperty.SetValue(window, true);
+            }
+            catch (Exception exception) when (IsReflectionFailure(exception))
+            {
+                window.Close();
+            }
+        }
+
+        private static bool IsReflectionFailure(Exception exception)
+        {
+            return exception is ArgumentException ||
+                   exception is TargetException ||
+                   exception is TargetInvocationException ||
+                   exception is MemberAccessException ||
+                   exception is InvalidOperationException ||
+                   exception is NotSupportedException;
+        }
+    }
+}

--- a/Editor/Presentation/ArkitNameSearchDropdown.cs
+++ b/Editor/Presentation/ArkitNameSearchDropdown.cs
@@ -19,7 +19,8 @@ namespace ARKitBlendShapeGenerator.Presentation
             AdvancedDropdownState state,
             IReadOnlyList<string> arkitNames,
             ICollection<string> usedByOtherMappings,
-            Action<string> onSelected) : base(state, onSelected)
+            string currentValue,
+            Action<string> onSelected) : base(state, currentValue, onSelected)
         {
             _arkitNames = arkitNames ?? new List<string>();
             _usedByOtherMappings = usedByOtherMappings ?? new HashSet<string>();

--- a/Editor/Presentation/ArkitNameSearchDropdown.cs
+++ b/Editor/Presentation/ArkitNameSearchDropdown.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor.IMGUI.Controls;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator.Presentation
+{
+    /// <summary>
+    /// カスタムマッピングのARKit名を検索して選択するドロップダウン
+    /// 同一ARKit名は複数のマッピングに設定できないため、他のマッピングで使用済みの名前は
+    /// 一覧から隠さずグレーアウトして選択不可にする
+    /// </summary>
+    internal sealed class ArkitNameSearchDropdown : SearchableNameDropdown
+    {
+        private readonly IReadOnlyList<string> _arkitNames;
+        private readonly ICollection<string> _usedByOtherMappings;
+
+        public ArkitNameSearchDropdown(
+            AdvancedDropdownState state,
+            IReadOnlyList<string> arkitNames,
+            ICollection<string> usedByOtherMappings,
+            Action<string> onSelected) : base(state, onSelected)
+        {
+            _arkitNames = arkitNames ?? new List<string>();
+            _usedByOtherMappings = usedByOtherMappings ?? new HashSet<string>();
+        }
+
+        internal static string BuildButtonLabel(string current)
+        {
+            return string.IsNullOrWhiteSpace(current) ? S("arkit_name.placeholder") : current.Trim();
+        }
+
+        protected override AdvancedDropdownItem BuildRoot()
+        {
+            var root = new AdvancedDropdownItem(S("arkit_name.dropdown.title"));
+            int nextId = 0;
+
+            foreach (var arkitName in _arkitNames)
+            {
+                if (string.IsNullOrEmpty(arkitName))
+                {
+                    continue;
+                }
+
+                bool isUsed = _usedByOtherMappings.Contains(arkitName);
+                root.AddChild(new ValueItem(isUsed ? arkitName + S("arkit_name.used_suffix") : arkitName, arkitName)
+                {
+                    id = nextId++,
+                    enabled = !isUsed
+                });
+            }
+
+            return root;
+        }
+    }
+}

--- a/Editor/Presentation/BlendShapeSearchDropdown.cs
+++ b/Editor/Presentation/BlendShapeSearchDropdown.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEditor.IMGUI.Controls;
 using static ARKitBlendShapeGenerator.Localization;
 
@@ -18,19 +19,17 @@ namespace ARKitBlendShapeGenerator.Presentation
         }
 
         private readonly IReadOnlyList<string> _blendShapeNames;
-        private readonly string _missingValue;
 
         public BlendShapeSearchDropdown(
             AdvancedDropdownState state,
             IReadOnlyList<string> blendShapeNames,
-            string missingValue,
-            Action<string> onSelected) : base(state, onSelected)
+            string currentValue,
+            Action<string> onSelected) : base(state, currentValue, onSelected)
         {
             _blendShapeNames = blendShapeNames ?? new List<string>();
-            _missingValue = missingValue;
         }
 
-        internal static SourceValueState ResolveState(string current, ICollection<string> availableBlendShapes)
+        internal static SourceValueState ResolveState(string current, IReadOnlyList<string> availableBlendShapes)
         {
             if (string.IsNullOrEmpty(current))
             {
@@ -42,7 +41,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                 : SourceValueState.Missing;
         }
 
-        internal static string BuildButtonLabel(string current, ICollection<string> availableBlendShapes)
+        internal static string BuildButtonLabel(string current, IReadOnlyList<string> availableBlendShapes)
         {
             switch (ResolveState(current, availableBlendShapes))
             {
@@ -63,9 +62,9 @@ namespace ARKitBlendShapeGenerator.Presentation
 
             root.AddChild(new ValueItem(S("source.placeholder"), string.Empty) { id = nextId++ });
 
-            if (!string.IsNullOrEmpty(_missingValue))
+            if (ResolveState(CurrentValue, _blendShapeNames) == SourceValueState.Missing)
             {
-                root.AddChild(new ValueItem(_missingValue + S("source.not_found_suffix"), _missingValue)
+                root.AddChild(new ValueItem(CurrentValue + S("source.not_found_suffix"), CurrentValue)
                 {
                     id = nextId++,
                     enabled = false

--- a/Editor/Presentation/BlendShapeSearchDropdown.cs
+++ b/Editor/Presentation/BlendShapeSearchDropdown.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor.IMGUI.Controls;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator.Presentation
+{
+    /// <summary>
+    /// ソースBlendShapeを検索して選択するドロップダウン
+    /// </summary>
+    internal sealed class BlendShapeSearchDropdown : SearchableNameDropdown
+    {
+        internal enum SourceValueState
+        {
+            Empty,
+            Found,
+            Missing
+        }
+
+        private readonly IReadOnlyList<string> _blendShapeNames;
+        private readonly string _missingValue;
+
+        public BlendShapeSearchDropdown(
+            AdvancedDropdownState state,
+            IReadOnlyList<string> blendShapeNames,
+            string missingValue,
+            Action<string> onSelected) : base(state, onSelected)
+        {
+            _blendShapeNames = blendShapeNames ?? new List<string>();
+            _missingValue = missingValue;
+        }
+
+        internal static SourceValueState ResolveState(string current, ICollection<string> availableBlendShapes)
+        {
+            if (string.IsNullOrEmpty(current))
+            {
+                return SourceValueState.Empty;
+            }
+
+            return availableBlendShapes != null && availableBlendShapes.Contains(current)
+                ? SourceValueState.Found
+                : SourceValueState.Missing;
+        }
+
+        internal static string BuildButtonLabel(string current, ICollection<string> availableBlendShapes)
+        {
+            switch (ResolveState(current, availableBlendShapes))
+            {
+                case SourceValueState.Empty:
+                    return S("source.placeholder");
+                case SourceValueState.Missing:
+                    return current + S("source.not_found_suffix");
+                default:
+                    return current;
+            }
+        }
+
+        protected override AdvancedDropdownItem BuildRoot()
+        {
+            var root = new AdvancedDropdownItem(S("source.dropdown.title"));
+
+            int nextId = 0;
+
+            root.AddChild(new ValueItem(S("source.placeholder"), string.Empty) { id = nextId++ });
+
+            if (!string.IsNullOrEmpty(_missingValue))
+            {
+                root.AddChild(new ValueItem(_missingValue + S("source.not_found_suffix"), _missingValue)
+                {
+                    id = nextId++,
+                    enabled = false
+                });
+            }
+
+            foreach (var blendShapeName in _blendShapeNames)
+            {
+                if (string.IsNullOrEmpty(blendShapeName))
+                {
+                    continue;
+                }
+
+                root.AddChild(new ValueItem(blendShapeName, blendShapeName) { id = nextId++ });
+            }
+
+            return root;
+        }
+    }
+}

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
@@ -18,28 +17,8 @@ namespace ARKitBlendShapeGenerator.Presentation
             }
         }
 
-        // 内部のcloseOnSelectionを無効化し閉じる処理を独自に行う
-        private const BindingFlags MemberFlags =
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
-
-        private static readonly FieldInfo WindowInstanceField =
-            typeof(AdvancedDropdown).GetField("m_WindowInstance", MemberFlags);
-
-        // 項目数に応じて変化するサイズの上限を設定
-        private static readonly PropertyInfo MaximumSizeProperty =
-            typeof(AdvancedDropdown).GetProperty("maximumSize", MemberFlags);
-
         // EditorWindow.maxSizeの既定値を設定
         private static readonly Vector2 MaximumWindowSize = new Vector2(4000f, 400f);
-
-        // 現在値の項目を開いた時点でハイライトする
-        private static readonly MethodInfo SetSelectedIndexMethod =
-            typeof(AdvancedDropdownState).GetMethod(
-                "SetSelectedIndex",
-                MemberFlags,
-                null,
-                new[] { typeof(AdvancedDropdownItem), typeof(int) },
-                null);
 
         private readonly AdvancedDropdownState _state;
         private readonly Action<string> _onSelected;
@@ -60,19 +39,7 @@ namespace ARKitBlendShapeGenerator.Presentation
             CurrentValue = currentValue;
             minimumSize = new Vector2(240f, 0f);
 
-            TrySetMaximumSize();
-        }
-
-        private void TrySetMaximumSize()
-        {
-            if (MaximumSizeProperty == null ||
-                !MaximumSizeProperty.CanWrite ||
-                MaximumSizeProperty.PropertyType != typeof(Vector2))
-            {
-                return;
-            }
-
-            MaximumSizeProperty.SetValue(this, MaximumWindowSize);
+            AdvancedDropdownReflection.TrySetMaximumSize(this, MaximumWindowSize);
         }
 
         public void Open(Rect buttonRect)
@@ -80,12 +47,20 @@ namespace ARKitBlendShapeGenerator.Presentation
             TrySelectCurrentValue();
 
             Show(buttonRect);
-            TryTakeOverSelectionHandling();
+            if (AdvancedDropdownReflection.TryOverrideSelectionHandling(
+                    this,
+                    OnWindowSelectionChanged,
+                    out var window))
+            {
+                _window = window;
+            }
         }
 
         private void TrySelectCurrentValue()
         {
-            if (SetSelectedIndexMethod == null || _state == null || string.IsNullOrEmpty(CurrentValue))
+            if (_state == null ||
+                string.IsNullOrEmpty(CurrentValue) ||
+                !AdvancedDropdownReflection.CanSetSelectedIndex)
             {
                 return;
             }
@@ -96,7 +71,7 @@ namespace ARKitBlendShapeGenerator.Presentation
             {
                 return;
             }
-            SetSelectedIndexMethod.Invoke(_state, new object[] { root, index });
+            AdvancedDropdownReflection.TrySetSelectedIndex(_state, root, index);
         }
 
         private static int IndexOfValue(AdvancedDropdownItem root, string value)
@@ -121,7 +96,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         }
 
         /// <summary>
-        /// TryTakeOverSelectionHandling失敗時のフォールバック
+        /// 内部選択処理の引き継ぎに失敗した場合のフォールバック
         /// </summary>
         protected override void ItemSelected(AdvancedDropdownItem item)
         {
@@ -141,34 +116,6 @@ namespace ARKitBlendShapeGenerator.Presentation
 
             value = null;
             return false;
-        }
-
-        private void TryTakeOverSelectionHandling()
-        {
-            if (!(WindowInstanceField?.GetValue(this) is EditorWindow window))
-            {
-                return;
-            }
-
-            var windowType = window.GetType();
-            var closeOnSelection = windowType.GetProperty("closeOnSelection", MemberFlags);
-            var selectionChanged = windowType.GetEvent("selectionChanged", MemberFlags);
-
-            // プロパティ不一致時のフォールバック
-            if (closeOnSelection == null ||
-                !closeOnSelection.CanWrite ||
-                closeOnSelection.PropertyType != typeof(bool) ||
-                selectionChanged == null ||
-                selectionChanged.EventHandlerType != typeof(Action<AdvancedDropdownItem>))
-            {
-                return;
-            }
-
-            _window = window;
-            closeOnSelection.SetValue(window, false);
-            selectionChanged.AddEventHandler(
-                window,
-                new Action<AdvancedDropdownItem>(OnWindowSelectionChanged));
         }
 
         private void OnWindowSelectionChanged(AdvancedDropdownItem item)

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Reflection;
+using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
@@ -16,7 +18,15 @@ namespace ARKitBlendShapeGenerator.Presentation
             }
         }
 
+        // 内部のcloseOnSelectionを無効化し閉じる処理を独自に行う
+        private const BindingFlags MemberFlags =
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+
+        private static readonly FieldInfo WindowInstanceField =
+            typeof(AdvancedDropdown).GetField("m_WindowInstance", MemberFlags);
+
         private readonly Action<string> _onSelected;
+        private EditorWindow _window;
 
         protected SearchableNameDropdown(AdvancedDropdownState state, Action<string> onSelected) : base(state)
         {
@@ -24,13 +34,75 @@ namespace ARKitBlendShapeGenerator.Presentation
             minimumSize = new Vector2(240f, 0f);
         }
 
+        public void Open(Rect buttonRect)
+        {
+            Show(buttonRect);
+            TryTakeOverSelectionHandling();
+        }
+
+        /// <summary>
+        /// TryTakeOverSelectionHandling失敗時のフォールバック
+        /// </summary>
         protected override void ItemSelected(AdvancedDropdownItem item)
         {
-            // 有効なアイテムのみ選択する
+            if (IsSelectable(item, out string value))
+            {
+                _onSelected?.Invoke(value);
+            }
+        }
+
+        private static bool IsSelectable(AdvancedDropdownItem item, out string value)
+        {
             if (item is ValueItem valueItem && item.enabled)
             {
-                _onSelected?.Invoke(valueItem.Value);
+                value = valueItem.Value;
+                return true;
             }
+
+            value = null;
+            return false;
+        }
+
+        private void TryTakeOverSelectionHandling()
+        {
+            if (!(WindowInstanceField?.GetValue(this) is EditorWindow window))
+            {
+                return;
+            }
+
+            var windowType = window.GetType();
+            var closeOnSelection = windowType.GetProperty("closeOnSelection", MemberFlags);
+            var selectionChanged = windowType.GetEvent("selectionChanged", MemberFlags);
+
+            // プロパティ不一致時のフォールバック
+            if (closeOnSelection == null ||
+                !closeOnSelection.CanWrite ||
+                closeOnSelection.PropertyType != typeof(bool) ||
+                selectionChanged == null ||
+                selectionChanged.EventHandlerType != typeof(Action<AdvancedDropdownItem>))
+            {
+                return;
+            }
+
+            _window = window;
+            closeOnSelection.SetValue(window, false);
+            selectionChanged.AddEventHandler(
+                window,
+                new Action<AdvancedDropdownItem>(OnWindowSelectionChanged));
+        }
+
+        private void OnWindowSelectionChanged(AdvancedDropdownItem item)
+        {
+            if (!IsSelectable(item, out string value))
+            {
+                return;
+            }
+
+            _onSelected?.Invoke(value);
+            _window?.Close();
+            _window = null;
+
+            GUIUtility.ExitGUI();
         }
     }
 }

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -25,6 +25,13 @@ namespace ARKitBlendShapeGenerator.Presentation
         private static readonly FieldInfo WindowInstanceField =
             typeof(AdvancedDropdown).GetField("m_WindowInstance", MemberFlags);
 
+        // 項目数に応じて変化するサイズの上限を設定
+        private static readonly PropertyInfo MaximumSizeProperty =
+            typeof(AdvancedDropdown).GetProperty("maximumSize", MemberFlags);
+
+        // EditorWindow.maxSizeの既定値を設定
+        private static readonly Vector2 MaximumWindowSize = new Vector2(4000f, 400f);
+
         private readonly Action<string> _onSelected;
         private EditorWindow _window;
 
@@ -32,6 +39,20 @@ namespace ARKitBlendShapeGenerator.Presentation
         {
             _onSelected = onSelected;
             minimumSize = new Vector2(240f, 0f);
+
+            TrySetMaximumSize();
+        }
+
+        private void TrySetMaximumSize()
+        {
+            if (MaximumSizeProperty == null ||
+                !MaximumSizeProperty.CanWrite ||
+                MaximumSizeProperty.PropertyType != typeof(Vector2))
+            {
+                return;
+            }
+
+            MaximumSizeProperty.SetValue(this, MaximumWindowSize);
         }
 
         public void Open(Rect buttonRect)

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -26,7 +26,8 @@ namespace ARKitBlendShapeGenerator.Presentation
 
         protected override void ItemSelected(AdvancedDropdownItem item)
         {
-            if (item is ValueItem valueItem)
+            // 有効なアイテムのみ選択する
+            if (item is ValueItem valueItem && item.enabled)
             {
                 _onSelected?.Invoke(valueItem.Value);
             }

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -32,12 +32,32 @@ namespace ARKitBlendShapeGenerator.Presentation
         // EditorWindow.maxSizeの既定値を設定
         private static readonly Vector2 MaximumWindowSize = new Vector2(4000f, 400f);
 
+        // 現在値の項目を開いた時点でハイライトする
+        private static readonly MethodInfo SetSelectedIndexMethod =
+            typeof(AdvancedDropdownState).GetMethod(
+                "SetSelectedIndex",
+                MemberFlags,
+                null,
+                new[] { typeof(AdvancedDropdownItem), typeof(int) },
+                null);
+
+        private readonly AdvancedDropdownState _state;
         private readonly Action<string> _onSelected;
         private EditorWindow _window;
 
-        protected SearchableNameDropdown(AdvancedDropdownState state, Action<string> onSelected) : base(state)
+        /// <summary>
+        /// ハイライトする項目
+        /// </summary>
+        protected string CurrentValue { get; }
+
+        protected SearchableNameDropdown(
+            AdvancedDropdownState state,
+            string currentValue,
+            Action<string> onSelected) : base(state)
         {
+            _state = state;
             _onSelected = onSelected;
+            CurrentValue = currentValue;
             minimumSize = new Vector2(240f, 0f);
 
             TrySetMaximumSize();
@@ -57,8 +77,47 @@ namespace ARKitBlendShapeGenerator.Presentation
 
         public void Open(Rect buttonRect)
         {
+            TrySelectCurrentValue();
+
             Show(buttonRect);
             TryTakeOverSelectionHandling();
+        }
+
+        private void TrySelectCurrentValue()
+        {
+            if (SetSelectedIndexMethod == null || _state == null || string.IsNullOrEmpty(CurrentValue))
+            {
+                return;
+            }
+
+            var root = BuildRoot();
+            int index = IndexOfValue(root, CurrentValue);
+            if (index < 0)
+            {
+                return;
+            }
+            SetSelectedIndexMethod.Invoke(_state, new object[] { root, index });
+        }
+
+        private static int IndexOfValue(AdvancedDropdownItem root, string value)
+        {
+            if (root == null)
+            {
+                return -1;
+            }
+
+            int index = 0;
+            foreach (var child in root.children)
+            {
+                if (child is ValueItem valueItem && valueItem.Value == value)
+                {
+                    return index;
+                }
+
+                index++;
+            }
+
+            return -1;
         }
 
         /// <summary>

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -1,0 +1,35 @@
+using System;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+
+namespace ARKitBlendShapeGenerator.Presentation
+{
+    internal abstract class SearchableNameDropdown : AdvancedDropdown
+    {
+        protected sealed class ValueItem : AdvancedDropdownItem
+        {
+            public readonly string Value;
+
+            public ValueItem(string label, string value) : base(label)
+            {
+                Value = value;
+            }
+        }
+
+        private readonly Action<string> _onSelected;
+
+        protected SearchableNameDropdown(AdvancedDropdownState state, Action<string> onSelected) : base(state)
+        {
+            _onSelected = onSelected;
+            minimumSize = new Vector2(240f, 0f);
+        }
+
+        protected override void ItemSelected(AdvancedDropdownItem item)
+        {
+            if (item is ValueItem valueItem)
+            {
+                _onSelected?.Invoke(valueItem.Value);
+            }
+        }
+    }
+}

--- a/Editor/Presentation/SearchableNameDropdown.cs
+++ b/Editor/Presentation/SearchableNameDropdown.cs
@@ -109,7 +109,7 @@ namespace ARKitBlendShapeGenerator.Presentation
             int index = 0;
             foreach (var child in root.children)
             {
-                if (child is ValueItem valueItem && valueItem.Value == value)
+                if (child is ValueItem valueItem && child.enabled && valueItem.Value == value)
                 {
                     return index;
                 }

--- a/Tests/Editor/BlendShapeSearchDropdownTests.cs
+++ b/Tests/Editor/BlendShapeSearchDropdownTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Presentation;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    public class BlendShapeSearchDropdownTests
+    {
+        private static readonly List<string> Available = new List<string> { "vrc.v_aa", "まばたき" };
+
+        [Test]
+        public void ResolveState_ReturnsEmpty_WhenValueIsNotSet()
+        {
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState(null, Available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Empty));
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState("", Available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Empty));
+        }
+
+        [Test]
+        public void ResolveState_ReturnsFound_WhenValueExistsInMesh()
+        {
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState("まばたき", Available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Found));
+        }
+
+        [Test]
+        public void ResolveState_ReturnsMissing_WhenValueIsNotInMesh()
+        {
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState("vrc.v_zz", Available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Missing));
+        }
+
+        [Test]
+        public void ResolveState_ReturnsMissing_WhenAvailableListIsNull()
+        {
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState("まばたき", null),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Missing));
+        }
+    }
+}

--- a/Tests/Editor/SearchableNameDropdownTests.cs
+++ b/Tests/Editor/SearchableNameDropdownTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Presentation;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    public class SearchableNameDropdownTests
+    {
+        [Test]
+        public void ReflectionContract_ResolvesSupportedMembers()
+        {
+            Assert.That(
+                AdvancedDropdownReflection.CanSetMaximumSize,
+                Is.True,
+                "maximumSize was not found in Unity {0}",
+                Application.unityVersion);
+            Assert.That(
+                AdvancedDropdownReflection.CanSetSelectedIndex,
+                Is.True,
+                "SetSelectedIndex was not found in Unity {0}",
+                Application.unityVersion);
+            Assert.That(
+                AdvancedDropdownReflection.CanOverrideSelectionHandling,
+                Is.True,
+                "AdvancedDropdownWindow selection members were not found in Unity {0}",
+                Application.unityVersion);
+        }
+
+        [Test]
+        public void ReflectionCalls_SucceedForSupportedMembers()
+        {
+            var state = new AdvancedDropdownState();
+            var dropdown = new TestDropdown(state);
+            var root = dropdown.CreateRoot();
+
+            Assert.That(
+                AdvancedDropdownReflection.TrySetMaximumSize(dropdown, new Vector2(4000f, 400f)),
+                Is.True,
+                "maximumSize could not be set in Unity {0}",
+                Application.unityVersion);
+            Assert.That(
+                AdvancedDropdownReflection.TrySetSelectedIndex(state, root, 0),
+                Is.True,
+                "SetSelectedIndex could not be invoked in Unity {0}",
+                Application.unityVersion);
+        }
+
+        [Test]
+        public void ReflectionCalls_OverrideSelectionHandlingForWindowInstance()
+        {
+            const BindingFlags memberFlags =
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public;
+            var windowField = typeof(AdvancedDropdown).GetField("m_WindowInstance", memberFlags);
+            Assert.That(windowField, Is.Not.Null);
+            var windowType = windowField.FieldType;
+            var closeOnSelection = windowType.GetProperty("closeOnSelection", memberFlags);
+            Assert.That(closeOnSelection, Is.Not.Null);
+
+            // 本番と同じくイベントとして解決する
+            var selectionChanged = windowType.GetEvent("selectionChanged", memberFlags);
+            Assert.That(selectionChanged, Is.Not.Null);
+            Assert.That(
+                selectionChanged.EventHandlerType,
+                Is.EqualTo(typeof(Action<AdvancedDropdownItem>)));
+
+            var dropdown = new TestDropdown(new AdvancedDropdownState());
+            var window = ScriptableObject.CreateInstance(windowType) as EditorWindow;
+            Assert.That(window, Is.Not.Null);
+
+            try
+            {
+                windowField.SetValue(dropdown, window);
+                int selectionCount = 0;
+                Assert.That(
+                    AdvancedDropdownReflection.TryOverrideSelectionHandling(
+                        dropdown,
+                        _ => selectionCount++,
+                        out var configuredWindow),
+                    Is.True,
+                    "Selection handling could not be overridden in Unity {0}",
+                    Application.unityVersion);
+                Assert.That(configuredWindow, Is.SameAs(window));
+                Assert.That(closeOnSelection.GetValue(window), Is.False);
+
+                var handlerField = windowType.GetField(selectionChanged.Name, memberFlags);
+                if (handlerField == null ||
+                    handlerField.FieldType != selectionChanged.EventHandlerType)
+                {
+                    Assert.Ignore(
+                        $"selectionChanged is not a field-like event in Unity {Application.unityVersion};" +
+                        " handler invocation was not verified");
+                }
+                else
+                {
+                    var selectionHandler =
+                        handlerField.GetValue(window) as Action<AdvancedDropdownItem>;
+                    Assert.That(selectionHandler, Is.Not.Null);
+                    selectionHandler(new AdvancedDropdownItem("Selected"));
+                    Assert.That(selectionCount, Is.EqualTo(1));
+                }
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(window);
+            }
+        }
+
+        private sealed class TestDropdown : SearchableNameDropdown
+        {
+            public TestDropdown(AdvancedDropdownState state)
+                : base(state, "value", _ => { })
+            {
+            }
+
+            public AdvancedDropdownItem CreateRoot()
+            {
+                return BuildRoot();
+            }
+
+            protected override AdvancedDropdownItem BuildRoot()
+            {
+                var root = new AdvancedDropdownItem("Test");
+                root.AddChild(new ValueItem("Value", "value") { id = 0 });
+                return root;
+            }
+        }
+    }
+}


### PR DESCRIPTION
ARKit名とソースBlendShapeの選択を検索可能なAdvancedDropdownに置き換えます。 #44
ARKit名は同一名を複数のマッピングに設定できないため、選択済みのものはグレーアウト(in use)しています。グレーアウトではなく非表示でもいいかもしれません。

<img width="454" height="958" alt="screenrecording-2026-08-12_00-20-45-snap" src="https://github.com/user-attachments/assets/204c6823-73e3-490b-84d9-e964b25271c9" />

コンポーネントのサイズ上限の設定や再選択時の挙動について調査中のためDraftとします。

---
TODO:
- [x] コンポーネントの最大サイズを設定する
  - アイテムの最大サイズが設定できておらずアイテムの数だけ大きくなっている
- [x] 再選択時の挙動を改善する
  - 値を選択済みの状態でドロップダウンが現在値を選択状態で開けない