### PR TITLE
fix: 上書きを元の位置での差し替えにして同名シェイプの統合を防ぐ

### DIFF
--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -219,50 +219,67 @@ namespace ARKitBlendShapeGenerator.Domain
                 plannedBlendShapes,
                 logger);
 
-            if (options.OverwriteExisting && plannedBlendShapes.Count > 0)
-            {
-                var namesToReplace = new HashSet<string>(
-                    plannedBlendShapes.Select(planned => planned.ArkitName));
-                namesToReplace.IntersectWith(GetExistingBlendShapeNames(targetMesh));
-
-                if (namesToReplace.Count > 0)
-                {
-                    if (!TryRemoveBlendShapesByNames(
-                            targetMesh,
-                            namesToReplace,
-                            out int removedCount,
-                            out var mergedShapeName))
-                    {
-                        // 上書きするとメッシュ側の同名シェイプが統合されてデータを失うため、
-                        // メッシュを変更しないまま生成全体を中止する
-                        logger?.Error(S("log.overwrite_merge_abort", mergedShapeName));
-                        return new BlendShapeGenerationResult(
-                            new List<string>(),
-                            BuildShapeIndices(targetMesh));
-                    }
-
-                    if (removedCount > 0)
-                    {
-                        Log(logger, options, $"Replaced existing blendshapes: {string.Join(", ", namesToReplace.OrderBy(name => name))}");
-                    }
-                }
-            }
-
             var cancellation = BuildMouthCancellationDelta(sourceMesh, existingShapes, options, logger);
 
+            // メッシュへ書き込む前に生成内容を全て確定させる。
+            // 置き換えは削除+末尾追加ではなく元の位置への差し替えで行うため、先に materialize する必要がある
+            var builtShapes = new List<BlendShapeData>();
             foreach (var planned in plannedBlendShapes)
             {
-                if (TryAddBlendShape(
+                if (TryBuildBlendShape(
                         sourceMesh,
-                        targetMesh,
                         planned.ArkitName,
                         planned.Sources,
                         options,
                         cancellation,
-                        logger))
+                        logger,
+                        out var built))
                 {
-                    existingShapes[planned.ArkitName] = targetMesh.BlendShapeCount - 1;
-                    generatedShapes.Add(planned.ArkitName);
+                    builtShapes.Add(built);
+                }
+            }
+
+            if (builtShapes.Count > 0)
+            {
+                var targetExistingNames = GetExistingBlendShapeNames(targetMesh);
+                var replacements = new Dictionary<string, BlendShapeData>();
+                var appended = new List<BlendShapeData>();
+
+                foreach (var built in builtShapes)
+                {
+                    if (options.OverwriteExisting && targetExistingNames.Contains(built.Name))
+                    {
+                        replacements[built.Name] = built;
+                    }
+                    else
+                    {
+                        appended.Add(built);
+                    }
+                }
+
+                if (!TryReplaceBlendShapesInPlace(targetMesh, replacements, out var mergedShapeName))
+                {
+                    // 元から同名シェイプが隣接しているメッシュは再構築でデータを失うため、
+                    // メッシュを変更しないまま生成全体を中止する
+                    logger?.Error(S("log.overwrite_merge_abort", mergedShapeName));
+                    return new BlendShapeGenerationResult(
+                        new List<string>(),
+                        BuildShapeIndices(targetMesh));
+                }
+
+                if (replacements.Count > 0)
+                {
+                    Log(logger, options, $"Replaced existing blendshapes: {string.Join(", ", replacements.Keys.OrderBy(name => name))}");
+                }
+
+                foreach (var built in appended)
+                {
+                    AppendBlendShape(targetMesh, built);
+                }
+
+                foreach (var built in builtShapes)
+                {
+                    generatedShapes.Add(built.Name);
                 }
             }
 
@@ -586,35 +603,50 @@ namespace ARKitBlendShapeGenerator.Domain
                 return;
             }
 
-            if (namesToReplace.Count > 0)
+            // 通常の生成と同じく、置き換えは元の位置へ差し替える（削除+末尾追加だと
+            // 隙間で同名シェイプが隣接して統合される）
+            var replacements = new Dictionary<string, BlendShapeData>();
+            var appended = new List<BlendShapeData>();
+            foreach (var (arkitName, deltaVertices, deltaNormals, deltaTangents) in plannedDeltas)
             {
-                if (!TryRemoveBlendShapesByNames(
-                        targetMesh,
-                        namesToReplace,
-                        out int removedCount,
-                        out var mergedShapeName))
-                {
-                    // 手続き的生成は補助機能のため、メッシュを守って生成を見送る
-                    Log(logger, options, $"Skip procedural (replacement would merge duplicate shape: {mergedShapeName})");
-                    return;
-                }
+                var built = new BlendShapeData(
+                    arkitName,
+                    new List<BlendShapeFrameData>
+                    {
+                        new BlendShapeFrameData(100f, deltaVertices, deltaNormals, deltaTangents),
+                    });
 
-                if (removedCount > 0)
+                if (namesToReplace.Contains(arkitName))
                 {
-                    Log(logger, options, $"Replaced existing blendshapes (procedural): {string.Join(", ", namesToReplace.OrderBy(name => name))}");
+                    replacements[arkitName] = built;
+                }
+                else
+                {
+                    appended.Add(built);
                 }
             }
 
-            foreach (var (arkitName, deltaVertices, deltaNormals, deltaTangents) in plannedDeltas)
+            if (!TryReplaceBlendShapesInPlace(targetMesh, replacements, out var mergedShapeName))
             {
-                targetMesh.AddBlendShapeFrame(
-                    arkitName,
-                    100f,
-                    deltaVertices,
-                    deltaNormals,
-                    deltaTangents);
-                generatedShapes.Add(arkitName);
-                Log(logger, options, $"Generated (procedural): {arkitName}");
+                // 手続き的生成は補助機能のため、メッシュを守って生成を見送る
+                Log(logger, options, $"Skip procedural (replacement would merge duplicate shape: {mergedShapeName})");
+                return;
+            }
+
+            if (replacements.Count > 0)
+            {
+                Log(logger, options, $"Replaced existing blendshapes (procedural): {string.Join(", ", replacements.Keys.OrderBy(name => name))}");
+            }
+
+            foreach (var built in appended)
+            {
+                AppendBlendShape(targetMesh, built);
+            }
+
+            foreach (var planned in plannedDeltas)
+            {
+                generatedShapes.Add(planned.arkitName);
+                Log(logger, options, $"Generated (procedural): {planned.arkitName}");
             }
         }
 
@@ -781,15 +813,20 @@ namespace ARKitBlendShapeGenerator.Domain
             return true;
         }
 
-        private static bool TryAddBlendShape(
+        /// <summary>
+        /// 生成するBlendShapeのデルタを計算する。メッシュへの書き込みは行わない。
+        /// 書き込み前に全て確定させることで、置き換え対象を元の位置へ差し替えられる
+        /// </summary>
+        private static bool TryBuildBlendShape(
             IMeshRepository sourceMesh,
-            IMeshRepository targetMesh,
             string arkitName,
             List<(int index, float weight, BlendShapeSide side)> sources,
             BlendShapeGenerationOptions options,
             MouthCancellationDelta cancellation,
-            IGenerationLogger logger)
+            IGenerationLogger logger,
+            out BlendShapeData built)
         {
+            built = null;
             int vertexCount = sourceMesh.VertexCount;
             var deltaVertices = new Vector3[vertexCount];
             var deltaNormals = new Vector3[vertexCount];
@@ -858,9 +895,27 @@ namespace ARKitBlendShapeGenerator.Domain
                 Log(logger, options, $"Applied cancellation: {arkitName}");
             }
 
-            targetMesh.AddBlendShapeFrame(arkitName, 100f, deltaVertices, deltaNormals, deltaTangents);
+            built = new BlendShapeData(
+                arkitName,
+                new List<BlendShapeFrameData>
+                {
+                    new BlendShapeFrameData(100f, deltaVertices, deltaNormals, deltaTangents),
+                });
             Log(logger, options, $"Generated: {arkitName} from {sourceCount} source(s)");
             return true;
+        }
+
+        private static void AppendBlendShape(IMeshRepository mesh, BlendShapeData shape)
+        {
+            foreach (var frame in shape.Frames)
+            {
+                mesh.AddBlendShapeFrame(
+                    shape.Name,
+                    frame.Weight,
+                    frame.DeltaVertices,
+                    frame.DeltaNormals,
+                    frame.DeltaTangents);
+            }
         }
 
         /// <summary>
@@ -926,23 +981,27 @@ namespace ARKitBlendShapeGenerator.Domain
         }
 
         /// <summary>
-        /// 指定した名前のBlendShapeを取り除く（ClearBlendShapes後に残りを再構築する）。
+        /// 指定した名前のBlendShapeを、その場で新しいデルタへ差し替える（ClearBlendShapes後に全体を再構築する）。
         ///
-        /// 再構築すると同名シェイプが統合されてデータを失う配置の場合はメッシュを一切変更せず、
-        /// falseを返して呼び出し元に中止させる。AddBlendShapeFrameは名前をキーにするうえ、
+        /// 削除して末尾へ追加し直すのではなく元の位置へ書き戻すのは、削除で空いた隙間によって
+        /// 同名シェイプが隣接するのを防ぐため。AddBlendShapeFrameは名前をキーにするうえ、
         /// 同名シェイプのフレームウェイトは昇順でなければならないため、同名シェイプが隣接すると
         /// 後続の同一ウェイトのフレームが追加されずデルタが失われる。
+        /// 並びを変えないので、隣接が新たに生じることはない。
+        ///
+        /// 元から同名シェイプが隣接しているメッシュ（FBXインポート等、このAPIを経由せずに
+        /// 作られたもの）だけは再構築でデータを失うため、メッシュを変更せずfalseを返す。
+        ///
+        /// 同じ名前のシェイプが複数ある場合は、そのすべてを置き換える。
         /// </summary>
-        private static bool TryRemoveBlendShapesByNames(
+        private static bool TryReplaceBlendShapesInPlace(
             IMeshRepository mesh,
-            HashSet<string> shapeNamesToRemove,
-            out int removedCount,
+            Dictionary<string, BlendShapeData> replacements,
             out string mergedShapeName)
         {
-            removedCount = 0;
             mergedShapeName = null;
 
-            if (mesh == null || shapeNamesToRemove == null || shapeNamesToRemove.Count == 0)
+            if (mesh == null || replacements == null || replacements.Count == 0)
             {
                 return true;
             }
@@ -954,18 +1013,20 @@ namespace ARKitBlendShapeGenerator.Domain
             }
 
             int vertexCount = mesh.VertexCount;
-            var preserved = new List<BlendShapeData>(blendShapeCount);
+            var rebuilt = new List<BlendShapeData>(blendShapeCount);
+            bool replacedAny = false;
 
             for (int shapeIndex = 0; shapeIndex < blendShapeCount; shapeIndex++)
             {
                 string existingName = mesh.GetBlendShapeName(shapeIndex);
 
-                // 空名シェイプは生成・照合の対象外だが、メッシュのデータとしては保持する。
-                // 削除対象は必ず非空のARKit名のため、空名が削除に該当することはない。
-                // （ここでpreservedに積まないと、ClearBlendShapes後の再構築で黙って消える）
-                if (!string.IsNullOrEmpty(existingName) && shapeNamesToRemove.Contains(existingName))
+                // 空名シェイプは生成・照合の対象外だが、メッシュのデータとしては保持する
+                // （ここでrebuiltに積まないと、ClearBlendShapes後の再構築で黙って消える）
+                if (!string.IsNullOrEmpty(existingName) &&
+                    replacements.TryGetValue(existingName, out var replacement))
                 {
-                    removedCount++;
+                    rebuilt.Add(replacement);
+                    replacedAny = true;
                     continue;
                 }
 
@@ -992,34 +1053,26 @@ namespace ARKitBlendShapeGenerator.Domain
                         deltaTangents));
                 }
 
-                preserved.Add(new BlendShapeData(existingName, frames));
+                rebuilt.Add(new BlendShapeData(existingName, frames));
             }
 
-            if (removedCount == 0)
+            if (!replacedAny)
             {
                 return true;
             }
 
-            // 再構築で同名シェイプが隣り合うとデータを失うため、メッシュへ触れる前に検出して中止する
-            mergedShapeName = FindAdjacentDuplicateName(preserved);
+            // 並びを変えないため、同名の隣接は元のメッシュに元からあった場合しか生じない。
+            // その場合だけは再構築でデータを失うため、メッシュへ触れる前に中止する
+            mergedShapeName = FindAdjacentDuplicateName(rebuilt);
             if (mergedShapeName != null)
             {
-                removedCount = 0;
                 return false;
             }
 
             mesh.ClearBlendShapes();
-            foreach (var shape in preserved)
+            foreach (var shape in rebuilt)
             {
-                foreach (var frame in shape.Frames)
-                {
-                    mesh.AddBlendShapeFrame(
-                        shape.Name,
-                        frame.Weight,
-                        frame.DeltaVertices,
-                        frame.DeltaNormals,
-                        frame.DeltaTangents);
-                }
+                AppendBlendShape(mesh, shape);
             }
 
             return true;
@@ -1029,13 +1082,13 @@ namespace ARKitBlendShapeGenerator.Domain
         /// 再構築したときに統合されてしまう同名シェイプ（隣り合う同名の並び）を探す。
         /// 見つからなければnull。空名も統合の対象になるため同様に扱う
         /// </summary>
-        private static string FindAdjacentDuplicateName(List<BlendShapeData> preserved)
+        private static string FindAdjacentDuplicateName(List<BlendShapeData> shapes)
         {
-            for (int i = 1; i < preserved.Count; i++)
+            for (int i = 1; i < shapes.Count; i++)
             {
-                if (string.Equals(preserved[i - 1].Name, preserved[i].Name))
+                if (string.Equals(shapes[i - 1].Name, shapes[i].Name))
                 {
-                    return preserved[i].Name;
+                    return shapes[i].Name;
                 }
             }
 

--- a/Tests/Editor/BlendShapeGenerationEngineTests.cs
+++ b/Tests/Editor/BlendShapeGenerationEngineTests.cs
@@ -246,7 +246,9 @@ namespace ARKitBlendShapeGenerator.Tests
         [Test]
         public void Generate_KeepsShapeOrder_WhenOverwriteEnabled()
         {
-            // 再構築後も残ったシェイプの並びは元のまま、生成したシェイプが末尾へ追加される
+            // 上書きは削除+末尾追加ではなく元の位置での差し替えで行うため、置き換えた
+            // シェイプは末尾へ移動せず元の位置に留まる。並びを変えないことが、同名シェイプを
+            // 隣接させずに済ませる仕組みそのものになっている（#50）
             var source = new FakeMeshRepository(TwoVertices())
                 .AddShape("vrc.blink", Vector3.up, Vector3.up);
             var target = new FakeMeshRepository(TwoVertices())
@@ -260,8 +262,10 @@ namespace ARKitBlendShapeGenerator.Tests
                 source, target, null, AutoMapping("eyeBlinkLeft", 1.0f, "vrc.blink"), options, null);
 
             Assert.That(result.ShapeIndices["笑い"], Is.EqualTo(0));
-            Assert.That(result.ShapeIndices["怒り"], Is.EqualTo(1));
-            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(2));
+            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(1));
+            Assert.That(result.ShapeIndices["怒り"], Is.EqualTo(2));
+            // 差し替えなので中身は新しいデルタになっている
+            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
         }
 
         [Test]

--- a/Tests/Editor/DuplicateShapeNameTests.cs
+++ b/Tests/Editor/DuplicateShapeNameTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 同名のシェイプキーを複数持つメッシュでの上書き生成を検証する。
+    ///
+    /// AddBlendShapeFrame は名前をキーにするうえ、同名シェイプのフレームウェイトは昇順を
+    /// 要求するため、同名シェイプが隣接するとデルタが失われる。そこで上書きは削除+末尾追加
+    /// ではなく元の位置での差し替えで行い、並びを変えないことで隣接を新たに生じさせない。
+    /// </summary>
+    public class DuplicateShapeNameTests
+    {
+        private static Vector3[] TwoVertices() => new[]
+        {
+            new Vector3(-1f, 0f, 0f),
+            new Vector3(1f, 0f, 0f),
+        };
+
+        private static BlendShapeGenerationOptions CreateOverwriteOptions()
+        {
+            return new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = 1.0f,
+                EnableLeftRightSplit = false,
+                BlendWidth = 0.02f,
+                OverwriteExisting = true,
+            };
+        }
+
+        private static List<ARKitMapping> AutoMapping(string arkitName, string sourceName)
+        {
+            return new List<ARKitMapping>
+            {
+                new ARKitMapping(arkitName, new List<SourceMapping>
+                {
+                    new SourceMapping(1.0f, sourceName),
+                }),
+            };
+        }
+
+        private static FakeMeshRepository SourceMesh()
+        {
+            return new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+        }
+
+        [Test]
+        public void Generate_KeepsSameNamedShapesSeparate_WhenOverwritingTheShapeBetweenThem()
+        {
+            // 同名シェイプに挟まれた対象を上書きする。削除すると両者が隣接して統合されるが、
+            // その場で差し替えるため並びが変わらず、どちらも元のデルタを保ったまま残る
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("dup", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("dup", Vector3.back, Vector3.back);
+
+            var result = BlendShapeGenerationEngine.Generate(
+                SourceMesh(), target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOverwriteOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+            Assert.That(target.CountShapes("dup"), Is.EqualTo(2));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(target.Shapes[2].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.back));
+        }
+
+        [Test]
+        public void Generate_KeepsShapeOrder_WhenOverwriting()
+        {
+            // 置き換えた対象は末尾へ移動せず元の位置に留まる。
+            // 並びが変わらないことが、同名シェイプを隣接させない仕組みそのものになっている
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("other", Vector3.forward, Vector3.forward);
+
+            var result = BlendShapeGenerationEngine.Generate(
+                SourceMesh(), target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOverwriteOptions(), null);
+
+            Assert.That(target.Shapes[0].Name, Is.EqualTo("eyeBlinkLeft"));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            Assert.That(target.Shapes[1].Name, Is.EqualTo("other"));
+            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(0));
+            Assert.That(result.ShapeIndices["other"], Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Generate_ReplacesEveryOccurrence_OfTheSameName()
+        {
+            // 同じ名前のシェイプが複数ある場合はすべて差し替える。
+            // 片方だけ残すと「上書きしたのに古いデータが残る」状態になる
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("other", Vector3.forward, Vector3.forward)
+                .AddShape("eyeBlinkLeft", Vector3.back, Vector3.back);
+
+            BlendShapeGenerationEngine.Generate(
+                SourceMesh(), target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOverwriteOptions(), null);
+
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+            Assert.That(target.CountShapes("eyeBlinkLeft"), Is.EqualTo(2));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            Assert.That(target.Shapes[2].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+        }
+
+        [Test]
+        public void Generate_DoesNotRebuild_WhenNothingIsReplaced()
+        {
+            // 置き換えが無ければ再構築しないので、元から同名が隣接していても影響を受けない
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddDistinctShape("dup", Vector3.forward)
+                .AddDistinctShape("dup", Vector3.back);
+
+            var result = BlendShapeGenerationEngine.Generate(
+                SourceMesh(), target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOverwriteOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+            Assert.That(target.CountShapes("dup"), Is.EqualTo(2));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(target.Shapes[1].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.back));
+        }
+
+        [Test]
+        public void Generate_AbortsOverwrite_WhenMeshAlreadyHasAdjacentDuplicates()
+        {
+            // 元から同名シェイプが隣接しているメッシュ（FBXインポート等）は、再構築すると
+            // 統合されてデルタを失う。差し替えでは解消できないため、メッシュへ触れずに中止する
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddDistinctShape("dup", Vector3.forward)
+                .AddDistinctShape("dup", Vector3.back)
+                .AddDistinctShape("eyeBlinkLeft", Vector3.right);
+
+            var result = BlendShapeGenerationEngine.Generate(
+                SourceMesh(), target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOverwriteOptions(), null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+
+            // メッシュは一切変更されない
+            Assert.That(target.Shapes.Count, Is.EqualTo(3));
+            Assert.That(target.CountShapes("dup"), Is.EqualTo(2));
+            Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
+            Assert.That(target.Shapes[1].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.back));
+            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.right));
+        }
+    }
+}

--- a/Tests/Editor/EmptyNameBlendShapeTests.cs
+++ b/Tests/Editor/EmptyNameBlendShapeTests.cs
@@ -125,64 +125,39 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
-        public void Generate_AbortsOverwrite_WhenRebuildWouldMergeSameNamedShapes()
+        public void Generate_KeepsBothEmptyNamedShapes_WhenOverwritingTheShapeBetweenThem()
         {
-            // 削除によって同名シェイプ（ここでは空名）が隣接する配置。
-            // AddBlendShapeFrame は名前をキーにし、同名シェイプのフレームウェイトは昇順を要求するため、
-            // 再構築すると2つ目の同一ウェイトのフレームが追加されずデルタが失われる。
-            // メッシュを壊さないよう、変更を加える前に検出して生成自体を中止する。
+            // 空名シェイプに挟まれた対象を上書きするケース。
+            // 削除して末尾へ追加し直すと、空いた隙間で空名シェイプが隣接して統合されるため、
+            // その場で差し替えて並びを保つ（同名シェイプの扱いは #50 / DuplicateShapeNameTests）
             var source = new FakeMeshRepository(TwoVertices())
                 .AddShape("vrc.blink", Vector3.up, Vector3.up);
-            // 構築時点では削除対象が間に挟まるため、空名シェイプは別々のシェイプになる
             var target = new FakeMeshRepository(TwoVertices())
                 .AddShape("", Vector3.forward, Vector3.forward)
                 .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
-                .AddShape("", Vector3.up, Vector3.up);
+                .AddShape("", Vector3.back, Vector3.back);
             var options = CreateOptions();
             options.OverwriteExisting = true;
-
-            Assert.That(target.CountShapes(""), Is.EqualTo(2), "前提: 削除前は空名シェイプが2つある");
 
             var result = BlendShapeGenerationEngine.Generate(
                 source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
 
-            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
 
-            // メッシュは一切変更されない（ClearBlendShapesまで到達しない）
+            // 空名シェイプは2つとも、それぞれのデルタを保ったまま残る
             Assert.That(target.Shapes.Count, Is.EqualTo(3));
             Assert.That(target.CountShapes(""), Is.EqualTo(2));
             Assert.That(target.Shapes[0].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.forward));
-            Assert.That(target.Shapes[2].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
-            // 置き換え対象も残したままにする
-            Assert.That(target.FindShape("eyeBlinkLeft").Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.right));
+            Assert.That(target.Shapes[2].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.back));
+            // 対象は元の位置のまま新しいデルタへ差し替わる
+            Assert.That(target.Shapes[1].Name, Is.EqualTo("eyeBlinkLeft"));
+            Assert.That(target.Shapes[1].Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
         }
 
         [Test]
-        public void Generate_AbortsOverwrite_WhenSameNamedShapesAreAlreadyAdjacent()
+        public void Generate_ProceedsWithOverwrite_WhenShapeNamesAreUnique()
         {
-            // 同名の非空シェイプが隣接する場合も同じく中止する（空名固有の問題ではない）。
-            // FakeMeshRepositoryでは連続追加が統合されるため、間に別シェイプを挟んで構築する
-            var source = new FakeMeshRepository(TwoVertices())
-                .AddShape("vrc.blink", Vector3.up, Vector3.up);
-            var target = new FakeMeshRepository(TwoVertices())
-                .AddShape("dup", Vector3.forward, Vector3.forward)
-                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
-                .AddShape("dup", Vector3.up, Vector3.up);
-            var options = CreateOptions();
-            options.OverwriteExisting = true;
-
-            var result = BlendShapeGenerationEngine.Generate(
-                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
-
-            Assert.That(result.GeneratedShapes, Is.Empty);
-            Assert.That(target.Shapes.Count, Is.EqualTo(3));
-            Assert.That(target.CountShapes("dup"), Is.EqualTo(2));
-        }
-
-        [Test]
-        public void Generate_ProceedsWithOverwrite_WhenRemainingShapeNamesAreUnique()
-        {
-            // 同名シェイプが無ければ従来どおり上書きされる（中止判定が過剰に効かないこと）
+            // 同名シェイプが無い通常のケースでも従来どおり上書きされる
             var source = new FakeMeshRepository(TwoVertices())
                 .AddShape("vrc.blink", Vector3.up, Vector3.up);
             var target = new FakeMeshRepository(TwoVertices())

--- a/Tests/Editor/FakeMeshRepository.cs
+++ b/Tests/Editor/FakeMeshRepository.cs
@@ -109,6 +109,24 @@ namespace ARKitBlendShapeGenerator.Tests
             return this;
         }
 
+        /// <summary>
+        /// 直前と同名でも必ず別のシェイプとして追加するテスト用ヘルパー。
+        /// AddBlendShapeFrameは同名連続を1つのシェイプへまとめるため、この経路では
+        /// 同名シェイプが隣接したメッシュを作れない。FBXインポート等、そのAPIを
+        /// 経由せずに作られたメッシュを再現するために使う
+        /// </summary>
+        public FakeMeshRepository AddDistinctShape(string name, params Vector3[] deltaVertices)
+        {
+            var shape = new Shape(name);
+            Shapes.Add(shape);
+            shape.Frames.Add(new Frame(
+                100f,
+                Copy(deltaVertices),
+                new Vector3[VertexCount],
+                new Vector3[VertexCount]));
+            return this;
+        }
+
         public Shape FindShape(string name) => Shapes.Find(s => s.Name == name);
 
         public int CountShapes(string name) => Shapes.FindAll(s => s.Name == name).Count;


### PR DESCRIPTION
## 概要

Closes #50

同名のシェイプキーを複数持つメッシュでも「既存を上書き」が使えるようにする。

#48 では、統合されてデータを失う配置を検出して**上書き自体を中止**していた。安全側の措置としては正しいが、該当メッシュでは上書き機能が使えないままだった。本PRはその制限を解消する。

## 原因は削除の実装方法だった

`AddBlendShapeFrame` が名前をキーにすることは変えられません。しかし**統合が起きるのは同名シェイプが隣接したときだけ**で、隣接は削除の副作用として生じていました。

```
["dup", "eyeBlinkLeft", "dup"]
  → eyeBlinkLeft を削除     → ["dup", "dup"]      ← ここで隣接する
  → 末尾へ新しい eyeBlinkLeft を追加
  → 再構築時に dup が1つへ統合され、2つ目のデルタが失われる
```

対象を削除して末尾へ追加し直すのをやめ、**元の位置で差し替える**ようにしました。並びが変わらないので隣接が新たに生じることはなく、同名シェイプはそのまま分離された状態で残ります。

```
["dup", "eyeBlinkLeft", "dup"]
  → eyeBlinkLeft を新しいデルタへその場で差し替え
  → ["dup", "eyeBlinkLeft(新)", "dup"]           ← 隣接しない
```

API の制限を回避するのではなく、**制限に触れない書き方に変える**のが解になっています。

## ⚠️ 挙動の変更: 上書きしたシェイプが末尾へ移動しなくなる

並びを変えないことが本修正の仕組みそのものなので、**置き換えたシェイプは元の位置に留まります**。

`Generate_KeepsShapeOrder_WhenOverwriteEnabled`（#51 で追加）は「残ったシェイプの並びは元のまま、生成したシェイプが末尾へ追加される」を仕様として固定していましたが、これは削除+末尾追加という実装方法に由来する挙動でした。この契約は維持できないため、期待値を更新しています。

```
["笑い", "eyeBlinkLeft", "怒り"] を eyeBlinkLeft で上書きしたとき

変更前: 笑い=0, 怒り=1, eyeBlinkLeft=2   ← 末尾へ移動
変更後: 笑い=0, eyeBlinkLeft=1, 怒り=2   ← 元の位置
```

上書きの前後でインデックスが安定する方向の変更であり、退行ではないと考えています。インデックスを直接指定して `SetBlendShapeWeight` を呼ぶ外部スクリプトがあった場合、従来はずれていたものがずれなくなります。ただし意図的に末尾へ寄せていた理由があれば教えてください。

## 変更内容

- `TryRemoveBlendShapesByNames` → `TryReplaceBlendShapesInPlace`。対象を新しいデルタへ差し替えつつ、元の並びで再構築する。
- `TryAddBlendShape` → `TryBuildBlendShape` に分割し、メッシュへ書き込む前に生成内容を確定させる。差し替えには全デルタが先に揃っている必要がある。
- 手続き的生成（`GenerateProceduralMouthShapes`）も同じ経路に揃えた。
- 中止する条件を「**元から同名シェイプが隣接しているメッシュ**」だけに限定した。

### 同じ名前のシェイプが複数ある場合

そのすべてを差し替えます。片方だけ残すと「上書きしたのに古いデータが残る」状態になるためです。

### 中止が残る条件

元から同名シェイプが隣接しているメッシュは、差し替えでも救えません（再構築すると統合される）。この配置は `AddBlendShapeFrame` 経由では作れないため、FBX インポート等でしか生じませんが、そのケースだけは従来どおりメッシュへ触れずに中止します。

## テスト

`DuplicateShapeNameTests` を追加しました。

- 同名シェイプに挟まれた対象を上書きしても、両者が分離されたままデルタを保つこと
- 上書きしたシェイプが元の位置に留まること
- 同じ名前のシェイプが複数ある場合、そのすべてが差し替わること
- 置き換えが無ければ再構築しないこと（元から隣接していても影響を受けない）
- 元から同名が隣接している場合のみ中止し、メッシュを一切変更しないこと

`FakeMeshRepository.AddDistinctShape` を追加しました。`AddBlendShapeFrame` は同名連続を1つのシェイプへまとめるため、この経路がないと「元から同名が隣接しているメッシュ」をテストで再現できません。FBX インポート等、その API を経由せずに作られたメッシュを表します。

既存テストの更新は2箇所です。

- `BlendShapeGenerationEngineTests.Generate_KeepsShapeOrder_WhenOverwriteEnabled`: 上記の並びの契約変更に伴う期待値の更新
- `EmptyNameBlendShapeTests`: 中止を期待していたケースを、差し替えでデータが保たれる期待に更新

`Generate_PreservesMultiFrameShape_WhenOverwriteEnabled`（多フレームの保持）は差し替え方式でもそのまま通ります。

**#58 で追加された EditMode テストの CI が本PRにも走り、全テストが通っています。**

## 完了条件の確認

- [x] 同名シェイプを含むメッシュで上書き生成した際の挙動が決定され、実装とテストに反映されている

## 未検証の点

CI（`FakeMeshRepository` を用いた EditMode テスト）で検証できているのは、差し替え方式が期待どおりに動くことまでです。次の1点は `FakeMeshRepository` がモデル化した前提のままで、実機の `UnityEngine.Mesh` では未確認です。

- `Mesh.AddBlendShapeFrame` が同名シェイプのフレームウェイトに昇順を要求すること。

ただし本PRは**この制約に触れない書き方へ変えるもの**なので、仮に制約が存在しなくても挙動は正しくなります。制約の有無は、中止が残る条件（元から同名が隣接しているメッシュ）が本当に必要かどうかにしか影響しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVT6dsweC6qwAHiWtZk8zv