### PR TITLE
fix: NDMF依存の下限を1.5.0へ引き上げる

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 ## 必要要件
 
 - Unity 2022.3.6f1以降
-- [NDMF](https://ndmf.nadena.dev/) 1.4.0以降
+- [NDMF](https://ndmf.nadena.dev/) 1.5.0以降（プレビュー機構がNDMF 1.5.0で追加されたため、1.4系ではコンパイルできません）
 - VRChat SDK (Avatars)
 
 ## インストール

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dependencies": {},
     "vpmDependencies": {
         "com.vrchat.avatars": ">=3.5.0",
-        "nadena.dev.ndmf": ">=1.4.0"
+        "nadena.dev.ndmf": ">=1.5.0"
     },
     "author": {
         "name": "kairox",


### PR DESCRIPTION
Closes #36

## 概要

`package.json` の `vpmDependencies` が `nadena.dev.ndmf: ">=1.4.0"` を指定していたが、現状のコードは NDMF 1.5.0 以降でないとコンパイルできない。
下限を `>=1.5.0` へ引き上げ、README.md の必要要件も揃えた。

## 調査結果

bdunderscore/ndmf を clone し、タグごとにツリーとシグネチャを確認した。

**1.4.1**

- `Editor/PreviewSystem/` ディレクトリ自体が存在しない
- `IRenderFilter` / `IRenderFilterNode` / `RenderGroup` / `RenderAspects` / `TogglablePreviewNode` / `PublishedValue` / `ComputeContext` / `PreviewingWith` のいずれも見つからない

**1.5.0**

上記がすべて追加されており、このリポジトリが実際に呼んでいる API も同じシグネチャで存在する。

| 使用箇所 | API | 1.5.0での定義 |
| ---- | ---- | ---- |
| `ARKitBlendShapeGeneratorPreview` | `ComputeContext.GetAvatarRoots()` | `Editor/PreviewSystem/ComputeContext/GlobalQueries.cs` |
| 同上 | `GetComponentsInChildren<C>(GameObject, bool)` | `Editor/PreviewSystem/ComputeContext/SingleObjectQueries.cs` |
| 同上 | `Observe<T>(PublishedValue<T>)` / `Observe<T>(T obj)` / `Observe<T,R>(T, Func<T,R>)` | 同上 |
| 同上 | `RenderGroup.For(Renderer)` / `WithData<T>` / `GetData<T>` | `Editor/PreviewSystem/IRenderFilter.cs` |
| 同上 | `RenderAspects.Mesh` / `.Shapes`、`IRenderFilterNode.Refresh(proxyPairs, context, updatedAspects)` | 同上 |
| 同上 | `TogglablePreviewNode.Create(displayName, qualifiedName, initialState)` | `Editor/PreviewSystem/TogglablePreviewNode.cs` |
| `ARKitBlendShapeGeneratorPreviewState` | `PublishedValue<T>(T value, string debugName)` | `Editor/PreviewSystem/ComputeContext/PublishedValue.cs` |
| `ARKitBlendShapeGeneratorPlugin` | `Sequence.PreviewingWith(params IRenderFilter[])` | `Editor/API/Fluent/Sequence/Sequence.cs` |
| `ARKitBlendShapeGeneratorEditor` | `LanguageSwitcher.DrawImmediate()` | `Editor/UI/LanguageSwitcher.cs` |
| `Localization` | `Localizer(string, Func<List<LocalizationAsset>>)` | `Editor/UI/Localization/Localizer.cs` |

1.5.0 より後に追加された API は使っていないため、下限は 1.5.0 とした。

## 変更内容

- `package.json`: `nadena.dev.ndmf` を `>=1.4.0` から `>=1.5.0` へ
- `README.md`: 必要要件を「1.5.0以降」に直し、1.4系で動かない理由を併記

## 動作確認

依存指定と文書のみの変更でコードの変更は無いため、EditModeテストの結果は変わらない。
CI（`.github/workflows/test.yml`）は `vrc-get install nadena.dev.ndmf` で最新版を入れるため、この変更の影響を受けない。

---
_Generated by [Claude Code](https://claude.ai/code/session_019ekXXAo6e2rL78UjFT1247)_