### PR TITLE
fix: 名前が空のシェイプキーが上書き生成で消える問題を修正

### DIFF
--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -919,6 +919,10 @@ namespace ARKitBlendShapeGenerator.Domain
                 // 空名シェイプは生成・照合の対象外だが、メッシュのデータとしては保持する。
                 // 削除対象は必ず非空のARKit名のため、空名が削除に該当することはない。
                 // （ここでpreservedに積まないと、ClearBlendShapes後の再構築で黙って消える）
+                //
+                // 既知の制限: AddBlendShapeFrameは名前をキーにするため、同名シェイプを個別には
+                // 復元できない。削除によって同名（空名を含む）シェイプが隣接すると、それらは
+                // 1つのシェイプへ統合されデルタは各フレームとして残るが個数は減る。
                 if (!string.IsNullOrEmpty(existingName) && shapeNamesToRemove.Contains(existingName))
                 {
                     removedCount++;

--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -227,7 +227,20 @@ namespace ARKitBlendShapeGenerator.Domain
 
                 if (namesToReplace.Count > 0)
                 {
-                    int removedCount = RemoveBlendShapesByNames(targetMesh, namesToReplace);
+                    if (!TryRemoveBlendShapesByNames(
+                            targetMesh,
+                            namesToReplace,
+                            out int removedCount,
+                            out var mergedShapeName))
+                    {
+                        // 上書きするとメッシュ側の同名シェイプが統合されてデータを失うため、
+                        // メッシュを変更しないまま生成全体を中止する
+                        logger?.Error(S("log.overwrite_merge_abort", mergedShapeName));
+                        return new BlendShapeGenerationResult(
+                            new List<string>(),
+                            BuildShapeIndices(targetMesh));
+                    }
+
                     if (removedCount > 0)
                     {
                         Log(logger, options, $"Replaced existing blendshapes: {string.Join(", ", namesToReplace.OrderBy(name => name))}");
@@ -265,9 +278,16 @@ namespace ARKitBlendShapeGenerator.Domain
                     logger);
             }
 
-            // 生成・削除後の最終状態からインデックスを再構築する
-            // 空名シェイプは名前で引けないためエントリを持たないが、iは実メッシュ上の位置のままなので
-            // 非空シェイプのインデックスは常に実体と一致する
+            return new BlendShapeGenerationResult(generatedShapes, BuildShapeIndices(targetMesh));
+        }
+
+        /// <summary>
+        /// 生成・削除後の最終状態からインデックス表を作る。
+        /// 空名シェイプは名前で引けないためエントリを持たないが、iは実メッシュ上の位置のままなので
+        /// 非空シェイプのインデックスは常に実体と一致する
+        /// </summary>
+        private static Dictionary<string, int> BuildShapeIndices(IMeshRepository targetMesh)
+        {
             var shapeIndices = new Dictionary<string, int>();
             for (int i = 0; i < targetMesh.BlendShapeCount; i++)
             {
@@ -278,7 +298,7 @@ namespace ARKitBlendShapeGenerator.Domain
                 }
             }
 
-            return new BlendShapeGenerationResult(generatedShapes, shapeIndices);
+            return shapeIndices;
         }
 
         /// <summary>
@@ -568,7 +588,17 @@ namespace ARKitBlendShapeGenerator.Domain
 
             if (namesToReplace.Count > 0)
             {
-                int removedCount = RemoveBlendShapesByNames(targetMesh, namesToReplace);
+                if (!TryRemoveBlendShapesByNames(
+                        targetMesh,
+                        namesToReplace,
+                        out int removedCount,
+                        out var mergedShapeName))
+                {
+                    // 手続き的生成は補助機能のため、メッシュを守って生成を見送る
+                    Log(logger, options, $"Skip procedural (replacement would merge duplicate shape: {mergedShapeName})");
+                    return;
+                }
+
                 if (removedCount > 0)
                 {
                     Log(logger, options, $"Replaced existing blendshapes (procedural): {string.Join(", ", namesToReplace.OrderBy(name => name))}");
@@ -895,21 +925,35 @@ namespace ARKitBlendShapeGenerator.Domain
             return result;
         }
 
-        private static int RemoveBlendShapesByNames(IMeshRepository mesh, HashSet<string> shapeNamesToRemove)
+        /// <summary>
+        /// 指定した名前のBlendShapeを取り除く（ClearBlendShapes後に残りを再構築する）。
+        ///
+        /// 再構築すると同名シェイプが統合されてデータを失う配置の場合はメッシュを一切変更せず、
+        /// falseを返して呼び出し元に中止させる。AddBlendShapeFrameは名前をキーにするうえ、
+        /// 同名シェイプのフレームウェイトは昇順でなければならないため、同名シェイプが隣接すると
+        /// 後続の同一ウェイトのフレームが追加されずデルタが失われる。
+        /// </summary>
+        private static bool TryRemoveBlendShapesByNames(
+            IMeshRepository mesh,
+            HashSet<string> shapeNamesToRemove,
+            out int removedCount,
+            out string mergedShapeName)
         {
+            removedCount = 0;
+            mergedShapeName = null;
+
             if (mesh == null || shapeNamesToRemove == null || shapeNamesToRemove.Count == 0)
             {
-                return 0;
+                return true;
             }
 
             int blendShapeCount = mesh.BlendShapeCount;
             if (blendShapeCount == 0)
             {
-                return 0;
+                return true;
             }
 
             int vertexCount = mesh.VertexCount;
-            int removedCount = 0;
             var preserved = new List<BlendShapeData>(blendShapeCount);
 
             for (int shapeIndex = 0; shapeIndex < blendShapeCount; shapeIndex++)
@@ -919,10 +963,6 @@ namespace ARKitBlendShapeGenerator.Domain
                 // 空名シェイプは生成・照合の対象外だが、メッシュのデータとしては保持する。
                 // 削除対象は必ず非空のARKit名のため、空名が削除に該当することはない。
                 // （ここでpreservedに積まないと、ClearBlendShapes後の再構築で黙って消える）
-                //
-                // 既知の制限: AddBlendShapeFrameは名前をキーにするため、同名シェイプを個別には
-                // 復元できない。削除によって同名（空名を含む）シェイプが隣接すると、それらは
-                // 1つのシェイプへ統合されデルタは各フレームとして残るが個数は減る。
                 if (!string.IsNullOrEmpty(existingName) && shapeNamesToRemove.Contains(existingName))
                 {
                     removedCount++;
@@ -957,7 +997,15 @@ namespace ARKitBlendShapeGenerator.Domain
 
             if (removedCount == 0)
             {
-                return 0;
+                return true;
+            }
+
+            // 再構築で同名シェイプが隣り合うとデータを失うため、メッシュへ触れる前に検出して中止する
+            mergedShapeName = FindAdjacentDuplicateName(preserved);
+            if (mergedShapeName != null)
+            {
+                removedCount = 0;
+                return false;
             }
 
             mesh.ClearBlendShapes();
@@ -974,7 +1022,24 @@ namespace ARKitBlendShapeGenerator.Domain
                 }
             }
 
-            return removedCount;
+            return true;
+        }
+
+        /// <summary>
+        /// 再構築したときに統合されてしまう同名シェイプ（隣り合う同名の並び）を探す。
+        /// 見つからなければnull。空名も統合の対象になるため同様に扱う
+        /// </summary>
+        private static string FindAdjacentDuplicateName(List<BlendShapeData> preserved)
+        {
+            for (int i = 1; i < preserved.Count; i++)
+            {
+                if (string.Equals(preserved[i - 1].Name, preserved[i].Name))
+                {
+                    return preserved[i].Name;
+                }
+            }
+
+            return null;
         }
 
         private static void Log(IGenerationLogger logger, BlendShapeGenerationOptions options, string message)

--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -186,10 +186,15 @@ namespace ARKitBlendShapeGenerator.Domain
                     new Dictionary<string, int>());
             }
 
+            // 空名シェイプは生成対象にも照合キーにもしない（キー""での偶発的な一致を避ける）
             var existingShapes = new Dictionary<string, int>();
             for (int i = 0; i < sourceMesh.BlendShapeCount; i++)
             {
-                existingShapes[sourceMesh.GetBlendShapeName(i)] = i;
+                var existingName = sourceMesh.GetBlendShapeName(i);
+                if (!string.IsNullOrEmpty(existingName))
+                {
+                    existingShapes[existingName] = i;
+                }
             }
 
             var generatedShapes = new List<string>();
@@ -261,6 +266,8 @@ namespace ARKitBlendShapeGenerator.Domain
             }
 
             // 生成・削除後の最終状態からインデックスを再構築する
+            // 空名シェイプは名前で引けないためエントリを持たないが、iは実メッシュ上の位置のままなので
+            // 非空シェイプのインデックスは常に実体と一致する
             var shapeIndices = new Dictionary<string, int>();
             for (int i = 0; i < targetMesh.BlendShapeCount; i++)
             {
@@ -864,6 +871,10 @@ namespace ARKitBlendShapeGenerator.Domain
             return 1.0f;
         }
 
+        /// <summary>
+        /// メッシュ上の既存BlendShape名を集める。
+        /// 空名シェイプは生成・置き換えの対象にならないため含めない（保持自体は削除処理側で担保する）。
+        /// </summary>
         private static HashSet<string> GetExistingBlendShapeNames(IMeshRepository mesh)
         {
             var result = new HashSet<string>();
@@ -904,12 +915,11 @@ namespace ARKitBlendShapeGenerator.Domain
             for (int shapeIndex = 0; shapeIndex < blendShapeCount; shapeIndex++)
             {
                 string existingName = mesh.GetBlendShapeName(shapeIndex);
-                if (string.IsNullOrEmpty(existingName))
-                {
-                    continue;
-                }
 
-                if (shapeNamesToRemove.Contains(existingName))
+                // 空名シェイプは生成・照合の対象外だが、メッシュのデータとしては保持する。
+                // 削除対象は必ず非空のARKit名のため、空名が削除に該当することはない。
+                // （ここでpreservedに積まないと、ClearBlendShapes後の再構築で黙って消える）
+                if (!string.IsNullOrEmpty(existingName) && shapeNamesToRemove.Contains(existingName))
                 {
                     removedCount++;
                     continue;

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -367,6 +367,9 @@ msgstr "Generation was aborted because the same ARKit name is duplicated in the 
 msgid "log.duplicate_preview_stop"
 msgstr "The same ARKit name is duplicated in the custom mappings. Preview is suspended until the duplicates are resolved.\nDuplicates: {0}"
 
+msgid "log.overwrite_merge_abort"
+msgstr "Generation was aborted because the mesh has multiple blend shapes with the same name, and \"Overwrite existing\" would merge them into one and lose data.\nAffected: \"{0}\"\nMake the blend shape names unique, or turn off \"Overwrite existing\"."
+
 msgid "log.renderer_not_found"
 msgstr "SkinnedMeshRenderer not found."
 

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -367,6 +367,9 @@ msgstr "カスタムマッピングで同一ARKit名が重複しているため�
 msgid "log.duplicate_preview_stop"
 msgstr "カスタムマッピングで同一ARKit名が重複しています。重複を解消するまでプレビューを停止します。\n重複: {0}"
 
+msgid "log.overwrite_merge_abort"
+msgstr "メッシュに同名のシェイプキーが複数あり、「既存を上書き」を行うとそれらが1つに統合されてデータが失われるため、生成を中止しました。\n該当: \"{0}\"\nシェイプキー名を一意にするか、「既存を上書き」をオフにしてください。"
+
 msgid "log.renderer_not_found"
 msgstr "SkinnedMeshRendererが見つかりません。"
 

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -1217,10 +1217,16 @@ namespace ARKitBlendShapeGenerator.Presentation
                 return categories;
             }
 
+            // 空名シェイプは名前で指定できずウェイト操作も効かないため、プレビュー対象から除外する
+            // （メッシュ上のデータとしてはそのまま保持される）
             var sourceShapeNames = new HashSet<string>();
             for (int i = 0; i < targetRenderer.sharedMesh.blendShapeCount; i++)
             {
-                sourceShapeNames.Add(targetRenderer.sharedMesh.GetBlendShapeName(i));
+                var shapeName = targetRenderer.sharedMesh.GetBlendShapeName(i);
+                if (!string.IsNullOrEmpty(shapeName))
+                {
+                    sourceShapeNames.Add(shapeName);
+                }
             }
 
             var processedAutoNames = new HashSet<string>();

--- a/Tests/Editor/EmptyNameBlendShapeTests.cs
+++ b/Tests/Editor/EmptyNameBlendShapeTests.cs
@@ -1,0 +1,166 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 名前が空のシェイプキーを含むメッシュでの挙動を固定化する。
+    ///
+    /// 仕様: 空名シェイプは「そのまま保持するが、生成・照合・プレビューの対象にはしない」。
+    /// </summary>
+    public class EmptyNameBlendShapeTests
+    {
+        private static Vector3[] TwoVertices() => new[]
+        {
+            new Vector3(-1f, 0f, 0f),
+            new Vector3(1f, 0f, 0f),
+        };
+
+        private static BlendShapeGenerationOptions CreateOptions()
+        {
+            return new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = 1.0f,
+                EnableLeftRightSplit = false,
+                BlendWidth = 0.02f,
+                OverwriteExisting = false,
+            };
+        }
+
+        private static List<ARKitMapping> AutoMapping(string arkitName, string sourceName)
+        {
+            return new List<ARKitMapping>
+            {
+                new ARKitMapping(arkitName, new List<SourceMapping>
+                {
+                    new SourceMapping(1.0f, sourceName),
+                }),
+            };
+        }
+
+        private static CustomBlendShapeMapping CustomMapping(string arkitName, string sourceName)
+        {
+            return new CustomBlendShapeMapping
+            {
+                arkitName = arkitName,
+                enabled = true,
+                sources = new List<BlendShapeSource>
+                {
+                    new BlendShapeSource { blendShapeName = sourceName, weight = 1.0f, side = BlendShapeSide.Both },
+                },
+            };
+        }
+
+        /// <summary>
+        /// 空名シェイプを中間に挟んだメッシュ。上書き生成では "eyeBlinkLeft" が削除・再生成される。
+        /// </summary>
+        private static FakeMeshRepository MeshWithEmptyNamedShape()
+        {
+            return new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up)
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right);
+        }
+
+        [Test]
+        public void Generate_PreservesEmptyNamedShape_WhenOverwritingExistingShape()
+        {
+            // 上書き時の削除・再構築（ClearBlendShapes → 再追加）で空名シェイプが黙って消えないこと
+            var source = MeshWithEmptyNamedShape();
+            var target = MeshWithEmptyNamedShape();
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            Assert.That(target.CountShapes(""), Is.EqualTo(1));
+            // デルタも失われていないこと
+            Assert.That(target.FindShape("").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Generate_KeepsShapeIndicesConsistent_WhenEmptyNamedShapeExists()
+        {
+            // 空名シェイプが保持される結果、インデックス表が実メッシュ上の位置と一致すること
+            var source = MeshWithEmptyNamedShape();
+            var target = MeshWithEmptyNamedShape();
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            // 再構築後の並びは ["vrc.blink", "", "eyeBlinkLeft"]
+            Assert.That(target.Shapes[0].Name, Is.EqualTo("vrc.blink"));
+            Assert.That(target.Shapes[1].Name, Is.EqualTo(""));
+            Assert.That(target.Shapes[2].Name, Is.EqualTo("eyeBlinkLeft"));
+
+            Assert.That(result.ShapeIndices["vrc.blink"], Is.EqualTo(0));
+            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(2));
+            // 空名は名前で引けないためエントリを持たない
+            Assert.That(result.ShapeIndices.ContainsKey(""), Is.False);
+        }
+
+        [Test]
+        public void Generate_PreservesEmptyNamedShape_WhenNothingIsRemoved()
+        {
+            // 削除が発生しない通常生成でも空名シェイプはそのまま残る
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+            Assert.That(target.CountShapes(""), Is.EqualTo(1));
+            Assert.That(target.FindShape("").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+        }
+
+        [Test]
+        public void Generate_DoesNotUseEmptyNamedShape_AsSource()
+        {
+            // 空名は照合キーにしないため、ソース名が空の設定は「ソースなし」として扱われる
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("jawOpen", ""),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.Shapes, Is.Empty);
+        }
+
+        [Test]
+        public void Generate_DoesNotTreatEmptyNamedShape_AsExistingTarget()
+        {
+            // 空名シェイプが「既存の生成先」と誤認されて生成がスキップされないこと
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var customMappings = new List<CustomBlendShapeMapping>
+            {
+                CustomMapping("eyeBlinkLeft", "vrc.blink"),
+            };
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, customMappings, null, CreateOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+        }
+    }
+}

--- a/Tests/Editor/EmptyNameBlendShapeTests.cs
+++ b/Tests/Editor/EmptyNameBlendShapeTests.cs
@@ -125,12 +125,12 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
-        public void Generate_MergesEmptyNamedShapes_WhenRemovalMakesThemAdjacent()
+        public void Generate_AbortsOverwrite_WhenRebuildWouldMergeSameNamedShapes()
         {
-            // 既知の制限: AddBlendShapeFrame は名前をキーにするため、同名シェイプを個別に再構築できない
-            // （直前と同名への追加は別シェイプではなく同一シェイプのフレーム追加になる）。
-            // 削除によって空名シェイプが隣接すると2つが1つへ統合され、デルタは残るが個数が減る。
-            // 名前を書き換えない方針では解消できないため、現状の挙動をここで固定化する。
+            // 削除によって同名シェイプ（ここでは空名）が隣接する配置。
+            // AddBlendShapeFrame は名前をキーにし、同名シェイプのフレームウェイトは昇順を要求するため、
+            // 再構築すると2つ目の同一ウェイトのフレームが追加されずデルタが失われる。
+            // メッシュを壊さないよう、変更を加える前に検出して生成自体を中止する。
             var source = new FakeMeshRepository(TwoVertices())
                 .AddShape("vrc.blink", Vector3.up, Vector3.up);
             // 構築時点では削除対象が間に挟まるため、空名シェイプは別々のシェイプになる
@@ -143,16 +143,61 @@ namespace ARKitBlendShapeGenerator.Tests
 
             Assert.That(target.CountShapes(""), Is.EqualTo(2), "前提: 削除前は空名シェイプが2つある");
 
-            BlendShapeGenerationEngine.Generate(
+            var result = BlendShapeGenerationEngine.Generate(
                 source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
 
-            // 2つの空名シェイプが1つ（2フレーム）へ統合される
+            Assert.That(result.GeneratedShapes, Is.Empty);
+
+            // メッシュは一切変更されない（ClearBlendShapesまで到達しない）
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+            Assert.That(target.CountShapes(""), Is.EqualTo(2));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(target.Shapes[2].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            // 置き換え対象も残したままにする
+            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.right));
+        }
+
+        [Test]
+        public void Generate_AbortsOverwrite_WhenSameNamedShapesAreAlreadyAdjacent()
+        {
+            // 同名の非空シェイプが隣接する場合も同じく中止する（空名固有の問題ではない）。
+            // FakeMeshRepositoryでは連続追加が統合されるため、間に別シェイプを挟んで構築する
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("dup", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("dup", Vector3.up, Vector3.up);
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+            Assert.That(target.CountShapes("dup"), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Generate_ProceedsWithOverwrite_WhenRemainingShapeNamesAreUnique()
+        {
+            // 同名シェイプが無ければ従来どおり上書きされる（中止判定が過剰に効かないこと）
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right);
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+            Assert.That(target.CountShapes("eyeBlinkLeft"), Is.EqualTo(1));
+            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
             Assert.That(target.CountShapes(""), Is.EqualTo(1));
-            var merged = target.FindShape("");
-            Assert.That(merged.Frames.Count, Is.EqualTo(2));
-            // デルタ自体は各フレームとして保持され、失われはしない
-            Assert.That(merged.Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
-            Assert.That(merged.Frames[1].DeltaVertices[0], Is.EqualTo(Vector3.up));
         }
 
         [Test]

--- a/Tests/Editor/EmptyNameBlendShapeTests.cs
+++ b/Tests/Editor/EmptyNameBlendShapeTests.cs
@@ -125,6 +125,37 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
+        public void Generate_MergesEmptyNamedShapes_WhenRemovalMakesThemAdjacent()
+        {
+            // 既知の制限: AddBlendShapeFrame は名前をキーにするため、同名シェイプを個別に再構築できない
+            // （直前と同名への追加は別シェイプではなく同一シェイプのフレーム追加になる）。
+            // 削除によって空名シェイプが隣接すると2つが1つへ統合され、デルタは残るが個数が減る。
+            // 名前を書き換えない方針では解消できないため、現状の挙動をここで固定化する。
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            // 構築時点では削除対象が間に挟まるため、空名シェイプは別々のシェイプになる
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("", Vector3.up, Vector3.up);
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            Assert.That(target.CountShapes(""), Is.EqualTo(2), "前提: 削除前は空名シェイプが2つある");
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            // 2つの空名シェイプが1つ（2フレーム）へ統合される
+            Assert.That(target.CountShapes(""), Is.EqualTo(1));
+            var merged = target.FindShape("");
+            Assert.That(merged.Frames.Count, Is.EqualTo(2));
+            // デルタ自体は各フレームとして保持され、失われはしない
+            Assert.That(merged.Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(merged.Frames[1].DeltaVertices[0], Is.EqualTo(Vector3.up));
+        }
+
+        [Test]
         public void Generate_DoesNotUseEmptyNamedShape_AsSource()
         {
             // 空名は照合キーにしないため、ソース名が空の設定は「ソースなし」として扱われる
@@ -146,11 +177,13 @@ namespace ARKitBlendShapeGenerator.Tests
         [Test]
         public void Generate_DoesNotTreatEmptyNamedShape_AsExistingTarget()
         {
-            // 空名シェイプが「既存の生成先」と誤認されて生成がスキップされないこと
+            // 空名シェイプが「既存の生成先」と誤認されて生成がスキップされないこと。
+            // 対象メッシュにも空名シェイプを置き、保持と生成結果の両方を検証する
             var source = new FakeMeshRepository(TwoVertices())
                 .AddShape("", Vector3.forward, Vector3.forward)
                 .AddShape("vrc.blink", Vector3.up, Vector3.up);
-            var target = new FakeMeshRepository(TwoVertices());
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("", Vector3.forward, Vector3.forward);
             var customMappings = new List<CustomBlendShapeMapping>
             {
                 CustomMapping("eyeBlinkLeft", "vrc.blink"),
@@ -161,6 +194,11 @@ namespace ARKitBlendShapeGenerator.Tests
 
             Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
             Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            // 対象メッシュの空名シェイプはそのまま残り、生成分が末尾に追加される
+            Assert.That(target.Shapes.Count, Is.EqualTo(2));
+            Assert.That(target.CountShapes(""), Is.EqualTo(1));
+            Assert.That(target.FindShape("").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(1));
         }
     }
 }


### PR DESCRIPTION
## 概要

Closes #38

> [!NOTE]
> このPRは #46 にスタックしています。base は `claude/issue-37-fix-6uqk8n` です。
> #46 がマージされた後、base を `main` に切り替えてください（差分は本PR独自の変更のみです）。

名前が空（`""`）のシェイプキーを持つメッシュで、上書き生成時に空名シェイプが黙って消えるデータ喪失バグを修正する。

## 原因

`RemoveBlendShapesByNames` は空名シェイプを preserved（保持リスト）にも removed（削除数）にも入れずに `continue` していた。削除が1件でも発生すると `ClearBlendShapes()` 後に preserved だけを再構築するため、**空名シェイプがメッシュから消える**。「既存を上書き」ON で該当名の置き換えが起きたときに踏む。

副作用として、消えた分だけ後続シェイプのインデックスが前にずれ、生成結果のインデックス表と実メッシュの対応も崩れていた。

## 仕様

issue #38 の解決プラン2に沿って、空名シェイプの扱いを次に統一した。

> **そのまま保持するが、生成・照合・プレビューの対象にはしない**

## 変更内容

### 保持の修正（`BlendShapeGenerationEngine`）
- `RemoveBlendShapesByNames`: 空名シェイプを preserved に含め、再構築時に復元する。削除対象は必ず非空の ARKit 名のため、空名が削除に該当することはない。
- `Generate`: `existingShapes` にキー `""` を登録しないよう変更。`TryGetSourceIndex` が空名を弾くため実害は薄かったが、意図を明確にして偶発的な一致を防ぐ。

### 同名シェイプの統合によるデータ喪失を防ぐ

`AddBlendShapeFrame` は名前をキーにするうえ、同名シェイプのフレームウェイトが昇順であることを要求する。削除によって同名（空名を含む）シェイプが隣接すると、2つ目の同一ウェイトのフレームは追加されず**デルタごと失われる**。

```
["", "eyeBlinkLeft", ""] → eyeBlinkLeft を削除 → preserved = ["", ""] → 再構築で2つ目が消える
```

デルタを失うくらいなら上書きしない方が安全なため、**メッシュへ触れる前に配置を検出して中止する**。

- `TryRemoveBlendShapesByNames`: `preserved` に同名の隣接があれば `ClearBlendShapes` を呼ばずに `false` を返す。
- 通常の生成経路: 既存の重複ARKit名と同じくエラーを出して生成全体を中止（メッシュは無変更）。`log.overwrite_merge_abort` を追加し、名前を一意にするか「既存を上書き」をオフにするよう案内する。
- 手続き的生成: 補助機能のため、その回の生成を見送る。
- 中止時にも実メッシュの状態を返せるよう、`shapeIndices` の構築を `BuildShapeIndices` として切り出した。

判定は「再構築後に同名が隣り合うか」だけを見るため、**同名の非空シェイプでも同様に中止**する。

### 明文化（コメント追加のみ、挙動変更なし）
- `GetExistingBlendShapeNames`: 空名を含めない理由（生成・置き換えの対象外）を記載。
- `BuildShapeIndices`: 空名はエントリを持たないが `i` は実メッシュ上の位置のままなので、非空シェイプのインデックスは常に実体と一致することを記載。

### プレビュー（`ARKitBlendShapeGeneratorEditor`）
- `BuildRealtimePreviewCategories`: 空名シェイプを一覧から除外。従来は Original カテゴリに空ラベルの行として現れるが、`ARKitBlendShapeGeneratorPreviewState.SetWeight` が空名を弾くため操作しても何も起きない無効行だった。

### テスト
`EmptyNameBlendShapeTests` を追加。

- 上書き生成後も空名シェイプがデルタごと残ること（本バグの回帰テスト）
- 生成結果のインデックスが実メッシュ上の位置と一致すること
- 削除が発生しない通常生成でも空名シェイプが残ること
- 空名がソースとして使われないこと／既存の生成先と誤認されないこと
- 同名が隣接する配置では中止してメッシュを一切変更しないこと（空名・非空の両方）
- 同名が無ければ従来どおり上書きされること（中止判定が過剰に効かないこと）

## 完了条件の確認

- [x] 空名シェイプキーがあるメッシュでも生成・上書き・プレビューでデータが失われない
- [x] 空名シェイプの扱いがコードとテストで明文化されている

同名シェイプを**個別に復元する**本質的な解決（プレースホルダ名の付与など）は #50 で追跡する。本PRは「失うくらいなら触らない」という安全弁までを担保する。

## 未検証の点

この環境に Unity がないため、issue の解決プラン1にある実機再現は行えていません。レビュー時に実機で確認いただけると確実です。

- Unity の `Mesh.AddBlendShapeFrame` が空文字名を受け付けるか。仮に拒否される場合、保持方法（例: プレースホルダ名の付与）を再検討する必要があります。本PRは名前を書き換えない方針を採っています。
- `AddBlendShapeFrame` がフレームウェイト昇順を要求する点。**仮にこの前提が誤りでも、本変更は稀な配置で上書きを行わないだけでデータを壊さない**ため安全側に倒しています。
- NDMF プレビュー実行時の見え方（空名シェイプがメッシュ上に残り、一覧には出ないこと）。

## レビュー対応・リベース履歴

Codexレビューの指摘に対応済み。

- **P3（テストの判別力）**: 対象メッシュが空だと空名シェイプの処理を戻してもテストが通ってしまう状態だったため、対象メッシュにも空名シェイプを置いて検証するようにした。
- **P1（同名シェイプの統合）**: 当初は「デルタは残る既知の制限」として #50 へ切り出したが、再指摘を受けて**前提が誤っていた**ことを確認した。フレームウェイト昇順の制約により実際にはデルタが失われるため、上記のとおり中止する実装に変更した。

なお #45（検索可能ドロップダウン）が main にマージされた際に #46 ごとリベースしているため、過去のスレッド内の返信が参照しているコミットID（`2f29ca8` 等）は現在のブランチには存在しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVT6dsweC6qwAHiWtZk8zv