### PR TITLE
fix: シェイプキー名の先頭・末尾スペースで挙動が食い違う問題を修正

### DIFF
--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -37,6 +37,11 @@ namespace ARKitBlendShapeGenerator.Domain
             };
         }
 
+        /// <summary>
+        /// 打ち消し対象のARKit名の集合を作る。
+        /// 名前は加工せず、AppliesToでの照合も完全一致で行う（ここでTrimすると
+        /// インスペクタの選択状態と実際の打ち消し対象が食い違う）。空白のみは未設定として無視する。
+        /// </summary>
         private static HashSet<string> BuildTargetSet(List<string> targets)
         {
             var result = new HashSet<string>();
@@ -49,7 +54,7 @@ namespace ARKitBlendShapeGenerator.Domain
             {
                 if (!string.IsNullOrWhiteSpace(target))
                 {
-                    result.Add(target.Trim());
+                    result.Add(target);
                 }
             }
 
@@ -587,7 +592,9 @@ namespace ARKitBlendShapeGenerator.Domain
         {
             foreach (var mapping in customMappings)
             {
-                if (mapping == null || !mapping.enabled || string.IsNullOrEmpty(mapping.arkitName))
+                // 生成する名前として使うため、空白のみは未設定として扱う
+                // （重複判定側も空白のみを無視するので、判定を素通りして生成されるのを防ぐ）
+                if (mapping == null || !mapping.enabled || string.IsNullOrWhiteSpace(mapping.arkitName))
                 {
                     continue;
                 }

--- a/Editor/Domain/CustomMappingValidation.cs
+++ b/Editor/Domain/CustomMappingValidation.cs
@@ -14,6 +14,10 @@ namespace ARKitBlendShapeGenerator.Domain
         /// <summary>
         /// ARKit名の列挙から重複を抽出する。
         /// SerializedProperty等、コンポーネントの実体を経由せずに検証する場合に使用する。
+        ///
+        /// 名前は一切加工せず完全一致で比較する。生成側も同じ規則で名前を扱うため、
+        /// ここだけTrimすると「重複扱いなのに別々に生成される」といった食い違いが生じる。
+        /// 空白のみは未設定として無視する。
         /// </summary>
         public static List<string> GetDuplicateArkitNames(IEnumerable<string> arkitNames)
         {
@@ -25,14 +29,13 @@ namespace ARKitBlendShapeGenerator.Domain
                 return new List<string>();
             }
 
-            foreach (var name in arkitNames)
+            foreach (var arkitName in arkitNames)
             {
-                if (string.IsNullOrWhiteSpace(name))
+                if (string.IsNullOrWhiteSpace(arkitName))
                 {
                     continue;
                 }
 
-                var arkitName = name.Trim();
                 if (!seen.Add(arkitName))
                 {
                     duplicates.Add(arkitName);
@@ -59,7 +62,6 @@ namespace ARKitBlendShapeGenerator.Domain
 
             var names = duplicateArkitNames
                 .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name.Trim())
                 .Distinct()
                 .OrderBy(name => name)
                 .ToList();

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -1194,7 +1194,10 @@ namespace ARKitBlendShapeGenerator.Presentation
 
             foreach (var mapping in customMappings)
             {
-                if (mapping == null || !mapping.enabled || string.IsNullOrEmpty(mapping.arkitName))
+                // 生成側（CollectCustomMappings）と同じ空判定にする。
+                // ここだけIsNullOrEmptyだと、生成されない空白のみの名前が
+                // 空欄のスライダーとしてプレビューに並んでしまう
+                if (mapping == null || !mapping.enabled || string.IsNullOrWhiteSpace(mapping.arkitName))
                 {
                     continue;
                 }

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -439,7 +439,8 @@ namespace ARKitBlendShapeGenerator.Presentation
         }
 
         /// <summary>
-        /// カスタムマッピングに設定済みのARKit名を列挙する（空白のみの要素は除外）
+        /// カスタムマッピングに設定済みのARKit名を列挙する（空白のみの要素は除外）。
+        /// 名前は加工しない。生成側と同じ規則で扱わないと、重複判定や使用済み判定が実挙動とずれる
         /// </summary>
         private static IEnumerable<string> EnumerateArkitNames(SerializedProperty customMappingsProperty)
         {
@@ -449,7 +450,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                     .FindPropertyRelative("arkitName").stringValue;
                 if (!string.IsNullOrWhiteSpace(arkitName))
                 {
-                    yield return arkitName.Trim();
+                    yield return arkitName;
                 }
             }
         }
@@ -470,7 +471,7 @@ namespace ARKitBlendShapeGenerator.Presentation
                     .FindPropertyRelative("arkitName").stringValue;
                 if (!string.IsNullOrWhiteSpace(arkitName))
                 {
-                    usedByOthers.Add(arkitName.Trim());
+                    usedByOthers.Add(arkitName);
                 }
             }
 

--- a/Editor/Presentation/ArkitNameSearchDropdown.cs
+++ b/Editor/Presentation/ArkitNameSearchDropdown.cs
@@ -28,7 +28,8 @@ namespace ARKitBlendShapeGenerator.Presentation
 
         internal static string BuildButtonLabel(string current)
         {
-            return string.IsNullOrWhiteSpace(current) ? S("arkit_name.placeholder") : current.Trim();
+            // 設定値は加工せずそのまま見せる（Trimして表示すると、実際に生成される名前と食い違う）
+            return string.IsNullOrWhiteSpace(current) ? S("arkit_name.placeholder") : current;
         }
 
         protected override AdvancedDropdownItem BuildRoot()

--- a/Tests/Editor/BlendShapeSearchDropdownTests.cs
+++ b/Tests/Editor/BlendShapeSearchDropdownTests.cs
@@ -42,5 +42,35 @@ namespace ARKitBlendShapeGenerator.Tests
                 BlendShapeSearchDropdown.ResolveState("まばたき", null),
                 Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Missing));
         }
+
+        [Test]
+        public void ResolveState_ReturnsMissing_WhenValueHasSurroundingWhitespace()
+        {
+            // 生成側と同じく完全一致で照合するため未検出になる。
+            // 表示と実挙動が一致することが重要で、ここで救済すると設定値の誤りが隠れる
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState(" まばたき ", Available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Missing));
+        }
+
+        [Test]
+        public void ResolveState_ReturnsFound_WhenMeshNameItselfHasSurroundingWhitespace()
+        {
+            // メッシュ側に空白付きの名前が実在すれば、そのまま指定できる
+            var available = new List<string> { " まばたき " };
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState(" まばたき ", available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Found));
+        }
+
+        [Test]
+        public void ResolveState_KeepsInternalSpaces()
+        {
+            // メッシュ由来の名前は加工しないため、名前中間のスペースはそのまま一致する
+            var available = new List<string> { "mouth smile" };
+            Assert.That(
+                BlendShapeSearchDropdown.ResolveState("mouth smile", available),
+                Is.EqualTo(BlendShapeSearchDropdown.SourceValueState.Found));
+        }
     }
 }

--- a/Tests/Editor/CustomMappingValidationTests.cs
+++ b/Tests/Editor/CustomMappingValidationTests.cs
@@ -24,18 +24,32 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
-        public void GetDuplicateArkitNames_DetectsDuplicates_IgnoringSurroundingWhitespace()
+        public void GetDuplicateArkitNames_DetectsDuplicates_ByExactName()
         {
             var mappings = new List<CustomBlendShapeMapping>
             {
                 Mapping("eyeBlinkLeft"),
-                Mapping(" eyeBlinkLeft "),
+                Mapping("eyeBlinkLeft"),
                 Mapping("jawOpen"),
             };
 
             Assert.That(
                 CustomMappingValidation.GetDuplicateArkitNames(mappings),
                 Is.EqualTo(new[] { "eyeBlinkLeft" }));
+        }
+
+        [Test]
+        public void GetDuplicateArkitNames_TreatsSurroundingWhitespaceAsDifferentName()
+        {
+            // 名前は加工せず完全一致で比較する。生成側も同じ規則なので、
+            // " eyeBlinkLeft " は別名として別のシェイプを作る（重複ではない）
+            var mappings = new List<CustomBlendShapeMapping>
+            {
+                Mapping("eyeBlinkLeft"),
+                Mapping(" eyeBlinkLeft "),
+            };
+
+            Assert.That(CustomMappingValidation.GetDuplicateArkitNames(mappings), Is.Empty);
         }
 
         [Test]

--- a/Tests/Editor/ShapeKeyNameMatchingTests.cs
+++ b/Tests/Editor/ShapeKeyNameMatchingTests.cs
@@ -1,0 +1,229 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// シェイプキー名の照合規則を固定化する。
+    ///
+    /// 仕様: 名前は一切加工せず完全一致で照合する。空白のみの設定値は未設定として扱う。
+    /// メッシュ由来の名前はMMDワールドやアニメーションカーブから参照される識別子であり、
+    /// ツールが書き換えてよいものではない。設定値を正規化して救済すると、壊れた設定値が
+    /// 気づかれないまま保存され続けるため、不一致は「未検出」として可視化する。
+    /// </summary>
+    public class ShapeKeyNameMatchingTests
+    {
+        private static Vector3[] TwoVertices() => new[]
+        {
+            new Vector3(-1f, 0f, 0f),
+            new Vector3(1f, 0f, 0f),
+        };
+
+        private static BlendShapeGenerationOptions CreateOptions()
+        {
+            return new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = 1.0f,
+                EnableLeftRightSplit = false,
+                BlendWidth = 0.02f,
+                OverwriteExisting = false,
+            };
+        }
+
+        private static CustomBlendShapeMapping CustomMapping(string arkitName, string sourceName)
+        {
+            return new CustomBlendShapeMapping
+            {
+                arkitName = arkitName,
+                enabled = true,
+                sources = new List<BlendShapeSource>
+                {
+                    new BlendShapeSource { blendShapeName = sourceName, weight = 1.0f, side = BlendShapeSide.Both },
+                },
+            };
+        }
+
+        [Test]
+        public void Generate_DoesNotResolveSourceName_WithSurroundingSpace()
+        {
+            // 設定値を正規化しないため、" あ " はメッシュの "あ" に一致しない。
+            // インスペクタも同じ規則で「(未検出)」と表示するため、表示と挙動は一致する
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", " あ "),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.Shapes, Is.Empty);
+        }
+
+        [Test]
+        public void Generate_ResolvesMeshShape_WhoseNameItselfHasSurroundingSpace()
+        {
+            // メッシュ側に前後の空白を含む名前が実在すれば、それを指定して生成できる。
+            // メッシュ由来の名前は常に指定可能でなければならない
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape(" あ ", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", " あ "),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "jawOpen" }));
+            Assert.That(target.FindShape("jawOpen").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+        }
+
+        [Test]
+        public void Generate_DistinguishesNames_ThatDifferOnlyBySurroundingSpace()
+        {
+            // 空白の有無で別のシェイプとして扱われる（片方に寄せない）
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape(" あ ", Vector3.up, Vector3.up)
+                .AddShape("あ", Vector3.forward, Vector3.forward);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", "あ"),
+            };
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(target.FindShape("jawOpen").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+        }
+
+        [Test]
+        public void Generate_KeepsInternalSpaces_InMeshSourceName()
+        {
+            // 名前中間のスペースを含む正当なシェイプキー名はそのまま一致する
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("mouth smile", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("mouthSmileLeft", "mouth smile"),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "mouthSmileLeft" }));
+            Assert.That(target.FindShape("mouthSmileLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+        }
+
+        [Test]
+        public void Generate_TreatsArkitNamesDifferingBySpace_AsSeparateShapes()
+        {
+            // 重複判定と生成が同じ規則で動くため、重複中止にはならず別名で2つ生成される
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShape("い", Vector3.forward, Vector3.forward);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", "あ"),
+                CustomMapping("jawOpen ", "い"),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "jawOpen", "jawOpen " }));
+            Assert.That(target.FindShape("jawOpen").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            Assert.That(target.FindShape("jawOpen ").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+        }
+
+        [Test]
+        public void Generate_IgnoresWhitespaceOnlyArkitName()
+        {
+            // 空白のみは未設定として扱い、そんな名前のシェイプを作らない
+            // （重複判定側も空白のみを無視するため、ここで作ると判定を素通りしてしまう）
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("   ", "あ"),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.Shapes, Is.Empty);
+        }
+
+        [Test]
+        public void Generate_AppliesCancellation_OnlyToExactlyMatchingTargetName()
+        {
+            // 打ち消し対象も完全一致。インスペクタのトグルと同じ規則なので、
+            // 「チェックが入っていないのに打ち消しが掛かる」状態にならない
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShape("口開き", new Vector3(0f, 0.25f, 0f), new Vector3(0f, 0.25f, 0f));
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", "あ"),
+            };
+            var options = CreateOptions();
+            options.EnableMouthCancellation = true;
+            options.MouthCancellationStrength = 1.0f;
+            options.MouthCancellationSources = new List<BlendShapeSource>
+            {
+                new BlendShapeSource { blendShapeName = "口開き", weight = 1.0f, side = BlendShapeSide.Both },
+            };
+            // 空白付きの対象名は生成される "jawOpen" と一致しない
+            options.MouthCancellationTargets = new HashSet<string> { " jawOpen " };
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, options, null);
+
+            // 打ち消しは掛からず、生成デルタのみ
+            Assert.That(
+                target.FindShape("jawOpen").Frames[0].DeltaVertices[0].y,
+                Is.EqualTo(1.0f).Within(0.0001f));
+        }
+
+        [Test]
+        public void Generate_AppliesCancellation_WhenTargetNameMatchesExactly()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShape("口開き", new Vector3(0f, 0.25f, 0f), new Vector3(0f, 0.25f, 0f));
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", "あ"),
+            };
+            var options = CreateOptions();
+            options.EnableMouthCancellation = true;
+            options.MouthCancellationStrength = 1.0f;
+            options.MouthCancellationSources = new List<BlendShapeSource>
+            {
+                new BlendShapeSource { blendShapeName = "口開き", weight = 1.0f, side = BlendShapeSide.Both },
+            };
+            options.MouthCancellationTargets = new HashSet<string> { "jawOpen" };
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, options, null);
+
+            // 生成デルタ(+1.0) + 打ち消し(-0.25) = +0.75
+            Assert.That(
+                target.FindShape("jawOpen").Frames[0].DeltaVertices[0].y,
+                Is.EqualTo(0.75f).Within(0.0001f));
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Closes #37

設定値の名前を「Trimして比較する箇所」と「未加工のまま使う箇所」が混在していたため、先頭・末尾に半角スペースを含む名前で判定と実挙動が食い違っていた問題を修正する。

## 方針

**名前は一切加工せず完全一致で照合する。空白のみの設定値は未設定として扱う。**

規則が1つしかないので、食い違いようがありません。

### 根拠

改変ツール一般の慣行を調べたところ、空白の扱いを明文化しているツールは見つからず、**単に完全一致で、外れたら黙って合わせにいかず不一致を可視化する**という設計に揃っていました。

- Unity の `Mesh.GetBlendShapeIndex` は完全一致で、外れれば `-1` を返すだけ。Unity 自身も取り込んだ名前を整形しない（Maya 由来の `Blade_Longer.Dagger_Low` のような名前もそのまま入る）
- VRCFury の Blendshape Link も完全一致で、名前が違う場合は利用者が Advanced Options で明示的に対応表を書く
- MMD ダンスワールドはシェイプキー名の完全一致を前提に参照する。Unity のアニメーションカーブも `blendShape.<名前>` で名前に依存する。つまりメッシュ側の名前は**外部から参照される公開契約**であり、ツールが書き換えてよいものではない

加えて、**設定値を正規化して救済すると問題が隠れます**。`" あ "` のまま生成が成功すると利用者は設定が壊れていることに気づけず、壊れたデータが保存され続けます。正規化しなければ「(未検出)」と表示され、その場で直せます。

混入経路が限定的である点も後押しになります。UI はドロップダウンから正規名かメッシュ名しか書き込まないため、空白付きの設定値が生まれるのはフリーテキスト入力での打ち間違いか YAML の直接編集だけです。前者はまさに気づいて直すべき打ち間違いです。

## 変更内容

`main` は既にほとんどの箇所が完全一致でした。食い違いは数箇所の `Trim()` が原因だったため、それらを取り除きます。

- `CustomMappingValidation`: 重複判定とメッセージ生成の `Trim()` を廃止
- `BlendShapeGenerationEngine.BuildTargetSet`: 打ち消し対象名の `Trim()` を廃止。`AppliesTo` は元から完全一致のため、これで両者の規則が揃う
- `CollectCustomMappings`: `arkitName` の空判定を `IsNullOrWhiteSpace` に変更。重複判定は空白のみを無視するため、従来は判定を素通りして `"   "` という名前のシェイプが作られうる状態だった
- `EnumerateArkitNames` / `GetArkitNamesUsedByOtherMappings`: `Trim()` を廃止
- `ArkitNameSearchDropdown.BuildButtonLabel`: 表示時の `Trim()` を廃止（実際に生成される名前と食い違わせない）

検索フィルタの `Trim()` は名前照合ではなく UI の絞り込み用なので残しています。

## 挙動の変更

**`" eyeBlinkLeft "` と `"eyeBlinkLeft"` は重複ではなく別名として扱われます。**

生成側の扱いに合わせたものです。従来は「重複扱いで生成が中止される」のに、中止されなければ別々のシェイプとして生成される、という食い違いがありました。今後は別名として2つ生成されます。片方は ARKit から認識されない無意味なシェイプですが、インスペクタ上でも別項目として見えるため利用者が気づけます。

## テスト

`ShapeKeyNameMatchingTests` を追加し、次を固定化しました。

- 空白付きの設定値はメッシュの名前に一致せず生成されない
- **メッシュ側に空白付きの名前が実在すれば指定して生成できる**（メッシュ由来の名前は常に指定可能であるべき）
- 空白の有無で別のシェイプとして区別される
- 名前中間のスペース（`mouth smile`）はそのまま一致する
- 空白のみの `arkitName` は未設定として無視される
- 打ち消し対象も完全一致でのみ適用される

`CustomMappingValidationTests` の重複判定テストは、上記の挙動変更に合わせて書き換えました。`BlendShapeSearchDropdownTests` には、表示側の判定が同じ規則に従うことを追加しています。

## 完了条件の確認

- [x] 末尾/先頭スペース入りの設定値でも、重複判定・生成・打ち消し・プレビューの挙動が一貫する
- [x] 名前中間にスペースを含む正当なシェイプキー名が引き続き動作する（テストで担保）

## 経緯

当初は「設定値を正規化して救済する」方針で実装し、その後 #45（検索可能ドロップダウン）のマージに伴うリベースや、完全一致を優先する二段構えへの変更を経ています。最終的に、調査で判明した慣行と整合し規則が1つで済む本方針に切り替え、`main` から作り直しました。そのため過去のレビュースレッドが参照しているコミットIDは現在のブランチには存在しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVT6dsweC6qwAHiWtZk8zv