### PR TITLE
test: シェイプ生成系のテストを整備する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,6 @@ Always review in Japanese.
   - .claude/skills/japanese-tech-writing
   - .claude/skills/cognitive-rhythm-writing
 
-## test
-
-- 生成ロジックのテストは `Tests/Editor` へEditModeテストとして置く
-  - メッシュ操作は `IMeshRepository` 越しに書き、テストは `FakeMeshRepository` へ差し替えて検証する
-- `Editor/` `Runtime/` を変更したらテストを追加または更新する
-- CIではテストを実行していないため、PRを出す前にUnityのTest RunnerでEditModeテストを実行する
-  - 手順はREADMEの「開発」を参照
-  - 実行できない環境で作業した場合はその旨をPR本文に書く
-
 ## github
 
 - 機能実装時はデフォルトブランチへのPRを作成する

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@ Always review in Japanese.
   - .claude/skills/japanese-tech-writing
   - .claude/skills/cognitive-rhythm-writing
 
+## test
+
+- 生成ロジックのテストは `Tests/Editor` へEditModeテストとして置く
+  - メッシュ操作は `IMeshRepository` 越しに書き、テストは `FakeMeshRepository` へ差し替えて検証する
+- `Editor/` `Runtime/` を変更したらテストを追加または更新する
+- CIではテストを実行していないため、PRを出す前にUnityのTest RunnerでEditModeテストを実行する
+  - 手順はREADMEの「開発」を参照
+  - 実行できない環境で作業した場合はその旨をPR本文に書く
+
 ## github
 
 - 機能実装時はデフォルトブランチへのPRを作成する

--- a/README.md
+++ b/README.md
@@ -110,6 +110,32 @@ VRChat/MMDの標準的なBlendShape名（vrc.blink, まばたき, あ, い, う�
 
 BlendShapeは線形合成されるため、焼き込み先を複数選ぶと、それらが同時に適用されたときに打ち消しが重なって対象の変形を通り越し、逆向きに変形します。焼き込み先は必要最小限（多くの場合は `jawOpen` のみ）に絞ってください。打ち消し量は `Mouth Cancellation Strength` で弱めることもできます。
 
+## 開発
+
+### テスト
+
+生成ロジックのテストは `Tests/Editor` にEditModeテストとして置いています。
+メッシュの読み書きは `IMeshRepository` 越しに行っているため、テストでは `UnityEngine.Mesh` を使わずインメモリ実装（`FakeMeshRepository`）へ差し替えて検証します。
+
+テストはCIでは実行していません。
+`Editor/` `Runtime/` を変更したときは、PRを出す前に手元で実行してください。
+
+1. このリポジトリをUnityプロジェクトの `Packages/` 以下へ配置する（VCC/ALCOM経由で導入したものは書き換えられないため、開発時はクローンを直接置く）
+2. `Packages/manifest.json` の `testables` にパッケージ名を追加する
+
+    ```json
+    {
+      "dependencies": { },
+      "testables": [ "com.qazx7412.kx-vrc-arkit-blendshape-generator" ]
+    }
+    ```
+
+3. Unityメニュー > Window > General > Test Runner を開く
+4. EditModeタブで `ARKitBlendShapeGenerator.Editor.Tests` を実行する
+
+`testables` へ追加しないとテストアセンブリがコンパイルされず、Test Runnerの一覧にも現れません。
+テストは配布物には含みません（リリース用のzipへ入れるのは `package.json` と `Runtime/` `Editor/` だけです）。
+
 ## ライセンス
 
 MIT License

--- a/Tests/Editor/ARKitBlendShapeGenerator.Editor.Tests.asmdef
+++ b/Tests/Editor/ARKitBlendShapeGenerator.Editor.Tests.asmdef
@@ -5,7 +5,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "ARKitBlendShapeGenerator.Editor",
-        "ARKitBlendShapeGenerator.Runtime"
+        "ARKitBlendShapeGenerator.Runtime",
+        "VRC.SDKBase"
     ],
     "includePlatforms": [
         "Editor"

--- a/Tests/Editor/BlendShapeGenerationEngineTests.cs
+++ b/Tests/Editor/BlendShapeGenerationEngineTests.cs
@@ -162,6 +162,53 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
+        public void Generate_PreservesMultiFrameShape_WhenOverwriteEnabled()
+        {
+            // 上書きは削除・再構築で行うため、置き換え対象でないシェイプのフレーム構成が
+            // 崩れていないことを確認する
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShapeFrame("表情", 50f, new Vector3(0f, 0.2f, 0f), new Vector3(0f, 0.2f, 0f))
+                .AddShapeFrame("表情", 100f, new Vector3(0f, 1.0f, 0f), new Vector3(0f, 1.0f, 0f))
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right);
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", 1.0f, "vrc.blink"), options, null);
+
+            var preserved = target.FindShape("表情");
+            Assert.That(target.CountShapes("表情"), Is.EqualTo(1));
+            Assert.That(preserved.Frames.Count, Is.EqualTo(2));
+            Assert.That(preserved.Frames[0].Weight, Is.EqualTo(50f));
+            Assert.That(preserved.Frames[1].Weight, Is.EqualTo(100f));
+            Assert.That(preserved.Frames[0].DeltaVertices[0], Is.EqualTo(new Vector3(0f, 0.2f, 0f)));
+            Assert.That(preserved.Frames[1].DeltaVertices[0], Is.EqualTo(new Vector3(0f, 1.0f, 0f)));
+        }
+
+        [Test]
+        public void Generate_KeepsShapeOrder_WhenOverwriteEnabled()
+        {
+            // 再構築後も残ったシェイプの並びは元のまま、生成したシェイプが末尾へ追加される
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("笑い", Vector3.up, Vector3.up)
+                .AddShape("eyeBlinkLeft", Vector3.right, Vector3.right)
+                .AddShape("怒り", Vector3.forward, Vector3.forward);
+            var options = CreateOptions();
+            options.OverwriteExisting = true;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", 1.0f, "vrc.blink"), options, null);
+
+            Assert.That(result.ShapeIndices["笑い"], Is.EqualTo(0));
+            Assert.That(result.ShapeIndices["怒り"], Is.EqualTo(1));
+            Assert.That(result.ShapeIndices["eyeBlinkLeft"], Is.EqualTo(2));
+        }
+
+        [Test]
         public void Generate_SkipsAutoMapping_WhenSourceShapeMissing()
         {
             var source = new FakeMeshRepository(TwoVertices())

--- a/Tests/Editor/BlendShapeGenerationOptionsTests.cs
+++ b/Tests/Editor/BlendShapeGenerationOptionsTests.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// コンポーネントの設定値から生成オプションへの変換の検証。
+    /// 設定項目を増やしたときに変換の追加を忘れると、インスペクタの操作が生成へ届かなくなる。
+    /// </summary>
+    public class BlendShapeGenerationOptionsTests
+    {
+        private GameObject _gameObject;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_gameObject != null)
+            {
+                Object.DestroyImmediate(_gameObject);
+                _gameObject = null;
+            }
+        }
+
+        private ARKitBlendShapeGeneratorComponent CreateComponent()
+        {
+            _gameObject = new GameObject("Avatar");
+            return _gameObject.AddComponent<ARKitBlendShapeGeneratorComponent>();
+        }
+
+        [Test]
+        public void FromComponent_CopiesGenerationSettings()
+        {
+            var component = CreateComponent();
+            component.intensityMultiplier = 0.8f;
+            component.enableLeftRightSplit = false;
+            component.blendWidth = 0.05f;
+            component.overwriteExisting = true;
+            component.enableProceduralMouthShapes = true;
+            component.proceduralMouthIntensity = 1.4f;
+            component.debugMode = true;
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.IntensityMultiplier, Is.EqualTo(0.8f));
+            Assert.That(options.EnableLeftRightSplit, Is.False);
+            Assert.That(options.BlendWidth, Is.EqualTo(0.05f));
+            Assert.That(options.OverwriteExisting, Is.True);
+            Assert.That(options.EnableProceduralMouthShapes, Is.True);
+            Assert.That(options.ProceduralMouthIntensity, Is.EqualTo(1.4f));
+            Assert.That(options.Debug, Is.True);
+        }
+
+        [Test]
+        public void FromComponent_CopiesMouthCancellationSettings()
+        {
+            var component = CreateComponent();
+            component.enableMouthCancellation = true;
+            component.mouthCancellationStrength = 0.6f;
+            component.mouthCancellationSources = new List<BlendShapeSource>
+            {
+                new BlendShapeSource { blendShapeName = "口開き", weight = 0.5f, side = BlendShapeSide.LeftOnly },
+            };
+            component.mouthCancellationTargets = new List<string> { "jawOpen", "mouthFunnel" };
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.EnableMouthCancellation, Is.True);
+            Assert.That(options.MouthCancellationStrength, Is.EqualTo(0.6f));
+            Assert.That(options.MouthCancellationSources, Is.SameAs(component.mouthCancellationSources));
+            Assert.That(options.MouthCancellationTargets, Is.EquivalentTo(new[] { "jawOpen", "mouthFunnel" }));
+        }
+
+        [Test]
+        public void FromComponent_IgnoresBlankCancellationTargets()
+        {
+            // 空白のみの項目は未設定として扱う。名前自体は加工せず、照合は完全一致で行う
+            var component = CreateComponent();
+            component.mouthCancellationTargets = new List<string> { "jawOpen", "", "   ", null, " mouthFunnel" };
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.MouthCancellationTargets, Is.EquivalentTo(new[] { "jawOpen", " mouthFunnel" }));
+        }
+
+        [Test]
+        public void FromComponent_ReturnsEmptyTargets_WhenTargetListIsNull()
+        {
+            var component = CreateComponent();
+            component.mouthCancellationTargets = null;
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.MouthCancellationTargets, Is.Empty);
+        }
+    }
+}

--- a/Tests/Editor/GenerateBlendShapesUseCaseTests.cs
+++ b/Tests/Editor/GenerateBlendShapesUseCaseTests.cs
@@ -99,7 +99,7 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
-        public void SelectPrimaryComponent_SkipsNullEntries()
+        public void SelectPrimaryComponent_SkipsNullEntries_WhileSearchingAvatarRoot()
         {
             var root = CreateComponent("Avatar");
 
@@ -107,7 +107,24 @@ namespace ARKitBlendShapeGenerator.Tests
                 root.transform,
                 new List<ARKitBlendShapeGeneratorComponent> { null, root });
 
+            // nullを踏んでもTransformの比較へ進まず、後続のルート直付けを見つける
             Assert.That(primary, Is.SameAs(root));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsFirstEntryAsIs_WhenNoComponentIsOnAvatarRoot()
+        {
+            var avatarRoot = new GameObject("Avatar");
+            _created.Add(avatarRoot);
+            var face = CreateComponent("Face");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                avatarRoot.transform,
+                new List<ARKitBlendShapeGeneratorComponent> { null, face });
+
+            // ルート直付けが無いときのフォールバックは先頭をそのまま返す。
+            // nullを除くのは呼び出し側の責務で、現在の呼び出し3経路はいずれも渡す前に除いている
+            Assert.That(primary, Is.Null);
         }
 
         [Test]

--- a/Tests/Editor/GenerateBlendShapesUseCaseTests.cs
+++ b/Tests/Editor/GenerateBlendShapesUseCaseTests.cs
@@ -1,0 +1,139 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.UseCase;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 処理対象コンポーネントの選定の検証。
+    ///
+    /// 各コンポーネントは別々のルートへ配置している。
+    /// 同一階層に複数置くと重複コンポーネントガードが働き、選定ロジックとは別の要因で結果が変わるため。
+    /// 選定はTransformの一致だけで決まるので、階層を組まなくても仕様は確認できる。
+    /// </summary>
+    public class GenerateBlendShapesUseCaseTests
+    {
+        private readonly List<GameObject> _created = new List<GameObject>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var gameObject in _created)
+            {
+                if (gameObject != null)
+                {
+                    Object.DestroyImmediate(gameObject);
+                }
+            }
+
+            _created.Clear();
+        }
+
+        private ARKitBlendShapeGeneratorComponent CreateComponent(string name)
+        {
+            var gameObject = new GameObject(name);
+            _created.Add(gameObject);
+            return gameObject.AddComponent<ARKitBlendShapeGeneratorComponent>();
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsNull_WhenComponentsAreNull()
+        {
+            var avatarRoot = CreateComponent("Avatar").transform;
+
+            Assert.That(GenerateBlendShapesUseCase.SelectPrimaryComponent(avatarRoot, null), Is.Null);
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsNull_WhenComponentsAreEmpty()
+        {
+            var avatarRoot = CreateComponent("Avatar").transform;
+
+            Assert.That(
+                GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                    avatarRoot, new List<ARKitBlendShapeGeneratorComponent>()),
+                Is.Null);
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_PrefersComponentOnAvatarRoot()
+        {
+            var face = CreateComponent("Face");
+            var root = CreateComponent("Avatar");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                root.transform,
+                new List<ARKitBlendShapeGeneratorComponent> { face, root });
+
+            // 先頭ではなくアバタールート直付けのものが選ばれる
+            Assert.That(primary, Is.SameAs(root));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsFirst_WhenNoComponentIsOnAvatarRoot()
+        {
+            var avatarRoot = new GameObject("Avatar");
+            _created.Add(avatarRoot);
+            var face = CreateComponent("Face");
+            var hair = CreateComponent("Hair");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                avatarRoot.transform,
+                new List<ARKitBlendShapeGeneratorComponent> { face, hair });
+
+            Assert.That(primary, Is.SameAs(face));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsFirst_WhenAvatarRootIsNull()
+        {
+            var face = CreateComponent("Face");
+            var root = CreateComponent("Avatar");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                (Transform)null,
+                new List<ARKitBlendShapeGeneratorComponent> { face, root });
+
+            Assert.That(primary, Is.SameAs(face));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_SkipsNullEntries()
+        {
+            var root = CreateComponent("Avatar");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                root.transform,
+                new List<ARKitBlendShapeGeneratorComponent> { null, root });
+
+            Assert.That(primary, Is.SameAs(root));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_AcceptsGameObjectAsAvatarRoot()
+        {
+            var face = CreateComponent("Face");
+            var root = CreateComponent("Avatar");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                root.gameObject,
+                new List<ARKitBlendShapeGeneratorComponent> { face, root });
+
+            Assert.That(primary, Is.SameAs(root));
+        }
+
+        [Test]
+        public void SelectPrimaryComponent_ReturnsFirst_WhenAvatarRootGameObjectIsNull()
+        {
+            var face = CreateComponent("Face");
+            var root = CreateComponent("Avatar");
+
+            var primary = GenerateBlendShapesUseCase.SelectPrimaryComponent(
+                (GameObject)null,
+                new List<ARKitBlendShapeGeneratorComponent> { face, root });
+
+            Assert.That(primary, Is.SameAs(face));
+        }
+    }
+}

--- a/Tests/Editor/MouthCancellationTests.cs
+++ b/Tests/Editor/MouthCancellationTests.cs
@@ -130,6 +130,64 @@ namespace ARKitBlendShapeGenerator.Tests
         }
 
         [Test]
+        public void Generate_ExtrapolatesCancellationSource_AboveHighestFrameWeight()
+        {
+            // 多フレーム（50→+0.2, 100→+1.0）の打ち消し元をweight150で評価すると、
+            // 最終フレームでクランプせず外挿して +1.8 になる。
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShapeFrame("口開き", 50f, new Vector3(0f, 0.2f, 0f), new Vector3(0f, 0.2f, 0f))
+                .AddShapeFrame("口開き", 100f, new Vector3(0f, 1.0f, 0f), new Vector3(0f, 1.0f, 0f));
+            var target = new FakeMeshRepository(TwoVertices());
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("jawOpen", "あ"),
+                CreateOptions("口開き", 1.5f, "jawOpen"), null);
+
+            var shape = target.FindShape("jawOpen");
+            // 生成デルタ(+1.0) + 打ち消し(-1.8) = -0.8
+            Assert.That(shape.Frames[0].DeltaVertices[0].y, Is.EqualTo(-0.8f).Within(0.0001f));
+        }
+
+        [Test]
+        public void Generate_EvaluatesCancellationSource_AtNegativeWeight()
+        {
+            // 打ち消し元をマイナス方向に適用しているアバターを想定する。
+            // 評価ウェイト-50での変形は-0.2となり、その逆方向（+0.2）が焼き込まれる。
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShape("口開き", new Vector3(0f, 0.4f, 0f), new Vector3(0f, 0.4f, 0f));
+            var target = new FakeMeshRepository(TwoVertices());
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("jawOpen", "あ"),
+                CreateOptions("口開き", -0.5f, "jawOpen"), null);
+
+            var shape = target.FindShape("jawOpen");
+            // 生成デルタ(+1.0) + 打ち消し(+0.2) = +1.2
+            Assert.That(shape.Frames[0].DeltaVertices[0].y, Is.EqualTo(1.2f).Within(0.0001f));
+        }
+
+        [Test]
+        public void Generate_EvaluatesCancellationSource_WithNegativeFrameWeight()
+        {
+            // フレームウェイトが負のシェイプキー。評価ウェイト-50は
+            // 変形なし(0)とweight-100フレームの補間になり、デルタは半分。
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("あ", Vector3.up, Vector3.up)
+                .AddShapeFrame("口開き", -100f, new Vector3(0f, 0.4f, 0f), new Vector3(0f, 0.4f, 0f));
+            var target = new FakeMeshRepository(TwoVertices());
+
+            BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("jawOpen", "あ"),
+                CreateOptions("口開き", -0.5f, "jawOpen"), null);
+
+            var shape = target.FindShape("jawOpen");
+            // 生成デルタ(+1.0) + 打ち消し(-0.4 * 0.5) = +0.8
+            Assert.That(shape.Frames[0].DeltaVertices[0].y, Is.EqualTo(0.8f).Within(0.0001f));
+        }
+
+        [Test]
         public void Generate_AppliesCancellationStrength()
         {
             var source = new FakeMeshRepository(TwoVertices())

--- a/Tests/Editor/ProceduralMouthShapeGeneratorTests.cs
+++ b/Tests/Editor/ProceduralMouthShapeGeneratorTests.cs
@@ -1,0 +1,470 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 口周りBlendShapeの手続き的生成の検証。
+    ///
+    /// 口領域の検出（マスク生成）と、検出した領域に対する頂点移動の2段階を分けて確認する。
+    /// テスト用のメッシュは口領域を模した直方体（左右2 × 上下2 × 前後2の8頂点）に、
+    /// 口から離れた頂点を1つ足した構成にしてある。
+    /// </summary>
+    public class ProceduralMouthShapeGeneratorTests
+    {
+        // 口領域の直方体の広がり。X方向の幅（SideX * 2）が移動量の基準になる
+        private const float SideX = 0.05f;
+        private const float UpperY = 0.01f;
+        private const float LowerY = -0.01f;
+        private const float FrontZ = 0.05f;
+        private const float BackZ = 0f;
+
+        private const float MouthWidth = SideX * 2f;
+
+        // 口領域検出に使うシェイプキーのデルタ量。全頂点で同じ量にして口領域ウェイトを1に揃える
+        private const float MouthSourceDelta = 0.02f;
+
+        // 移動量の比率と奥行き減衰（ProceduralMouthShapeGeneratorの定数に対応）
+        private const float MouthTranslateRatio = 0.12f;
+        private const float JawTranslateRatio = 0.20f;
+        private const float DepthFalloffMinScale = 0.3f;
+
+        // 頂点インデックス（Lは X < 0、Rは X > 0）
+        private const int UpperFrontL = 0;
+        private const int UpperFrontR = 1;
+        private const int LowerFrontL = 2;
+        private const int LowerFrontR = 3;
+        private const int UpperBackL = 4;
+        private const int UpperBackR = 5;
+        private const int LowerBackL = 6;
+
+        // 口領域の頂点数と、口から離れた頂点のインデックス
+        private const int RegionVertexCount = 8;
+        private const int OutsideVertex = 8;
+
+        private static Vector3[] MouthVertices() => new[]
+        {
+            new Vector3(-SideX, UpperY, FrontZ),
+            new Vector3(SideX, UpperY, FrontZ),
+            new Vector3(-SideX, LowerY, FrontZ),
+            new Vector3(SideX, LowerY, FrontZ),
+            new Vector3(-SideX, UpperY, BackZ),
+            new Vector3(SideX, UpperY, BackZ),
+            new Vector3(-SideX, LowerY, BackZ),
+            new Vector3(SideX, LowerY, BackZ),
+            new Vector3(0f, 0.5f, 0f),
+        };
+
+        /// <summary>口領域の8頂点だけを動かすシェイプキーを1つ持つメッシュ</summary>
+        private static FakeMeshRepository MouthMesh(string sourceShapeName = "vrc.v_aa")
+        {
+            return new FakeMeshRepository(MouthVertices())
+                .AddShape(sourceShapeName, RegionDeltas());
+        }
+
+        private static Vector3[] RegionDeltas()
+        {
+            var deltas = new Vector3[MouthVertices().Length];
+            for (int i = 0; i < RegionVertexCount; i++)
+            {
+                deltas[i] = Vector3.down * MouthSourceDelta;
+            }
+
+            return deltas;
+        }
+
+        private static BlendShapeGenerationOptions CreateOptions(bool enableLeftRightSplit = false)
+        {
+            return new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = 1.0f,
+                EnableLeftRightSplit = enableLeftRightSplit,
+                BlendWidth = 0.02f,
+                EnableProceduralMouthShapes = true,
+                ProceduralMouthIntensity = 1.0f,
+            };
+        }
+
+        private static ProceduralMouthShapeGenerator.MouthRegionContext CreateContext(
+            FakeMeshRepository mesh = null)
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryCreateContext(mesh ?? MouthMesh(), out var context),
+                Is.True,
+                "テストメッシュから口領域を検出できていない");
+            return context;
+        }
+
+        private static Vector3[] BuildDeltas(
+            string arkitName,
+            BlendShapeGenerationOptions options = null,
+            ProceduralMouthShapeGenerator.MouthRegionContext context = null)
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryBuildDeltaVertices(
+                    context ?? CreateContext(),
+                    arkitName,
+                    options ?? CreateOptions(),
+                    out var deltas),
+                Is.True,
+                $"{arkitName} のデルタを生成できていない");
+            return deltas;
+        }
+
+        [TestCase("vrc.v_aa")]
+        [TestCase("vrc_v_ou")]
+        [TestCase("あ")]
+        [TestCase("ん")]
+        [TestCase("E")]
+        public void HasMouthSource_ReturnsTrue_ForCandidateName(string shapeName)
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.HasMouthSource(new List<string> { "unrelated", shapeName }),
+                Is.True);
+        }
+
+        [Test]
+        public void HasMouthSource_ReturnsFalse_WhenNoCandidateExists()
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.HasMouthSource(new List<string> { "vrc.blink", "まばたき" }),
+                Is.False);
+        }
+
+        [Test]
+        public void HasMouthSource_ReturnsFalse_ForNullOrEmpty()
+        {
+            Assert.That(ProceduralMouthShapeGenerator.HasMouthSource(null), Is.False);
+            Assert.That(ProceduralMouthShapeGenerator.HasMouthSource(new List<string>()), Is.False);
+        }
+
+        [Test]
+        public void TryCreateContext_ReturnsFalse_ForNullMesh()
+        {
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(null, out var context), Is.False);
+            Assert.That(context, Is.Null);
+        }
+
+        [Test]
+        public void TryCreateContext_ReturnsFalse_WhenMeshHasNoVertices()
+        {
+            var mesh = new FakeMeshRepository(new Vector3[0]).AddShape("vrc.v_aa");
+
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(mesh, out _), Is.False);
+        }
+
+        [Test]
+        public void TryCreateContext_ReturnsFalse_WhenMouthSourceMissing()
+        {
+            // 口領域の検出に使えるシェイプキーが無いメッシュ
+            var mesh = new FakeMeshRepository(MouthVertices()).AddShape("vrc.blink", RegionDeltas());
+
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(mesh, out _), Is.False);
+        }
+
+        [Test]
+        public void TryCreateContext_ReturnsFalse_WhenMouthSourceHasNoDeformation()
+        {
+            // 名前は一致するがデルタが全て0のシェイプキーからは領域を決められない
+            var mesh = new FakeMeshRepository(MouthVertices())
+                .AddShape("vrc.v_aa", new Vector3[MouthVertices().Length]);
+
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(mesh, out _), Is.False);
+        }
+
+        [Test]
+        public void TryCreateContext_ReturnsFalse_WhenMouthRegionHasNoWidth()
+        {
+            // 口領域がX方向に広がりを持たない場合、移動量の基準となる幅が取れない
+            var vertices = new[]
+            {
+                new Vector3(0f, UpperY, FrontZ),
+                new Vector3(0f, LowerY, FrontZ),
+            };
+            var mesh = new FakeMeshRepository(vertices)
+                .AddShape("vrc.v_aa", Vector3.down * MouthSourceDelta, Vector3.down * MouthSourceDelta);
+
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(mesh, out _), Is.False);
+        }
+
+        [Test]
+        public void TryCreateContext_DetectsMouthRegion()
+        {
+            var context = CreateContext();
+
+            Assert.That(context.MouthWidth, Is.EqualTo(MouthWidth).Within(1e-6f));
+            for (int i = 0; i < RegionVertexCount; i++)
+            {
+                Assert.That(context.Weights[i], Is.EqualTo(1f).Within(1e-6f), $"頂点{i}が口領域に入っていない");
+            }
+
+            Assert.That(context.Weights[OutsideVertex], Is.EqualTo(0f).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryCreateContext_ExcludesVerticesFarFromCoreRegion()
+        {
+            // 顔全体が動くシェイプキーを想定し、口から離れた頂点にもわずかなデルタを持たせる。
+            // ウェイト自体は0より大きくなるが、コア領域のバウンディングボックス外なので除外される。
+            var deltas = RegionDeltas();
+            deltas[OutsideVertex] = Vector3.down * (MouthSourceDelta * 0.1f);
+            var mesh = new FakeMeshRepository(MouthVertices()).AddShape("vrc.v_aa", deltas);
+
+            var context = CreateContext(mesh);
+
+            Assert.That(context.Weights[OutsideVertex], Is.EqualTo(0f).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryCreateContext_SeparatesUpperAndLowerLip()
+        {
+            var context = CreateContext();
+
+            // 唇の境界線は口領域のウェイト付き重心Y（このメッシュではY=0）になる
+            Assert.That(context.LowerRatios[UpperFrontL], Is.EqualTo(0f).Within(1e-6f));
+            Assert.That(context.LowerRatios[UpperFrontR], Is.EqualTo(0f).Within(1e-6f));
+            Assert.That(context.LowerRatios[LowerFrontL], Is.EqualTo(1f).Within(1e-6f));
+            Assert.That(context.LowerRatios[LowerFrontR], Is.EqualTo(1f).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryCreateContext_AttenuatesDepth()
+        {
+            var context = CreateContext();
+
+            // 最前面は減衰なし、最奥はDepthFalloffMinScaleまで減衰する
+            Assert.That(context.DepthFactors[UpperFrontL], Is.EqualTo(1f).Within(1e-6f));
+            Assert.That(context.DepthFactors[UpperBackL], Is.EqualTo(DepthFalloffMinScale).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryCreateContext_UsesMultipleSourceGroups()
+        {
+            // グループごとに1つずつ拾うため、母音違いのシェイプキーが混在しても領域は合成される
+            var frontOnly = new Vector3[MouthVertices().Length];
+            frontOnly[UpperFrontL] = Vector3.down * MouthSourceDelta;
+            frontOnly[UpperFrontR] = Vector3.down * MouthSourceDelta;
+            var backOnly = new Vector3[MouthVertices().Length];
+            backOnly[UpperBackL] = Vector3.down * MouthSourceDelta;
+            backOnly[UpperBackR] = Vector3.down * MouthSourceDelta;
+
+            var mesh = new FakeMeshRepository(MouthVertices())
+                .AddShape("vrc.v_aa", frontOnly)
+                .AddShape("vrc.v_ou", backOnly);
+
+            Assert.That(ProceduralMouthShapeGenerator.TryCreateContext(mesh, out var context), Is.True);
+            Assert.That(context.Weights[UpperFrontL], Is.EqualTo(1f).Within(1e-6f));
+            Assert.That(context.Weights[UpperBackL], Is.EqualTo(1f).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_ReturnsFalse_ForUnknownName()
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryBuildDeltaVertices(
+                    CreateContext(), "eyeBlinkLeft", CreateOptions(), out var deltas),
+                Is.False);
+            Assert.That(deltas, Is.Null);
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_ReturnsFalse_ForNullArguments()
+        {
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryBuildDeltaVertices(
+                    null, "mouthLeft", CreateOptions(), out _),
+                Is.False);
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryBuildDeltaVertices(
+                    CreateContext(), "mouthLeft", null, out _),
+                Is.False);
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_ReturnsFalse_WhenIntensityIsZero()
+        {
+            var options = CreateOptions();
+            options.ProceduralMouthIntensity = 0f;
+
+            Assert.That(
+                ProceduralMouthShapeGenerator.TryBuildDeltaVertices(
+                    CreateContext(), "mouthLeft", options, out _),
+                Is.False);
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_SupportsAllTargetShapeNames()
+        {
+            // TargetShapeNamesに名前を足したのに移動定義を足し忘れる事故を防ぐ
+            var context = CreateContext();
+            var options = CreateOptions();
+
+            foreach (var arkitName in ProceduralMouthShapeGenerator.TargetShapeNames)
+            {
+                Assert.That(
+                    ProceduralMouthShapeGenerator.TryBuildDeltaVertices(context, arkitName, options, out _),
+                    Is.True,
+                    arkitName);
+            }
+        }
+
+        // アバターは+Zを向いている前提。左右分割の規約に合わせ、mouthLeftは-X方向へ動く
+        [TestCase("mouthLeft", -1f, 0f, 0f)]
+        [TestCase("mouthRight", 1f, 0f, 0f)]
+        [TestCase("jawLeft", -1f, 0f, 0f)]
+        [TestCase("jawRight", 1f, 0f, 0f)]
+        [TestCase("jawForward", 0f, 0f, 1f)]
+        [TestCase("mouthShrugUpper", 0f, 0f, 1f)]
+        [TestCase("mouthShrugLower", 0f, 0f, 1f)]
+        [TestCase("mouthUpperUpLeft", 0f, 1f, 0f)]
+        [TestCase("mouthUpperUpRight", 0f, 1f, 0f)]
+        [TestCase("mouthLowerDownLeft", 0f, -1f, 0f)]
+        [TestCase("mouthLowerDownRight", 0f, -1f, 0f)]
+        public void TryBuildDeltaVertices_MovesVerticesTowardDefinedDirection(
+            string arkitName, float x, float y, float z)
+        {
+            var expected = new Vector3(x, y, z);
+            var deltas = BuildDeltas(arkitName);
+
+            bool moved = false;
+            for (int i = 0; i < deltas.Length; i++)
+            {
+                if (deltas[i] == Vector3.zero)
+                {
+                    continue;
+                }
+
+                Assert.That(
+                    Vector3.Dot(deltas[i].normalized, expected),
+                    Is.EqualTo(1f).Within(1e-4f),
+                    $"{arkitName} の頂点{i}が想定と違う方向へ動いている");
+                moved = true;
+            }
+
+            Assert.That(moved, Is.True, $"{arkitName} でどの頂点も動いていない");
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_MovesMouthByWidthRatio()
+        {
+            var deltas = BuildDeltas("mouthLeft");
+
+            // 移動量は口領域の幅に対する比率で決まる
+            Assert.That(deltas[UpperFrontL].x, Is.EqualTo(-MouthWidth * MouthTranslateRatio).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_ScalesWithIntensityOptions()
+        {
+            var options = CreateOptions();
+            options.IntensityMultiplier = 0.5f;
+            options.ProceduralMouthIntensity = 1.5f;
+
+            var deltas = BuildDeltas("mouthLeft", options);
+
+            Assert.That(
+                deltas[UpperFrontL].x,
+                Is.EqualTo(-MouthWidth * MouthTranslateRatio * 0.5f * 1.5f).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_AppliesDepthFalloff()
+        {
+            var deltas = BuildDeltas("mouthLeft");
+
+            // 奥の頂点は前面より動きが小さくなり、単純な平行移動にならない
+            Assert.That(
+                deltas[UpperBackL].x,
+                Is.EqualTo(deltas[UpperFrontL].x * DepthFalloffMinScale).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_LeavesVerticesOutsideRegionUntouched()
+        {
+            var deltas = BuildDeltas("mouthLeft");
+
+            Assert.That(deltas[OutsideVertex], Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_IsSymmetric_BetweenLeftAndRight()
+        {
+            var left = BuildDeltas("mouthLeft");
+            var right = BuildDeltas("mouthRight");
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                Assert.That(right[i].x, Is.EqualTo(-left[i].x).Within(1e-6f), $"頂点{i}");
+            }
+        }
+
+        // 上唇側/下唇側のどちらを動かすかは唇の境界線で分ける
+        [TestCase("mouthLeft", true, true)]
+        [TestCase("jawLeft", false, true)]
+        [TestCase("jawForward", false, true)]
+        [TestCase("mouthShrugUpper", true, false)]
+        [TestCase("mouthShrugLower", false, true)]
+        [TestCase("mouthUpperUpLeft", true, false)]
+        [TestCase("mouthLowerDownLeft", false, true)]
+        public void TryBuildDeltaVertices_AppliesLipMask(string arkitName, bool movesUpper, bool movesLower)
+        {
+            // 左右分割は無効にして、唇の分離だけを見る
+            var deltas = BuildDeltas(arkitName);
+
+            Assert.That(deltas[UpperFrontL] != Vector3.zero, Is.EqualTo(movesUpper), "上唇側");
+            Assert.That(deltas[LowerFrontL] != Vector3.zero, Is.EqualTo(movesLower), "下唇側");
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_MovesJawByJawRatio()
+        {
+            var deltas = BuildDeltas("jawLeft");
+
+            Assert.That(deltas[LowerFrontL].x, Is.EqualTo(-MouthWidth * JawTranslateRatio).Within(1e-6f));
+        }
+
+        [TestCase("mouthUpperUpLeft", UpperFrontL, UpperFrontR)]
+        [TestCase("mouthLowerDownLeft", LowerFrontL, LowerFrontR)]
+        public void TryBuildDeltaVertices_AppliesLeftSideOnly_WhenSplitEnabled(
+            string arkitName, int leftVertex, int rightVertex)
+        {
+            var deltas = BuildDeltas(arkitName, CreateOptions(enableLeftRightSplit: true));
+
+            // LeftOnlyはX<0側にのみ適用される
+            Assert.That(deltas[leftVertex], Is.Not.EqualTo(Vector3.zero));
+            Assert.That(deltas[rightVertex], Is.EqualTo(Vector3.zero));
+        }
+
+        [TestCase("mouthUpperUpRight", UpperFrontR, UpperFrontL)]
+        [TestCase("mouthLowerDownRight", LowerFrontR, LowerFrontL)]
+        public void TryBuildDeltaVertices_AppliesRightSideOnly_WhenSplitEnabled(
+            string arkitName, int rightVertex, int leftVertex)
+        {
+            var deltas = BuildDeltas(arkitName, CreateOptions(enableLeftRightSplit: true));
+
+            Assert.That(deltas[rightVertex], Is.Not.EqualTo(Vector3.zero));
+            Assert.That(deltas[leftVertex], Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_IgnoresSide_WhenSplitDisabled()
+        {
+            var deltas = BuildDeltas("mouthUpperUpLeft");
+
+            // 左右分割が無効なら左右どちらの頂点も同じだけ動く
+            Assert.That(deltas[UpperFrontL].y, Is.GreaterThan(0f));
+            Assert.That(deltas[UpperFrontR].y, Is.EqualTo(deltas[UpperFrontL].y).Within(1e-6f));
+        }
+
+        [Test]
+        public void TryBuildDeltaVertices_KeepsUpperLipStill_ForLowerLipShapes()
+        {
+            var deltas = BuildDeltas("jawForward");
+
+            Assert.That(deltas[LowerBackL].z, Is.GreaterThan(0f));
+            Assert.That(deltas[UpperBackL], Is.EqualTo(Vector3.zero));
+        }
+    }
+}


### PR DESCRIPTION
Closes #42

## 変更内容

### `ProceduralMouthShapeGenerator` のテスト追加

`Tests/Editor/ProceduralMouthShapeGeneratorTests.cs`（新規）。
口領域を模した直方体（左右2 × 上下2 × 前後2の8頂点）に、口から離れた頂点を1つ足した `FakeMeshRepository` で検証する。

- `HasMouthSource`: 候補名の判定、候補なし・null・空の場合
- `TryCreateContext`: 領域ウェイト、上唇側/下唇側の分離、奥行き減衰係数、複数グループの合成、コア領域から離れた頂点の除外
- `TryCreateContext` の失敗系: メッシュがnull、頂点なし、口ソースなし、デルタが全て0、口領域に幅がない
- `TryBuildDeltaVertices`: `TargetShapeNames` 全11種の移動方向、移動量（口領域の幅に対する比率）、強度係数、奥行き減衰、左右対称性、唇マスク、左右分割の有無、領域外の頂点を動かさないこと

### `GenerateBlendShapesUseCase` のテスト追加

`Tests/Editor/GenerateBlendShapesUseCaseTests.cs`（新規）。
`SelectPrimaryComponent` のアバタールート直付け優先、null除外、Transform/GameObjectの両オーバーロードを固定する。

各コンポーネントは別々のルートへ置いている。
同一階層に複数置くと重複コンポーネントガードが働き、選定ロジックとは別の要因で結果が変わるため。
選定はTransformの一致だけで決まるので、階層を組まなくても仕様は確認できる。

`ResolveTargetRenderer` は #39 で仕様を統一してからテストする（#51 で対応中）。

### `BlendShapeGenerationOptions.FromComponent` のテスト追加

`Tests/Editor/BlendShapeGenerationOptionsTests.cs`（新規）。
設定項目を増やしたときに変換の追加を忘れると、インスペクタの操作が生成へ届かなくなるため、写しと打ち消し対象の空白除去を固定する。

### エンジンの未カバー分岐のテスト追加

- 上書き時の削除・再構築で、置き換え対象でない多フレームシェイプのフレームウェイトとデルタが保たれること
- 再構築後もシェイプの並びが保たれ、生成分が末尾へ追加されること
- 打ち消し元の評価が最終フレームを超えたときに外挿されること
- 評価ウェイトが負の場合と、フレームウェイトが負の場合の補間

### テスト実行手順の明記

CIでのテスト実行（issue #42 のプラン4）は見送り、READMEに手順を書いた。
game-ciでのEditModeテスト実行にはUnityライセンスのsecret登録が必要で、これはリポジトリ所有者の作業になるため。
このリポジトリはVPMパッケージであってUnityプロジェクトではないので、CIでは加えてテスト用プロジェクトの生成とVPM依存（VRChat SDK / NDMF）の解決も要る。
導入する場合は別途issueを立てる想定。

READMEには `Packages/manifest.json` の `testables` へパッケージ名を追加する手順も書いた。
これを忘れるとテストアセンブリがコンパイルされず、Test Runnerの一覧にも現れない。

## 影響範囲

`Editor/` `Runtime/` の変更なし。
`Tests/Editor` とドキュメントのみ。

テストアセンブリの `.asmdef` へ `VRC.SDKBase` の参照を足した。
`ARKitBlendShapeGeneratorComponent` が `IEditorOnly` を実装しているため、テストからコンポーネントを扱うのに必要になる。

## 未確認事項

この作業環境にUnityが無いため、テストは実行できていない。
マージ前にTest RunnerでEditModeテストを実行して確認をお願いします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6hVP9bjPofkaszwpJR7Vq)_