### PR TITLE
fix: 左右分割OFF時はSideのドロップダウンを非活性にする

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -54,7 +54,7 @@ msgid "prop.enable_left_right_split"
 msgstr "Left/Right Split"
 
 msgid "prop.enable_left_right_split.tooltip"
-msgstr "Generate left/right variants separately (e.g. blink). When off, the Side setting of custom mappings is ignored as well and every source is applied to both sides."
+msgstr "Split by the vertex X coordinate to generate left/right variants separately (e.g. blink). When off, the Side setting of custom mappings is ignored as well and every source is applied to both sides (the Side dropdown is shown disabled)."
 
 msgid "prop.blend_width"
 msgstr "Blend Width"
@@ -235,6 +235,9 @@ msgstr "Right Only"
 
 msgid "enum.side.tooltip"
 msgstr "Which half the source is applied to. Left Only = the avatar's left half (mesh local X < 0), Right Only = the right half (X > 0). Ignored while Left/Right Split is off."
+
+msgid "enum.side.split_off.tooltip"
+msgstr "Left/Right Split is off, so this setting is ignored during generation (the value itself is kept). Turn Left/Right Split on to apply it."
 
 msgid "enum.side.cancellation.tooltip"
 msgstr "Which half the cancellation is applied to. Left Only = the avatar's left half (mesh local X < 0), Right Only = the right half (X > 0). It represents how the blend shape is applied on the avatar, so it takes effect regardless of the Left/Right Split setting."

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -54,7 +54,7 @@ msgid "prop.enable_left_right_split"
 msgstr "左右分割"
 
 msgid "prop.enable_left_right_split.tooltip"
-msgstr "左右分割を有効にする（まばたき等を左右別々に生成）。OFFにするとカスタムマッピングのSide指定も無視され、両側に適用されます。"
+msgstr "頂点のX座標による左右分割を行う（まばたき等を左右別々に生成）。OFFにするとカスタムマッピングのSide指定も無視され、両側に適用されます（Sideのドロップダウンは非活性表示になります）。"
 
 msgid "prop.blend_width"
 msgstr "グラデーション幅"
@@ -235,6 +235,9 @@ msgstr "右のみ"
 
 msgid "enum.side.tooltip"
 msgstr "ソースを適用する左右の範囲。左のみ＝アバターから見て左半分（メッシュローカル座標のX<0）、右のみ＝右半分（X>0）。左右分割がOFFのときは無視されます。"
+
+msgid "enum.side.split_off.tooltip"
+msgstr "左右分割がOFFのため、この指定は生成時に無視されます（設定値は保持されます）。左右に分けて適用するには左右分割を有効にしてください。"
 
 msgid "enum.side.cancellation.tooltip"
 msgstr "打ち消しを適用する左右の範囲。左のみ＝アバターから見て左半分（メッシュローカル座標のX<0）、右のみ＝右半分（X>0）。アバター側での適用範囲を表すため、左右分割の設定に関わらず適用されます。"

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -577,7 +577,12 @@ namespace ARKitBlendShapeGenerator.Presentation
             // ソースBlendShape（ドロップダウンの左端をヘッダー行のARKit名に揃える）
             for (int j = 0; j < sourcesProperty.arraySize; j++)
             {
-                if (!DrawSourceItem(sourcesProperty, j, MappingToggleWidth))
+                // カスタムマッピングのSideは左右分割がOFFのとき生成側で無視される
+                if (!DrawSourceItem(
+                        sourcesProperty,
+                        j,
+                        MappingToggleWidth,
+                        sideAppliesNow: IsLeftRightSplitEnabled()))
                 {
                     break;
                 }
@@ -588,13 +593,26 @@ namespace ARKitBlendShapeGenerator.Presentation
         }
 
         /// <summary>
+        /// 左右分割が有効か。編集途中の値を見るためserializedObject側から取る
+        /// </summary>
+        private bool IsLeftRightSplitEnabled()
+        {
+            var property = serializedObject.FindProperty("enableLeftRightSplit");
+            return property == null || property.boolValue;
+        }
+
+        /// <summary>
         /// ソースBlendShape1件を描画する。要素を削除した場合はfalse（呼び出し元は列挙を打ち切る）
         /// </summary>
+        /// <param name="sideAppliesNow">
+        /// 現在の設定でSideが生成に効くか。効かない場合はドロップダウンを非活性にして無視されることを示す
+        /// </param>
         private bool DrawSourceItem(
             SerializedProperty sourcesProperty,
             int sourceIndex,
             float leadingSpace = 0f,
-            string sideTooltipKey = "enum.side.tooltip")
+            string sideTooltipKey = "enum.side.tooltip",
+            bool sideAppliesNow = true)
         {
             var sourceProperty = sourcesProperty.GetArrayElementAtIndex(sourceIndex);
             var blendShapeNameProperty = sourceProperty.FindPropertyRelative("blendShapeName");
@@ -639,17 +657,21 @@ namespace ARKitBlendShapeGenerator.Presentation
             }
 
             // 左右適用範囲
-            var sideTooltip = S(sideTooltipKey);
+            var sideTooltip = S(sideAppliesNow ? sideTooltipKey : "enum.side.split_off.tooltip");
             var sideLabels = new[]
             {
                 new GUIContent(S("enum.side.both"), sideTooltip),
                 new GUIContent(S("enum.side.left_only"), sideTooltip),
                 new GUIContent(S("enum.side.right_only"), sideTooltip),
             };
-            int newSide = EditorGUILayout.Popup(sideProperty.enumValueIndex, sideLabels, GUILayout.Width(70));
-            if (newSide != sideProperty.enumValueIndex)
+            // 値そのものは保持したまま、効いていないことを非活性表示で示す
+            using (new EditorGUI.DisabledScope(!sideAppliesNow))
             {
-                sideProperty.enumValueIndex = newSide;
+                int newSide = EditorGUILayout.Popup(sideProperty.enumValueIndex, sideLabels, GUILayout.Width(70));
+                if (newSide != sideProperty.enumValueIndex)
+                {
+                    sideProperty.enumValueIndex = newSide;
+                }
             }
 
             bool removed = false;

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 | ---- | ---- |
 | **Target Renderer** | 対象のSkinnedMeshRenderer（空の場合はBody/Face/Headを自動検出） |
 | **Intensity Multiplier** | 生成時の強度係数（0.5〜1.5推奨） |
-| **Enable Left Right Split** | 左右分割を有効化（まばたき等を左右別々に生成）。OFFにするとカスタムマッピングのSide指定も無視され、両側に適用される |
+| **Enable Left Right Split** | 頂点のX座標による左右分割を行う（まばたき等を左右別々に生成）。OFFにするとカスタムマッピングのSide指定も無視され、両側に適用される |
 | **Blend Width** | 左右分割時のグラデーション幅（中央付近で左右をブレンドする範囲、0.001〜0.1。メッシュローカル座標で中心から片側への幅を指定するため、グラデーション全体は指定値の2倍） |
 | **Overwrite Existing** | 既存のARKit BlendShapeを上書きする |
 | **Enable Procedural Mouth Shapes** | 既存シェイプキーから生成できない口周りのBlendShapeを頂点移動で自動生成する（デフォルト: 無効） |
@@ -67,7 +67,9 @@ Target Renderer が空のときは、コンポーネントの直下にある `Bo
 
 ソースBlendShapeの名前はシェイプキー名との完全一致で照合します（大文字小文字や前後の空白も区別されます）。
 Sideは適用する頂点の範囲を表し、「左のみ」はアバターから見て左半分（メッシュローカル座標のX < 0）、「右のみ」は右半分（X > 0）に適用されます。
-`Enable Left Right Split` がOFFのときはSideの指定は無視され、ソースが両側に適用されます。
+`Enable Left Right Split` は生成全体で頂点のX座標による左右分割を行うかどうかのスイッチです。
+OFFのときはカスタムマッピングのSideも無視され、ソースが両側に適用されます。
+無視されていることが分かるよう、OFFのあいだSideのドロップダウンは非活性で表示されます（設定値そのものは保持され、ONに戻すとまた効きます）。
 
 ### NDMFプレビュー
 

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -29,7 +29,7 @@ namespace ARKitBlendShapeGenerator
         [Range(0.1f, 2.0f)]
         public float intensityMultiplier = 1.0f;
 
-        [Tooltip("Generate left/right variants separately (e.g. blink). When off, the Side setting of custom mappings is ignored as well and every source is applied to both sides")]
+        [Tooltip("Split by the vertex X coordinate to generate left/right variants separately (e.g. blink). When off, the Side setting of custom mappings is ignored as well and every source is applied to both sides")]
         public bool enableLeftRightSplit = true;
 
         [Tooltip("Width of the gradient around the center where left and right are blended when splitting (the distance from the center to one side in mesh local X, so the whole gradient spans twice this value)")]

--- a/Tests/Editor/BlendShapeGenerationEngineTests.cs
+++ b/Tests/Editor/BlendShapeGenerationEngineTests.cs
@@ -36,7 +36,11 @@ namespace ARKitBlendShapeGenerator.Tests
             };
         }
 
-        private static CustomBlendShapeMapping CustomMapping(string arkitName, string sourceName, float weight)
+        private static CustomBlendShapeMapping CustomMapping(
+            string arkitName,
+            string sourceName,
+            float weight,
+            BlendShapeSide side = BlendShapeSide.Both)
         {
             return new CustomBlendShapeMapping
             {
@@ -44,7 +48,7 @@ namespace ARKitBlendShapeGenerator.Tests
                 enabled = true,
                 sources = new List<BlendShapeSource>
                 {
-                    new BlendShapeSource { blendShapeName = sourceName, weight = weight, side = BlendShapeSide.Both },
+                    new BlendShapeSource { blendShapeName = sourceName, weight = weight, side = side },
                 },
             };
         }
@@ -98,6 +102,58 @@ namespace ARKitBlendShapeGenerator.Tests
             // LeftOnlyはX<0側にのみ適用される（X=-1は全適用、X=+1は適用なし）
             Assert.That(shape.Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
             Assert.That(shape.Frames[0].DeltaVertices[1], Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Generate_AppliesCustomMappingSide_WhenLeftRightSplitEnabled()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("wink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var options = CreateOptions();
+            options.EnableLeftRightSplit = true;
+
+            BlendShapeGenerationEngine.Generate(
+                source,
+                target,
+                new List<CustomBlendShapeMapping>
+                {
+                    CustomMapping("eyeBlinkLeft", "wink", 1.0f, BlendShapeSide.LeftOnly),
+                },
+                null,
+                options,
+                null);
+
+            var shape = target.FindShape("eyeBlinkLeft");
+            Assert.That(shape.Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            Assert.That(shape.Frames[0].DeltaVertices[1], Is.EqualTo(Vector3.zero));
+        }
+
+        [Test]
+        public void Generate_IgnoresCustomMappingSide_WhenLeftRightSplitDisabled()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("wink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+            var options = CreateOptions();
+            options.EnableLeftRightSplit = false;
+
+            BlendShapeGenerationEngine.Generate(
+                source,
+                target,
+                new List<CustomBlendShapeMapping>
+                {
+                    CustomMapping("eyeBlinkLeft", "wink", 1.0f, BlendShapeSide.LeftOnly),
+                },
+                null,
+                options,
+                null);
+
+            // 左右分割は生成全体のスイッチで、カスタムマッピングのSideもここで止まる
+            // （インスペクタ側はこの状態のときSideのドロップダウンを非活性にして無視されることを示す）
+            var shape = target.FindShape("eyeBlinkLeft");
+            Assert.That(shape.Frames[0].DeltaVertices[0], Is.EqualTo(Vector3.up));
+            Assert.That(shape.Frames[0].DeltaVertices[1], Is.EqualTo(Vector3.up));
         }
 
         [Test]


### PR DESCRIPTION
Closes #52

## 方針

#52 では2案を挙げていたが、**現状の挙動を正として維持し、UI側で無視されることを示す**方を採った。

`EnableLeftRightSplit` は「頂点のX座標で左右に分けるかどうか」を決める生成全体のスイッチとして働いている。

| 参照箇所 | 用途 |
| ---- | ---- |
| `CollectAutoMappings`（`side = 有効 ? mapping.side : Both`） | 自動マッピングの左右分割エントリ |
| `TryAddBlendShape`（ソース単位の左右フィルタ） | 自動マッピングとカスタムマッピング |
| `ProceduralMouthShapeGenerator`（`mouthUpperUp*` / `mouthLowerDown*`） | 手続き的生成 |

3経路すべてがこのスイッチで止まるため、X座標での分割が成立しないメッシュ（左右非対称、原点が中央にない等）ではまとめて切れる。カスタムマッピングのSideだけを独立させると、このスイッチがX分割を止めきれなくなる。

打ち消し元のSideだけが独立して効くのは、これがアバター側での適用範囲を表すもので生成時の分割とは別物のためで、コードにもその旨のコメントがある。

したがって問題は挙動ではなく、**効いていない設定を操作できてしまうこと**に絞られる。

## 変更内容

- `Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs`: `DrawSourceItem` に `sideAppliesNow` を追加し、左右分割がOFFのあいだカスタムマッピングのSideドロップダウンを `EditorGUI.DisabledScope` で非活性表示にする。設定値は保持するので、ONに戻せばそのまま効く。打ち消し元は分割設定と独立に効くため従来どおり操作できる
- `Editor/Localization/ja-jp.po` / `en-us.po`: 非活性時のツールチップ `enum.side.split_off.tooltip` を追加。`prop.enable_left_right_split.tooltip` を「頂点のX座標による左右分割」と、スイッチの範囲が分かる表現に変更
- `Tests/Editor/BlendShapeGenerationEngineTests.cs`: 左右分割のON/OFFでカスタムマッピングのSideがどう扱われるかを固定するテストを2件追加。今回維持すると決めた挙動が意図せず変わらないようにする
- `README.md`: 同上の説明を追加
- `Runtime/ARKitBlendShapeGeneratorComponent.cs`: `[Tooltip]` を `.po` と同内容に揃える

## 確認方法

`Tests/Editor` のEditModeテストで、左右分割ONのときSideが適用され、OFFのとき両側へ適用されることを検証している。
インスペクタの非活性表示そのものはUnity上で未確認（この環境にUnityが無いため）。ローカライズキーの使用漏れ、ja/enの差分、重複msgidが無いことはスクリプトで確認済み。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xe1fEtz5V3iXow6ks9k257)_