### PR TITLE
refactor: スキンドメッシュの解決ロジックを一本化する

### DIFF
--- a/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
@@ -61,9 +61,11 @@ namespace ARKitBlendShapeGenerator.Handler
                 if (renderer == null)
                 {
                     // targetRenderer未設定時は子要素をフォールバック対象にする
-                    renderer = context
-                        .GetComponentsInChildren<SkinnedMeshRenderer>(component.gameObject, true)
-                        .FirstOrDefault();
+                    // レンダラーの列挙はComputeContext経由で行い（変更監視のため）、
+                    // どれを選ぶかの判断は他経路と共通のTargetRendererResolverに委ねる
+                    renderer = TargetRendererResolver.SelectFallback(
+                        component.transform,
+                        context.GetComponentsInChildren<SkinnedMeshRenderer>(component.gameObject, true));
                 }
 
                 if (renderer != null && context.Observe(renderer, r => r.sharedMesh) != null)

--- a/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
@@ -63,9 +63,21 @@ namespace ARKitBlendShapeGenerator.Handler
                     // targetRenderer未設定時は子要素をフォールバック対象にする
                     // レンダラーの列挙はComputeContext経由で行い（変更監視のため）、
                     // どれを選ぶかの判断は他経路と共通のTargetRendererResolverに委ねる
-                    renderer = TargetRendererResolver.SelectFallback(
-                        component.transform,
-                        context.GetComponentsInChildren<SkinnedMeshRenderer>(component.gameObject, true));
+                    // 監視の登録と選択で二度走査するため、ここで確定させる
+                    var candidates = context
+                        .GetComponentsInChildren<SkinnedMeshRenderer>(component.gameObject, true)
+                        .ToArray();
+
+                    // フォールバックは名前も選択条件に含むため、候補の改名にも追従させる
+                    foreach (var candidate in candidates)
+                    {
+                        if (TargetRendererResolver.IsNameSearchTarget(component.transform, candidate))
+                        {
+                            context.Observe(candidate.gameObject, go => go.name);
+                        }
+                    }
+
+                    renderer = TargetRendererResolver.SelectFallback(component.transform, candidates);
                 }
 
                 if (renderer != null && context.Observe(renderer, r => r.sharedMesh) != null)

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -8,6 +8,7 @@ using nadena.dev.ndmf.ui;
 using ARKitBlendShapeGenerator.Domain;
 using ARKitBlendShapeGenerator.Handler;
 using ARKitBlendShapeGenerator.Infra;
+using ARKitBlendShapeGenerator.UseCase;
 using static ARKitBlendShapeGenerator.Localization;
 
 namespace ARKitBlendShapeGenerator.Presentation
@@ -1091,12 +1092,7 @@ namespace ARKitBlendShapeGenerator.Presentation
 
         private SkinnedMeshRenderer GetPreviewTargetRenderer()
         {
-            if (_component.targetRenderer != null)
-            {
-                return _component.targetRenderer;
-            }
-
-            return _component.GetComponentInChildren<SkinnedMeshRenderer>(true);
+            return GenerateBlendShapesUseCase.ResolveTargetRenderer(_component);
         }
 
         private sealed class PreviewShapeCategories

--- a/Editor/UseCase/GenerateBlendShapesUseCase.cs
+++ b/Editor/UseCase/GenerateBlendShapesUseCase.cs
@@ -46,21 +46,11 @@ namespace ARKitBlendShapeGenerator.UseCase
 
         /// <summary>
         /// 生成対象のSkinnedMeshRendererを解決する（未設定時は子要素から検索）
+        /// 解決順序の実体はTargetRendererResolverにあり、全経路でこれを共有する
         /// </summary>
         public static SkinnedMeshRenderer ResolveTargetRenderer(ARKitBlendShapeGeneratorComponent component)
         {
-            if (component == null)
-            {
-                return null;
-            }
-
-            var renderer = component.targetRenderer;
-            if (renderer == null)
-            {
-                renderer = component.GetComponentInChildren<SkinnedMeshRenderer>();
-            }
-
-            return renderer;
+            return TargetRendererResolver.Resolve(component);
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 
 | 項目 | 説明 |
 | ---- | ---- |
-| **Target Renderer** | 対象のSkinnedMeshRenderer（空の場合はBody/Faceを自動検出） |
+| **Target Renderer** | 対象のSkinnedMeshRenderer（空の場合はBody/Face/Headを自動検出） |
 | **Intensity Multiplier** | 生成時の強度係数（0.5〜1.5推奨） |
 | **Enable Left Right Split** | 左右分割を有効化（まばたき等を左右別々に生成） |
 | **Blend Width** | 左右分割時のグラデーション幅（中央付近で左右をブレンドする範囲、0.001〜0.1） |
@@ -51,6 +51,10 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 | **Mouth Cancellation Strength** | 打ち消し量の全体係数（0.0〜1.0） |
 | **Custom Mappings** | 自動マッピングできないBlendShapeを手動で指定 |
 | **Debug Mode** | デバッグログを出力する |
+
+Target Renderer が空のときは、コンポーネントの直下にある `Body` / `body` / `Face` / `face` / `Head` / `head` のいずれかの名前を持つSkinnedMeshRendererを優先し、見つからなければ子孫の最初のSkinnedMeshRendererを対象にします。
+どちらの検索も非アクティブなオブジェクトを含みます。
+この探索順序はビルド、プレビュー、インスペクタ表示のすべてで共通です。
 
 ### カスタムマッピング
 

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -80,7 +80,7 @@ namespace ARKitBlendShapeGenerator
         private void Reset()
         {
             // 自動でBodyメッシュを検索
-            targetRenderer = FindBodyMesh();
+            targetRenderer = TargetRendererResolver.Resolve(this);
 
             // デフォルトのカスタムマッピングを追加（視線系）
             InitializeDefaultCustomMappings();
@@ -91,25 +91,6 @@ namespace ARKitBlendShapeGenerator
 #if UNITY_EDITOR
             EditorOnValidateHook?.Invoke(this);
 #endif
-        }
-
-        private SkinnedMeshRenderer FindBodyMesh()
-        {
-            // よくある名前パターンで検索
-            string[] bodyNames = { "Body", "body", "Face", "face", "Head", "head" };
-
-            foreach (var name in bodyNames)
-            {
-                var found = transform.Find(name);
-                if (found != null)
-                {
-                    var smr = found.GetComponent<SkinnedMeshRenderer>();
-                    if (smr != null) return smr;
-                }
-            }
-
-            // 見つからない場合は最初のSkinnedMeshRendererを返す
-            return GetComponentInChildren<SkinnedMeshRenderer>();
         }
 
         private void InitializeDefaultCustomMappings()
@@ -134,7 +115,7 @@ namespace ARKitBlendShapeGenerator
         public List<string> GetAvailableBlendShapes()
         {
             var result = new List<string>();
-            var renderer = targetRenderer ?? GetComponentInChildren<SkinnedMeshRenderer>();
+            var renderer = TargetRendererResolver.Resolve(this);
 
             if (renderer != null && renderer.sharedMesh != null)
             {

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,4 +1,7 @@
 using System.Runtime.CompilerServices;
 
-// Editorアセンブリからinternalメンバー（EditorOnValidateHook）へアクセスするため
+// Editorアセンブリからinternalメンバー（EditorOnValidateHook、TargetRendererResolver）へアクセスするため
 [assembly: InternalsVisibleTo("ARKitBlendShapeGenerator.Editor")]
+
+// テストアセンブリからTargetRendererResolverへアクセスするため
+[assembly: InternalsVisibleTo("ARKitBlendShapeGenerator.Editor.Tests")]

--- a/Runtime/TargetRendererResolver.cs
+++ b/Runtime/TargetRendererResolver.cs
@@ -75,8 +75,7 @@ namespace ARKitBlendShapeGenerator
                     firstFound = candidate;
                 }
 
-                // 名前検索の対象は直下の子のみ（Reset時の実装がtransform.Findだったため）
-                if (root == null || candidate.transform.parent != root)
+                if (!IsNameSearchTarget(root, candidate))
                 {
                     continue;
                 }
@@ -90,6 +89,20 @@ namespace ARKitBlendShapeGenerator
             }
 
             return preferred != null ? preferred : firstFound;
+        }
+
+        /// <summary>
+        /// 候補が名前検索の対象になるか判定する
+        /// 名前検索の対象は直下の子のみ（Reset時の実装がtransform.Findだったため）
+        ///
+        /// 候補の名前を変更監視の対象に含める必要があるNDMFプレビューと、
+        /// 判定条件を共有するために切り出している
+        /// </summary>
+        public static bool IsNameSearchTarget(Transform root, SkinnedMeshRenderer candidate)
+        {
+            return root != null
+                && candidate != null
+                && candidate.transform.parent == root;
         }
     }
 }

--- a/Runtime/TargetRendererResolver.cs
+++ b/Runtime/TargetRendererResolver.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ARKitBlendShapeGenerator
+{
+    /// <summary>
+    /// 生成対象のSkinnedMeshRendererを解決する唯一のロジック
+    /// NDMFビルド・NDMFプレビュー・インスペクタUI・シェイプキー一覧・Reset時の自動設定は、すべてここを経由する
+    ///
+    /// 解決順序:
+    /// 1. targetRenderer（Destroy済みの参照は未設定として扱う）
+    /// 2. 直下の子のうちPreferredNamesに一致する名前を持つSkinnedMeshRenderer
+    /// 3. 自身を含む子孫の最初のSkinnedMeshRenderer（ヒエラルキー順）
+    ///
+    /// 2と3はいずれも非アクティブなオブジェクトを含める。
+    /// NDMFビルドでは非アクティブなメッシュも成果物に残るため、除外するとプレビューとの食い違いが生じる。
+    /// </summary>
+    internal static class TargetRendererResolver
+    {
+        /// <summary>
+        /// 名前検索で優先するオブジェクト名（配列の並びがそのまま優先順位）
+        /// </summary>
+        private static readonly string[] PreferredNames = { "Body", "body", "Face", "face", "Head", "head" };
+
+        /// <summary>
+        /// コンポーネントから生成対象のSkinnedMeshRendererを解決する
+        /// </summary>
+        public static SkinnedMeshRenderer Resolve(ARKitBlendShapeGeneratorComponent component)
+        {
+            if (component == null)
+            {
+                return null;
+            }
+
+            // UnityEngine.Objectの==演算子で判定するため、Destroy済みの参照はフォールバックに回る
+            if (component.targetRenderer != null)
+            {
+                return component.targetRenderer;
+            }
+
+            return SelectFallback(
+                component.transform,
+                component.GetComponentsInChildren<SkinnedMeshRenderer>(true));
+        }
+
+        /// <summary>
+        /// targetRenderer未設定時のフォールバック探索
+        /// レンダラーの列挙を自前で行う経路（ComputeContext経由で取得するNDMFプレビュー）と
+        /// 探索順序を共有するために切り出している
+        /// candidatesにはrootを含む子孫のSkinnedMeshRendererをヒエラルキー順で渡す
+        /// </summary>
+        public static SkinnedMeshRenderer SelectFallback(
+            Transform root,
+            IEnumerable<SkinnedMeshRenderer> candidates)
+        {
+            if (candidates == null)
+            {
+                return null;
+            }
+
+            SkinnedMeshRenderer firstFound = null;
+            SkinnedMeshRenderer preferred = null;
+            int preferredRank = int.MaxValue;
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate == null)
+                {
+                    continue;
+                }
+
+                if (firstFound == null)
+                {
+                    firstFound = candidate;
+                }
+
+                // 名前検索の対象は直下の子のみ（Reset時の実装がtransform.Findだったため）
+                if (root == null || candidate.transform.parent != root)
+                {
+                    continue;
+                }
+
+                int rank = Array.IndexOf(PreferredNames, candidate.name);
+                if (rank >= 0 && rank < preferredRank)
+                {
+                    preferredRank = rank;
+                    preferred = candidate;
+                }
+            }
+
+            return preferred != null ? preferred : firstFound;
+        }
+    }
+}

--- a/Tests/Editor/TargetRendererResolverTests.cs
+++ b/Tests/Editor/TargetRendererResolverTests.cs
@@ -1,0 +1,218 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.UseCase;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 生成対象レンダラーの解決順序を検証する
+    /// ビルド・NDMFプレビュー・インスペクタUI・シェイプキー一覧の全経路が同じ結果を返すことを担保する
+    /// </summary>
+    public class TargetRendererResolverTests
+    {
+        private readonly List<Object> _created = new List<Object>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var obj in _created)
+            {
+                if (obj != null)
+                {
+                    Object.DestroyImmediate(obj);
+                }
+            }
+
+            _created.Clear();
+        }
+
+        private ARKitBlendShapeGeneratorComponent CreateRoot()
+        {
+            var root = new GameObject("Avatar");
+            _created.Add(root);
+            return root.AddComponent<ARKitBlendShapeGeneratorComponent>();
+        }
+
+        private SkinnedMeshRenderer AddRenderer(Transform parent, string name, bool active = true)
+        {
+            var go = new GameObject(name);
+            go.transform.SetParent(parent, false);
+            go.SetActive(active);
+            return go.AddComponent<SkinnedMeshRenderer>();
+        }
+
+        private Mesh CreateMeshWithShape(string shapeName)
+        {
+            var mesh = new Mesh { vertices = new[] { Vector3.zero } };
+            mesh.AddBlendShapeFrame(shapeName, 100f, new[] { Vector3.up }, null, null);
+            _created.Add(mesh);
+            return mesh;
+        }
+
+        /// <summary>
+        /// NDMFプレビューはComputeContext経由でレンダラーを列挙するため、
+        /// 同じ候補列をSelectFallbackに渡す形で経路を再現する
+        /// </summary>
+        private static SkinnedMeshRenderer ResolveAsPreview(ARKitBlendShapeGeneratorComponent component)
+        {
+            if (component.targetRenderer != null)
+            {
+                return component.targetRenderer;
+            }
+
+            return TargetRendererResolver.SelectFallback(
+                component.transform,
+                component.GetComponentsInChildren<SkinnedMeshRenderer>(true));
+        }
+
+        [Test]
+        public void Resolve_ReturnsNull_WhenComponentIsNull()
+        {
+            Assert.That(TargetRendererResolver.Resolve(null), Is.Null);
+        }
+
+        [Test]
+        public void Resolve_ReturnsNull_WhenNoRendererExists()
+        {
+            var component = CreateRoot();
+
+            Assert.That(TargetRendererResolver.Resolve(component), Is.Null);
+        }
+
+        [Test]
+        public void Resolve_ReturnsTargetRenderer_WhenAssigned()
+        {
+            var component = CreateRoot();
+            var body = AddRenderer(component.transform, "Body");
+            var explicitTarget = AddRenderer(component.transform, "Hair");
+            component.targetRenderer = explicitTarget;
+
+            // 名前検索より明示的な指定が優先される
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(explicitTarget));
+            Assert.That(TargetRendererResolver.Resolve(component), Is.Not.EqualTo(body));
+        }
+
+        [Test]
+        public void Resolve_PrefersNamedChild_OverFirstInHierarchy()
+        {
+            var component = CreateRoot();
+            AddRenderer(component.transform, "Hair");
+            var body = AddRenderer(component.transform, "Body");
+
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(body));
+        }
+
+        [Test]
+        public void Resolve_PrefersBody_OverFaceAndHead()
+        {
+            var component = CreateRoot();
+            AddRenderer(component.transform, "Head");
+            AddRenderer(component.transform, "Face");
+            var body = AddRenderer(component.transform, "Body");
+
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(body));
+        }
+
+        [Test]
+        public void Resolve_IncludesInactiveRenderer()
+        {
+            var component = CreateRoot();
+            var inactive = AddRenderer(component.transform, "Hair", active: false);
+
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(inactive));
+        }
+
+        [Test]
+        public void Resolve_PrefersInactiveNamedChild_OverActiveUnnamedChild()
+        {
+            var component = CreateRoot();
+            AddRenderer(component.transform, "Hair");
+            var inactiveBody = AddRenderer(component.transform, "Body", active: false);
+
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(inactiveBody));
+        }
+
+        [Test]
+        public void Resolve_IgnoresNamedGrandchild_ForNameSearch()
+        {
+            var component = CreateRoot();
+            var hair = AddRenderer(component.transform, "Hair");
+            var container = new GameObject("Armature");
+            container.transform.SetParent(component.transform, false);
+            AddRenderer(container.transform, "Body");
+
+            // 名前検索の対象は直下の子のみ。孫階層のBodyは一般フォールバックとしてのみ扱う
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(hair));
+        }
+
+        [Test]
+        public void Resolve_FallsBackToChild_WhenTargetRendererIsDestroyed()
+        {
+            var component = CreateRoot();
+            var body = AddRenderer(component.transform, "Body");
+            var doomed = AddRenderer(component.transform, "Hair");
+            component.targetRenderer = doomed;
+
+            Object.DestroyImmediate(doomed.gameObject);
+
+            // Missing参照はC#のnullではないため、==演算子ではなくUnityのnull判定が必要
+            Assert.That(TargetRendererResolver.Resolve(component), Is.EqualTo(body));
+        }
+
+        [Test]
+        public void AllEntryPoints_ResolveSameRenderer_WhenTargetRendererIsUnset()
+        {
+            var component = CreateRoot();
+            AddRenderer(component.transform, "Hair");
+            var inactiveBody = AddRenderer(component.transform, "Body", active: false);
+            inactiveBody.sharedMesh = CreateMeshWithShape("まばたき");
+
+            // ビルドとインスペクタUIが共有する経路
+            Assert.That(
+                GenerateBlendShapesUseCase.ResolveTargetRenderer(component),
+                Is.EqualTo(inactiveBody));
+
+            // NDMFプレビューの経路
+            Assert.That(ResolveAsPreview(component), Is.EqualTo(inactiveBody));
+
+            // シェイプキー一覧の経路
+            Assert.That(component.GetAvailableBlendShapes(), Is.EqualTo(new[] { "まばたき" }));
+        }
+
+        [Test]
+        public void GetAvailableBlendShapes_FallsBackToChild_WhenTargetRendererIsDestroyed()
+        {
+            var component = CreateRoot();
+            var body = AddRenderer(component.transform, "Body");
+            body.sharedMesh = CreateMeshWithShape("まばたき");
+            var doomed = AddRenderer(component.transform, "Hair");
+            component.targetRenderer = doomed;
+
+            Object.DestroyImmediate(doomed.gameObject);
+
+            Assert.That(component.GetAvailableBlendShapes(), Is.EqualTo(new[] { "まばたき" }));
+        }
+
+        [Test]
+        public void SelectFallback_SkipsNullEntries()
+        {
+            var component = CreateRoot();
+            var body = AddRenderer(component.transform, "Body");
+
+            var candidates = new SkinnedMeshRenderer[] { null, body };
+
+            Assert.That(
+                TargetRendererResolver.SelectFallback(component.transform, candidates),
+                Is.EqualTo(body));
+        }
+
+        [Test]
+        public void SelectFallback_ReturnsNull_WhenCandidatesAreNull()
+        {
+            var component = CreateRoot();
+
+            Assert.That(TargetRendererResolver.SelectFallback(component.transform, null), Is.Null);
+        }
+    }
+}

--- a/Tests/Editor/TargetRendererResolverTests.cs
+++ b/Tests/Editor/TargetRendererResolverTests.cs
@@ -208,6 +208,32 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
+        public void IsNameSearchTarget_ReturnsTrue_ForDirectChild()
+        {
+            var component = CreateRoot();
+            var body = AddRenderer(component.transform, "Body");
+
+            // 名前は判定に含まない。直下の子であれば改名後にBodyになり得るため監視対象になる
+            var hair = AddRenderer(component.transform, "Hair");
+
+            Assert.That(TargetRendererResolver.IsNameSearchTarget(component.transform, body), Is.True);
+            Assert.That(TargetRendererResolver.IsNameSearchTarget(component.transform, hair), Is.True);
+        }
+
+        [Test]
+        public void IsNameSearchTarget_ReturnsFalse_ForGrandchildAndNullArguments()
+        {
+            var component = CreateRoot();
+            var container = new GameObject("Armature");
+            container.transform.SetParent(component.transform, false);
+            var grandchild = AddRenderer(container.transform, "Body");
+
+            Assert.That(TargetRendererResolver.IsNameSearchTarget(component.transform, grandchild), Is.False);
+            Assert.That(TargetRendererResolver.IsNameSearchTarget(null, grandchild), Is.False);
+            Assert.That(TargetRendererResolver.IsNameSearchTarget(component.transform, null), Is.False);
+        }
+
+        [Test]
         public void SelectFallback_ReturnsNull_WhenCandidatesAreNull()
         {
             var component = CreateRoot();


### PR DESCRIPTION
Closes #39

## 背景

`targetRenderer` 未設定時のフォールバック解決が、NDMFビルド、NDMFプレビュー、インスペクタUI、シェイプキー一覧、Reset時の自動設定でそれぞれ異なっていた。
特に非アクティブオブジェクトの扱いが食い違っていたため、顔メッシュが非アクティブな構成では「プレビューで見えているメッシュ」と「ビルドで処理されるメッシュ」が別物になり得た。

## 決めた仕様

解決順序を次のとおり1つに定めた。

1. `targetRenderer`（Destroy済みの参照は未設定として扱う）
2. 直下の子のうち `Body` / `body` / `Face` / `face` / `Head` / `head` の名前を持つ SkinnedMeshRenderer
3. 自身を含む子孫の最初の SkinnedMeshRenderer（ヒエラルキー順）

2と3はいずれも非アクティブなオブジェクトを含む。
NDMFビルドでは非アクティブなメッシュも成果物に残るため、除外するとプレビューとの食い違いが生じる。

これまで Reset 時にしか効いていなかった名前検索は、共通仕様に含めた（issue のコメントで確認済み）。
これによりフォールバックの優先順位も統一される。

## 変更内容

- `Runtime/TargetRendererResolver.cs` を追加し、解決順序の実体をここに集約した
- `GenerateBlendShapesUseCase.ResolveTargetRenderer` は Resolver への委譲に変更した（ビルドとインスペクタUIの経路）
- `ARKitBlendShapeGeneratorEditor.GetPreviewTargetRenderer` を `ResolveTargetRenderer` 呼び出しに置き換えた
- `ARKitBlendShapeGeneratorComponent.GetAvailableBlendShapes` と `Reset` を Resolver 呼び出しに置き換え、`FindBodyMesh` を削除した
- NDMFプレビューは `ComputeContext` による変更監視が必要なため、レンダラーの列挙は `ComputeContext` 経由のまま残し、どれを選ぶかの判断だけを `SelectFallback` で共有する形にした
- 名前が選択条件に含まれるため、NDMFプレビューでは名前検索の対象になる候補の GameObject 名も `ComputeContext` で監視し、プレビュー中の改名に追従させた（判定条件は `TargetRendererResolver.IsNameSearchTarget` で共有する）

## 副次的に直った不具合

- `GetAvailableBlendShapes` が C# の `??` 演算子で判定していたため、`targetRenderer` が Destroy 済み（Missing）のときだけ子要素へフォールバックせず、シェイプキー一覧が空になっていた
- 非アクティブ配下にコンポーネントがある場合、プレビューには生成結果が見えるのにビルドはレンダラーを見つけられず警告スキップになっていた
- `FindBodyMesh` 内部で、名前検索（`transform.Find`、非アクティブを含む）とフォールバック（非アクティブを除外）の扱いが揃っていなかった

## テスト

`Tests/Editor/TargetRendererResolverTests.cs` を追加した。

- `targetRenderer` 指定時はそれを返す（名前検索より優先）
- 名前検索が階層順より優先される、および `Body` が `Face` / `Head` より優先される
- 非アクティブなレンダラー、非アクティブな `Body` が選ばれる
- 名前検索の対象は直下の子のみで、孫階層の `Body` は一般フォールバック扱いになる
- Missing 参照時に子要素へフォールバックする（`Resolve` と `GetAvailableBlendShapes` の両方）
- ビルド、NDMFプレビュー、シェイプキー一覧の3経路が同じレンダラーに解決される
- 候補が null、候補列に null が混ざる場合の挙動
- `IsNameSearchTarget` が直下の子とそれ以外を判別する

なお、リポジトリに Unity のテスト実行 CI が無いため、テストは Unity Editor 上での実行が未確認です。
プレビュー中の改名への追従は `ComputeContext` の挙動に依存するため、自動テストの対象外です。

## 動作確認のお願い

名前検索を共通仕様へ含めたことで、`targetRenderer` 未設定かつ `Body` がヒエラルキー先頭でない構成では、ビルドで選ばれるメッシュがこれまでと変わります。
通常は Reset 時に `targetRenderer` が自動設定されるため影響は限定的なはずですが、意図と合っているかご確認ください。