### PR TITLE
perf: スライダー操作中のプレビュー再生成をまとめる

### DIFF
--- a/Editor/Domain/PreviewRebuildDebouncer.cs
+++ b/Editor/Domain/PreviewRebuildDebouncer.cs
@@ -1,0 +1,74 @@
+using System;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// 連続して届く再生成要求を1回にまとめるための時刻計算。
+    ///
+    /// スライダーをドラッグしている間は要求が毎フレーム届く。そのたびに再生成すると
+    /// 大きいアバターでは操作が重くなるため、要求が止むまで実行を先送りする。
+    /// ただし先送りだけだと長いドラッグの間プレビューが固まって見えるので、
+    /// 最初の要求からの上限で打ち切り、ドラッグ中も一定間隔では追従させる。
+    ///
+    /// 時刻を引数で受け取るのでUnityのAPIに依存しない（実際の駆動はInfra層が行う）。
+    /// </summary>
+    internal sealed class PreviewRebuildDebouncer
+    {
+        /// <summary>最後の要求からこれだけ変化が無ければ実行する</summary>
+        public const double IdleDelaySeconds = 0.1;
+
+        /// <summary>要求が続いていても、最初の要求からこれ以上は先送りしない</summary>
+        public const double MaxDeferSeconds = 0.4;
+
+        private readonly double _idleDelaySeconds;
+        private readonly double _maxDeferSeconds;
+
+        private bool _isPending;
+        private double _firstRequestTime;
+        private double _dueTime;
+
+        public PreviewRebuildDebouncer()
+            : this(IdleDelaySeconds, MaxDeferSeconds)
+        {
+        }
+
+        public PreviewRebuildDebouncer(double idleDelaySeconds, double maxDeferSeconds)
+        {
+            _idleDelaySeconds = idleDelaySeconds;
+            _maxDeferSeconds = maxDeferSeconds;
+        }
+
+        /// <summary>先送り中の要求があるか</summary>
+        public bool IsPending => _isPending;
+
+        /// <summary>先送り中の要求を実行する時刻（IsPendingがfalseのときは意味を持たない）</summary>
+        public double DueTime => _dueTime;
+
+        /// <summary>再生成を要求する。先送り中であれば実行時刻を延ばす</summary>
+        public void Request(double now)
+        {
+            if (!_isPending)
+            {
+                _isPending = true;
+                _firstRequestTime = now;
+            }
+
+            _dueTime = Math.Min(now + _idleDelaySeconds, _firstRequestTime + _maxDeferSeconds);
+        }
+
+        /// <summary>
+        /// 実行時刻を過ぎていれば要求を取り下げてtrueを返す。
+        /// 呼び出し側はtrueのときだけ再生成を走らせる
+        /// </summary>
+        public bool TryConsume(double now)
+        {
+            if (!_isPending || now < _dueTime)
+            {
+                return false;
+            }
+
+            _isPending = false;
+            return true;
+        }
+    }
+}

--- a/Editor/Domain/PreviewSettingsSnapshot.cs
+++ b/Editor/Domain/PreviewSettingsSnapshot.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// プレビューの再生成が必要かどうかの判定結果
+    /// </summary>
+    internal enum PreviewSettingsChange
+    {
+        /// <summary>生成結果に影響する変更は無い</summary>
+        None,
+
+        /// <summary>スライダーで連続的に変わる値だけが変わった（実行を遅らせてよい）</summary>
+        Continuous,
+
+        /// <summary>生成対象や合成内容そのものが変わった（すぐ作り直す必要がある）</summary>
+        Structural,
+    }
+
+    /// <summary>
+    /// プレビュー結果に影響するコンポーネント設定のスナップショット。
+    ///
+    /// 値の取得（ComputeContextでの監視登録を伴う）は呼び出し側が行い、ここでは
+    /// 取得済みの値どうしの比較だけを担う。NDMFに触れないので単体テストできる。
+    /// </summary>
+    internal sealed class PreviewSettingsSnapshot
+    {
+        // スライダーでドラッグ中に毎フレーム変わる値
+        public float IntensityMultiplier { get; set; }
+        public float BlendWidth { get; set; }
+        public float ProceduralMouthIntensity { get; set; }
+        public float MouthCancellationStrength { get; set; }
+
+        // 1回の操作で1度だけ変わる値
+        public bool EnableLeftRightSplit { get; set; }
+        public bool OverwriteExisting { get; set; }
+        public bool EnableProceduralMouthShapes { get; set; }
+        public bool EnableMouthCancellation { get; set; }
+        public int MouthCancellationSignature { get; set; }
+        public int CustomMappingsSignature { get; set; }
+        public int TargetRendererInstanceId { get; set; }
+
+        /// <summary>
+        /// 生成結果に影響する差分を分類する。
+        ///
+        /// 連続値だけの差分を分けているのは、スライダーのドラッグ中に毎フレーム
+        /// フル再生成が走るのを避けるため。どちらの値も最終的には同じ経路で反映される
+        /// </summary>
+        public PreviewSettingsChange CompareWith(PreviewSettingsSnapshot other)
+        {
+            if (other == null)
+            {
+                return PreviewSettingsChange.Structural;
+            }
+
+            if (EnableLeftRightSplit != other.EnableLeftRightSplit ||
+                OverwriteExisting != other.OverwriteExisting ||
+                EnableProceduralMouthShapes != other.EnableProceduralMouthShapes ||
+                EnableMouthCancellation != other.EnableMouthCancellation ||
+                MouthCancellationSignature != other.MouthCancellationSignature ||
+                CustomMappingsSignature != other.CustomMappingsSignature ||
+                TargetRendererInstanceId != other.TargetRendererInstanceId)
+            {
+                return PreviewSettingsChange.Structural;
+            }
+
+            if (!Mathf.Approximately(IntensityMultiplier, other.IntensityMultiplier) ||
+                !Mathf.Approximately(BlendWidth, other.BlendWidth) ||
+                !Mathf.Approximately(ProceduralMouthIntensity, other.ProceduralMouthIntensity) ||
+                !Mathf.Approximately(MouthCancellationStrength, other.MouthCancellationStrength))
+            {
+                return PreviewSettingsChange.Continuous;
+            }
+
+            return PreviewSettingsChange.None;
+        }
+
+        /// <summary>
+        /// カスタムマッピングの内容を1つの整数へ畳む。
+        /// リストの中身はComputeContextの監視で差分を取れないため、署名で比較する
+        /// </summary>
+        public static int BuildCustomMappingsSignature(List<CustomBlendShapeMapping> customMappings)
+        {
+            unchecked
+            {
+                int hash = 17;
+                if (customMappings == null)
+                {
+                    return hash;
+                }
+
+                hash = (hash * 31) + customMappings.Count;
+                foreach (var mapping in customMappings)
+                {
+                    if (mapping == null)
+                    {
+                        hash = (hash * 31) + 1;
+                        continue;
+                    }
+
+                    hash = (hash * 31) + (mapping.enabled ? 1 : 0);
+                    hash = (hash * 31) + HashString(mapping.arkitName);
+                    hash = HashSources(hash, mapping.sources);
+                }
+
+                return hash;
+            }
+        }
+
+        /// <summary>打ち消しの元と対象の内容を1つの整数へ畳む</summary>
+        public static int BuildMouthCancellationSignature(List<BlendShapeSource> sources, List<string> targets)
+        {
+            unchecked
+            {
+                int hash = HashSources(17, sources);
+
+                if (targets == null)
+                {
+                    return (hash * 31) + 2;
+                }
+
+                hash = (hash * 31) + targets.Count;
+                foreach (var target in targets)
+                {
+                    hash = (hash * 31) + HashString(target);
+                }
+
+                return hash;
+            }
+        }
+
+        private static int HashSources(int hash, List<BlendShapeSource> sources)
+        {
+            unchecked
+            {
+                if (sources == null)
+                {
+                    return (hash * 31) + 2;
+                }
+
+                hash = (hash * 31) + sources.Count;
+                foreach (var source in sources)
+                {
+                    if (source == null)
+                    {
+                        hash = (hash * 31) + 3;
+                        continue;
+                    }
+
+                    hash = (hash * 31) + HashString(source.blendShapeName);
+                    hash = (hash * 31) + source.weight.GetHashCode();
+                    hash = (hash * 31) + (int)source.side;
+                }
+
+                return hash;
+            }
+        }
+
+        private static int HashString(string value)
+        {
+            return value != null ? value.GetHashCode() : 0;
+        }
+    }
+}

--- a/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
@@ -134,17 +134,11 @@ namespace ARKitBlendShapeGenerator.Handler
             private readonly ARKitBlendShapeGeneratorComponent _component;
             private readonly int _componentInstanceId;
             private readonly int _observedComponentConfigRevision;
-            private readonly float _observedIntensityMultiplier;
-            private readonly bool _observedEnableLeftRightSplit;
-            private readonly float _observedBlendWidth;
-            private readonly bool _observedOverwriteExisting;
-            private readonly bool _observedEnableProceduralMouthShapes;
-            private readonly float _observedProceduralMouthIntensity;
-            private readonly bool _observedEnableMouthCancellation;
-            private readonly float _observedMouthCancellationStrength;
-            private readonly int _observedMouthCancellationSignature;
-            private readonly int _observedTargetRendererInstanceId;
-            private readonly int _observedCustomMappingsSignature;
+            private readonly PreviewSettingsSnapshot _observedSettings;
+
+            // 先送りの合図は全プレビューノードへ届く。自分が受け取った分まで進めておかないと、
+            // 他のコンポーネントの操作で進んだ合図をいつまでも「未反映」と見なしてしまう
+            private int _observedDeferredRebuildRevision;
             private readonly Dictionary<string, int> _shapeIndices = new Dictionary<string, int>();
             private HashSet<int> _appliedInteractiveIndices = new HashSet<int>();
             private HashSet<int> _nextAppliedInteractiveIndices = new HashSet<int>();
@@ -160,46 +154,15 @@ namespace ARKitBlendShapeGenerator.Handler
                 _component = component;
                 _componentInstanceId = component != null ? component.GetInstanceID() : 0;
                 _observedComponentConfigRevision = context.Observe(ARKitBlendShapeGeneratorPreviewState.ComponentConfigRevision);
+                _observedDeferredRebuildRevision = context.Observe(ARKitBlendShapeGeneratorPreviewState.DeferredRebuildRevision);
 
                 // customMappingsの内容を含むコンポーネント変更全体を監視
-                float observedIntensityMultiplier = 0f;
-                bool observedEnableLeftRightSplit = false;
-                float observedBlendWidth = 0f;
-                bool observedOverwriteExisting = false;
-                bool observedEnableProceduralMouthShapes = false;
-                float observedProceduralMouthIntensity = 0f;
-                bool observedEnableMouthCancellation = false;
-                float observedMouthCancellationStrength = 0f;
-                int observedMouthCancellationSignature = 0;
-                int observedCustomMappingsSignature = 0;
-                SkinnedMeshRenderer observedTargetRenderer = null;
                 if (component != null)
                 {
                     context.Observe(component);
-                    observedIntensityMultiplier = context.Observe(component, c => c.intensityMultiplier);
-                    observedEnableLeftRightSplit = context.Observe(component, c => c.enableLeftRightSplit);
-                    observedBlendWidth = context.Observe(component, c => c.blendWidth);
-                    observedOverwriteExisting = context.Observe(component, c => c.overwriteExisting);
-                    observedEnableProceduralMouthShapes = context.Observe(component, c => c.enableProceduralMouthShapes);
-                    observedProceduralMouthIntensity = context.Observe(component, c => c.proceduralMouthIntensity);
-                    observedEnableMouthCancellation = context.Observe(component, c => c.enableMouthCancellation);
-                    observedMouthCancellationStrength = context.Observe(component, c => c.mouthCancellationStrength);
-                    observedMouthCancellationSignature = BuildMouthCancellationSignature(component);
-                    observedCustomMappingsSignature = BuildCustomMappingsSignature(component.customMappings);
-                    observedTargetRenderer = context.Observe(component, c => c.targetRenderer);
                 }
 
-                _observedIntensityMultiplier = observedIntensityMultiplier;
-                _observedEnableLeftRightSplit = observedEnableLeftRightSplit;
-                _observedBlendWidth = observedBlendWidth;
-                _observedOverwriteExisting = observedOverwriteExisting;
-                _observedEnableProceduralMouthShapes = observedEnableProceduralMouthShapes;
-                _observedProceduralMouthIntensity = observedProceduralMouthIntensity;
-                _observedEnableMouthCancellation = observedEnableMouthCancellation;
-                _observedMouthCancellationStrength = observedMouthCancellationStrength;
-                _observedMouthCancellationSignature = observedMouthCancellationSignature;
-                _observedCustomMappingsSignature = observedCustomMappingsSignature;
-                _observedTargetRendererInstanceId = observedTargetRenderer != null ? observedTargetRenderer.GetInstanceID() : 0;
+                _observedSettings = ObserveSettings(component, context);
 
                 context.Observe(originalRenderer, r => r.sharedMesh);
                 context.Observe(proxyRenderer, r => r.sharedMesh);
@@ -238,85 +201,17 @@ namespace ARKitBlendShapeGenerator.Handler
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
 
-                int currentConfigRevision = context.Observe(ARKitBlendShapeGeneratorPreviewState.ComponentConfigRevision);
-                if (currentConfigRevision != _observedComponentConfigRevision)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
                 if ((updatedAspects & RenderAspects.Mesh) != 0)
                 {
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
 
+                // ノードを残す場合に監視が切れないよう、判定より先に監視をすべて登録しておく
+                int currentDeferredRebuildRevision = context.Observe(
+                    ARKitBlendShapeGeneratorPreviewState.DeferredRebuildRevision);
+                int currentConfigRevision = context.Observe(ARKitBlendShapeGeneratorPreviewState.ComponentConfigRevision);
                 context.Observe(_component);
-
-                float currentIntensityMultiplier = context.Observe(_component, c => c.intensityMultiplier);
-                if (!Mathf.Approximately(currentIntensityMultiplier, _observedIntensityMultiplier))
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                bool currentEnableLeftRightSplit = context.Observe(_component, c => c.enableLeftRightSplit);
-                if (currentEnableLeftRightSplit != _observedEnableLeftRightSplit)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                float currentBlendWidth = context.Observe(_component, c => c.blendWidth);
-                if (!Mathf.Approximately(currentBlendWidth, _observedBlendWidth))
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                bool currentOverwriteExisting = context.Observe(_component, c => c.overwriteExisting);
-                if (currentOverwriteExisting != _observedOverwriteExisting)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                bool currentEnableProceduralMouthShapes = context.Observe(_component, c => c.enableProceduralMouthShapes);
-                if (currentEnableProceduralMouthShapes != _observedEnableProceduralMouthShapes)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                float currentProceduralMouthIntensity = context.Observe(_component, c => c.proceduralMouthIntensity);
-                if (!Mathf.Approximately(currentProceduralMouthIntensity, _observedProceduralMouthIntensity))
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                bool currentEnableMouthCancellation = context.Observe(_component, c => c.enableMouthCancellation);
-                if (currentEnableMouthCancellation != _observedEnableMouthCancellation)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                float currentMouthCancellationStrength = context.Observe(_component, c => c.mouthCancellationStrength);
-                if (!Mathf.Approximately(currentMouthCancellationStrength, _observedMouthCancellationStrength))
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                int currentMouthCancellationSignature = BuildMouthCancellationSignature(_component);
-                if (currentMouthCancellationSignature != _observedMouthCancellationSignature)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                int currentCustomMappingsSignature = BuildCustomMappingsSignature(_component.customMappings);
-                if (currentCustomMappingsSignature != _observedCustomMappingsSignature)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
-
-                var currentTargetRenderer = context.Observe(_component, c => c.targetRenderer);
-                int currentTargetRendererId = currentTargetRenderer != null ? currentTargetRenderer.GetInstanceID() : 0;
-                if (currentTargetRendererId != _observedTargetRendererInstanceId)
-                {
-                    return Task.FromResult<IRenderFilterNode>(null);
-                }
+                var currentSettings = ObserveSettings(_component, context);
 
                 var pair = proxyPairs.FirstOrDefault();
                 if (pair.Item1 is not SkinnedMeshRenderer ||
@@ -325,7 +220,70 @@ namespace ARKitBlendShapeGenerator.Handler
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
 
-                return Task.FromResult<IRenderFilterNode>(this);
+                bool deferredRebuildRequested = currentDeferredRebuildRevision != _observedDeferredRebuildRevision;
+                _observedDeferredRebuildRevision = currentDeferredRebuildRevision;
+
+                // 反映済みの設定（_observedSettings）は更新しない。
+                // 先送り中は差分が残り続けることで、実行までの延長を要求し続ける
+                switch (currentSettings.CompareWith(_observedSettings))
+                {
+                    case PreviewSettingsChange.Structural:
+                        return Task.FromResult<IRenderFilterNode>(null);
+
+                    case PreviewSettingsChange.Continuous:
+                        if (deferredRebuildRequested)
+                        {
+                            // 先送りしていた分をここで反映する
+                            return Task.FromResult<IRenderFilterNode>(null);
+                        }
+
+                        // スライダーのドラッグ中は毎フレーム変更が届く。そのたびにフル再生成すると
+                        // 大きいアバターでは操作が重くなるため、値が落ち着くまで実行を遅らせ、
+                        // それまでは1つ前の結果を出したままにする
+                        PreviewRebuildScheduler.Request();
+                        return Task.FromResult<IRenderFilterNode>(this);
+
+                    default:
+                        if (currentConfigRevision != _observedComponentConfigRevision)
+                        {
+                            // 差分を検出できなくても設定自体は変わっているなら作り直す。
+                            // 署名の衝突など、比較での取りこぼしに対する保険
+                            return Task.FromResult<IRenderFilterNode>(null);
+                        }
+
+                        return Task.FromResult<IRenderFilterNode>(this);
+                }
+            }
+
+            /// <summary>
+            /// 生成に影響する設定を、ComputeContextへ監視を登録しながら読み出す
+            /// </summary>
+            private static PreviewSettingsSnapshot ObserveSettings(
+                ARKitBlendShapeGeneratorComponent component,
+                ComputeContext context)
+            {
+                if (component == null)
+                {
+                    return new PreviewSettingsSnapshot();
+                }
+
+                var targetRenderer = context.Observe(component, c => c.targetRenderer);
+                return new PreviewSettingsSnapshot
+                {
+                    IntensityMultiplier = context.Observe(component, c => c.intensityMultiplier),
+                    EnableLeftRightSplit = context.Observe(component, c => c.enableLeftRightSplit),
+                    BlendWidth = context.Observe(component, c => c.blendWidth),
+                    OverwriteExisting = context.Observe(component, c => c.overwriteExisting),
+                    EnableProceduralMouthShapes = context.Observe(component, c => c.enableProceduralMouthShapes),
+                    ProceduralMouthIntensity = context.Observe(component, c => c.proceduralMouthIntensity),
+                    EnableMouthCancellation = context.Observe(component, c => c.enableMouthCancellation),
+                    MouthCancellationStrength = context.Observe(component, c => c.mouthCancellationStrength),
+                    MouthCancellationSignature = PreviewSettingsSnapshot.BuildMouthCancellationSignature(
+                        component.mouthCancellationSources,
+                        component.mouthCancellationTargets),
+                    CustomMappingsSignature = PreviewSettingsSnapshot.BuildCustomMappingsSignature(component.customMappings),
+                    TargetRendererInstanceId = targetRenderer != null ? targetRenderer.GetInstanceID() : 0,
+                };
             }
 
             public void OnFrame(Renderer original, Renderer proxy)
@@ -390,94 +348,6 @@ namespace ARKitBlendShapeGenerator.Handler
                 {
                     _shapeIndices[kvp.Key] = kvp.Value;
                 }
-            }
-
-            private static int BuildCustomMappingsSignature(List<CustomBlendShapeMapping> customMappings)
-            {
-                unchecked
-                {
-                    int hash = 17;
-                    if (customMappings == null)
-                    {
-                        return hash;
-                    }
-
-                    hash = (hash * 31) + customMappings.Count;
-                    foreach (var mapping in customMappings)
-                    {
-                        if (mapping == null)
-                        {
-                            hash = (hash * 31) + 1;
-                            continue;
-                        }
-
-                        hash = (hash * 31) + (mapping.enabled ? 1 : 0);
-                        hash = (hash * 31) + HashString(mapping.arkitName);
-                        hash = HashSources(hash, mapping.sources);
-                    }
-
-                    return hash;
-                }
-            }
-
-            private static int BuildMouthCancellationSignature(ARKitBlendShapeGeneratorComponent component)
-            {
-                unchecked
-                {
-                    int hash = 17;
-                    if (component == null)
-                    {
-                        return hash;
-                    }
-
-                    hash = HashSources(hash, component.mouthCancellationSources);
-
-                    var targets = component.mouthCancellationTargets;
-                    if (targets == null)
-                    {
-                        return (hash * 31) + 2;
-                    }
-
-                    hash = (hash * 31) + targets.Count;
-                    foreach (var target in targets)
-                    {
-                        hash = (hash * 31) + HashString(target);
-                    }
-
-                    return hash;
-                }
-            }
-
-            private static int HashSources(int hash, List<BlendShapeSource> sources)
-            {
-                unchecked
-                {
-                    if (sources == null)
-                    {
-                        return (hash * 31) + 2;
-                    }
-
-                    hash = (hash * 31) + sources.Count;
-                    foreach (var source in sources)
-                    {
-                        if (source == null)
-                        {
-                            hash = (hash * 31) + 3;
-                            continue;
-                        }
-
-                        hash = (hash * 31) + HashString(source.blendShapeName);
-                        hash = (hash * 31) + source.weight.GetHashCode();
-                        hash = (hash * 31) + (int)source.side;
-                    }
-
-                    return hash;
-                }
-            }
-
-            private static int HashString(string value)
-            {
-                return value != null ? value.GetHashCode() : 0;
             }
 
             public void Dispose()

--- a/Editor/Infra/ARKitBlendShapeGeneratorPreviewState.cs
+++ b/Editor/Infra/ARKitBlendShapeGeneratorPreviewState.cs
@@ -55,6 +55,14 @@ namespace ARKitBlendShapeGenerator.Infra
             0,
             debugName: "ARKitBlendShapeGenerator/ComponentConfigRevision");
 
+        /// <summary>
+        /// 先送りしていた再生成を実行させる合図。
+        /// プレビューはこの値が進んだときだけ、遅らせていた分をまとめて反映する
+        /// </summary>
+        public static readonly PublishedValue<int> DeferredRebuildRevision = new PublishedValue<int>(
+            0,
+            debugName: "ARKitBlendShapeGenerator/DeferredRebuildRevision");
+
         public static Snapshot Current => RuntimeState.Value;
 
         public static void BeginEdit(int componentInstanceId)
@@ -158,6 +166,12 @@ namespace ARKitBlendShapeGenerator.Infra
         public static void NotifyComponentConfigurationChanged()
         {
             ComponentConfigRevision.Value = ComponentConfigRevision.Value + 1;
+        }
+
+        /// <summary>先送りしていた再生成を実行させる</summary>
+        public static void NotifyDeferredRebuild()
+        {
+            DeferredRebuildRevision.Value = DeferredRebuildRevision.Value + 1;
         }
 
     }

--- a/Editor/Infra/PreviewRebuildScheduler.cs
+++ b/Editor/Infra/PreviewRebuildScheduler.cs
@@ -1,0 +1,44 @@
+using UnityEditor;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Infra
+{
+    /// <summary>
+    /// 先送りした再生成をエディタの更新に合わせて実行する。
+    /// 実行時刻の決め方はPreviewRebuildDebouncerが持ち、ここはUnityのAPIとつなぐだけ。
+    ///
+    /// 要求元はプレビューノードのRefreshで、いずれもエディタのメインスレッドから呼ばれる
+    /// </summary>
+    internal static class PreviewRebuildScheduler
+    {
+        private static readonly PreviewRebuildDebouncer Debouncer = new PreviewRebuildDebouncer();
+
+        private static bool _isHooked;
+
+        /// <summary>再生成を要求する。要求が続く間はまとめられ、落ち着いてから1回だけ実行される</summary>
+        public static void Request()
+        {
+            Debouncer.Request(EditorApplication.timeSinceStartup);
+
+            if (_isHooked)
+            {
+                return;
+            }
+
+            _isHooked = true;
+            EditorApplication.update += Tick;
+        }
+
+        private static void Tick()
+        {
+            if (!Debouncer.TryConsume(EditorApplication.timeSinceStartup))
+            {
+                return;
+            }
+
+            _isHooked = false;
+            EditorApplication.update -= Tick;
+            ARKitBlendShapeGeneratorPreviewState.NotifyDeferredRebuild();
+        }
+    }
+}

--- a/Tests/Editor/PreviewRebuildDebouncerTests.cs
+++ b/Tests/Editor/PreviewRebuildDebouncerTests.cs
@@ -1,0 +1,92 @@
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// スライダー操作中の再生成をまとめる時刻計算の検証。
+    ///
+    /// 「要求が止むまで待つ」だけだと長いドラッグの間プレビューが固まって見えるため、
+    /// 最初の要求からの上限で打ち切る。その2つの規則が両方効いていることを固定化する。
+    /// </summary>
+    public class PreviewRebuildDebouncerTests
+    {
+        private const double IdleDelay = 0.1;
+        private const double MaxDefer = 0.4;
+
+        private static PreviewRebuildDebouncer CreateDebouncer()
+        {
+            return new PreviewRebuildDebouncer(IdleDelay, MaxDefer);
+        }
+
+        [Test]
+        public void TryConsume_ReturnsFalse_WhenNothingIsRequested()
+        {
+            var debouncer = CreateDebouncer();
+
+            Assert.That(debouncer.IsPending, Is.False);
+            Assert.That(debouncer.TryConsume(100.0), Is.False);
+        }
+
+        [Test]
+        public void TryConsume_WaitsForTheIdleDelay_AfterASingleRequest()
+        {
+            var debouncer = CreateDebouncer();
+            debouncer.Request(100.0);
+
+            Assert.That(debouncer.TryConsume(100.0 + IdleDelay - 0.01), Is.False);
+            Assert.That(debouncer.TryConsume(100.0 + IdleDelay), Is.True);
+        }
+
+        [Test]
+        public void Request_PushesBackTheDueTime_WhileRequestsKeepArriving()
+        {
+            // ドラッグ中は要求が届き続ける。その間は実行しない
+            var debouncer = CreateDebouncer();
+            debouncer.Request(100.0);
+            debouncer.Request(100.05);
+
+            Assert.That(debouncer.TryConsume(100.1), Is.False);
+            Assert.That(debouncer.TryConsume(100.15), Is.True);
+        }
+
+        [Test]
+        public void Request_StopsPushingBack_AtTheMaximumDeferral()
+        {
+            // 要求が途切れなくても、最初の要求からMaxDeferで打ち切って追従させる
+            var debouncer = CreateDebouncer();
+            for (double now = 100.0; now <= 100.0 + MaxDefer; now += 0.02)
+            {
+                debouncer.Request(now);
+            }
+
+            Assert.That(debouncer.DueTime, Is.EqualTo(100.0 + MaxDefer).Within(0.0001));
+            Assert.That(debouncer.TryConsume(100.0 + MaxDefer), Is.True);
+        }
+
+        [Test]
+        public void TryConsume_ClearsTheRequest_SoItDoesNotFireTwice()
+        {
+            var debouncer = CreateDebouncer();
+            debouncer.Request(100.0);
+
+            Assert.That(debouncer.TryConsume(100.5), Is.True);
+            Assert.That(debouncer.IsPending, Is.False);
+            Assert.That(debouncer.TryConsume(100.6), Is.False);
+        }
+
+        [Test]
+        public void Request_StartsANewDeferral_AfterThePreviousOneIsConsumed()
+        {
+            // 実行後の要求は、前回の上限を引きずらずに測り直す
+            var debouncer = CreateDebouncer();
+            debouncer.Request(100.0);
+            debouncer.TryConsume(100.0 + IdleDelay);
+
+            debouncer.Request(200.0);
+
+            Assert.That(debouncer.TryConsume(200.0 + IdleDelay - 0.01), Is.False);
+            Assert.That(debouncer.TryConsume(200.0 + IdleDelay), Is.True);
+        }
+    }
+}

--- a/Tests/Editor/PreviewSettingsSnapshotTests.cs
+++ b/Tests/Editor/PreviewSettingsSnapshotTests.cs
@@ -1,0 +1,159 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// プレビュー設定の差分の分類を検証する。
+    ///
+    /// 連続値（スライダー）だけの差分は実行を遅らせてよく、それ以外はすぐ作り直す。
+    /// 分類を誤ると「操作しても反映されない」か「重いまま」のどちらかになる。
+    /// </summary>
+    public class PreviewSettingsSnapshotTests
+    {
+        private static PreviewSettingsSnapshot CreateSnapshot()
+        {
+            return new PreviewSettingsSnapshot
+            {
+                IntensityMultiplier = 1.0f,
+                BlendWidth = 0.02f,
+                ProceduralMouthIntensity = 1.0f,
+                MouthCancellationStrength = 1.0f,
+                EnableLeftRightSplit = true,
+                OverwriteExisting = false,
+                EnableProceduralMouthShapes = false,
+                EnableMouthCancellation = false,
+                MouthCancellationSignature = 123,
+                CustomMappingsSignature = 456,
+                TargetRendererInstanceId = 789,
+            };
+        }
+
+        [Test]
+        public void CompareWith_ReturnsNone_WhenNothingChanged()
+        {
+            Assert.That(
+                CreateSnapshot().CompareWith(CreateSnapshot()),
+                Is.EqualTo(PreviewSettingsChange.None));
+        }
+
+        [Test]
+        public void CompareWith_ReturnsStructural_WhenComparedWithNothing()
+        {
+            Assert.That(
+                CreateSnapshot().CompareWith(null),
+                Is.EqualTo(PreviewSettingsChange.Structural));
+        }
+
+        [TestCase("IntensityMultiplier")]
+        [TestCase("BlendWidth")]
+        [TestCase("ProceduralMouthIntensity")]
+        [TestCase("MouthCancellationStrength")]
+        public void CompareWith_ReturnsContinuous_WhenOnlyASliderValueChanged(string changedField)
+        {
+            var current = CreateSnapshot();
+            switch (changedField)
+            {
+                case "IntensityMultiplier":
+                    current.IntensityMultiplier += 0.1f;
+                    break;
+                case "BlendWidth":
+                    current.BlendWidth += 0.01f;
+                    break;
+                case "ProceduralMouthIntensity":
+                    current.ProceduralMouthIntensity += 0.1f;
+                    break;
+                case "MouthCancellationStrength":
+                    current.MouthCancellationStrength -= 0.1f;
+                    break;
+            }
+
+            Assert.That(
+                current.CompareWith(CreateSnapshot()),
+                Is.EqualTo(PreviewSettingsChange.Continuous));
+        }
+
+        [Test]
+        public void CompareWith_ReturnsStructural_WhenAToggleChanged()
+        {
+            var current = CreateSnapshot();
+            current.EnableLeftRightSplit = !current.EnableLeftRightSplit;
+
+            Assert.That(
+                current.CompareWith(CreateSnapshot()),
+                Is.EqualTo(PreviewSettingsChange.Structural));
+        }
+
+        [Test]
+        public void CompareWith_ReturnsStructural_WhenMappingContentChanged()
+        {
+            var current = CreateSnapshot();
+            current.CustomMappingsSignature += 1;
+
+            Assert.That(
+                current.CompareWith(CreateSnapshot()),
+                Is.EqualTo(PreviewSettingsChange.Structural));
+        }
+
+        [Test]
+        public void CompareWith_PrefersStructural_WhenBothKindsChanged()
+        {
+            // 作り直しが必要な変更が混ざっていれば、遅らせずに作り直す
+            var current = CreateSnapshot();
+            current.IntensityMultiplier += 0.1f;
+            current.OverwriteExisting = !current.OverwriteExisting;
+
+            Assert.That(
+                current.CompareWith(CreateSnapshot()),
+                Is.EqualTo(PreviewSettingsChange.Structural));
+        }
+
+        [Test]
+        public void BuildCustomMappingsSignature_ChangesWithTheMappingContent()
+        {
+            var mappings = new List<CustomBlendShapeMapping>
+            {
+                new CustomBlendShapeMapping
+                {
+                    arkitName = "eyeBlinkLeft",
+                    enabled = true,
+                    sources = new List<BlendShapeSource>
+                    {
+                        new BlendShapeSource { blendShapeName = "vrc.blink", weight = 1.0f },
+                    },
+                },
+            };
+
+            int baseline = PreviewSettingsSnapshot.BuildCustomMappingsSignature(mappings);
+
+            mappings[0].sources[0].weight = 0.5f;
+            Assert.That(PreviewSettingsSnapshot.BuildCustomMappingsSignature(mappings), Is.Not.EqualTo(baseline));
+
+            mappings[0].sources[0].weight = 1.0f;
+            mappings[0].enabled = false;
+            Assert.That(PreviewSettingsSnapshot.BuildCustomMappingsSignature(mappings), Is.Not.EqualTo(baseline));
+        }
+
+        [Test]
+        public void BuildMouthCancellationSignature_ChangesWithSourcesAndTargets()
+        {
+            var sources = new List<BlendShapeSource>
+            {
+                new BlendShapeSource { blendShapeName = "口開き", weight = 1.0f },
+            };
+            var targets = new List<string> { "jawOpen" };
+
+            int baseline = PreviewSettingsSnapshot.BuildMouthCancellationSignature(sources, targets);
+
+            targets.Add("mouthFunnel");
+            int withExtraTarget = PreviewSettingsSnapshot.BuildMouthCancellationSignature(sources, targets);
+            Assert.That(withExtraTarget, Is.Not.EqualTo(baseline));
+
+            sources[0].side = BlendShapeSide.LeftOnly;
+            Assert.That(
+                PreviewSettingsSnapshot.BuildMouthCancellationSignature(sources, targets),
+                Is.Not.EqualTo(withExtraTarget));
+        }
+    }
+}


### PR DESCRIPTION
Closes #43

## 何が問題だったか

プレビューは監視している設定が1つでも変わるとノードを破棄し、メッシュ複製と全ARKitシェイプのフル再生成をやり直す。強度係数やグラデーション幅のスライダーはドラッグ中に毎フレーム変わるため、その間ずっとフル再生成が走っていた。

## 何を変えたか

### 1. 連続値の変更は先送りする

変わった設定を2つに分ける。

| 区分 | 対象 | 扱い |
| --- | --- | --- |
| 連続値 | 強度係数、グラデーション幅、手続き的生成の強度、打ち消しの強度 | 落ち着くまで先送り |
| それ以外 | 左右分割、上書き、手続き的生成のON/OFF、打ち消しのON/OFF、打ち消しの元と対象、カスタムマッピング、対象レンダラー | すぐ作り直す |

連続値だけの変更なら1つ前の結果を出したままにし、値が落ち着いてから1回だけ作り直す。先送りだけだと長いドラッグの間プレビューが固まって見えるので、最初の要求から一定時間（既定 0.4 秒）で打ち切り、ドラッグ中も一定間隔で追従させる。落ち着き待ちは 0.1 秒。

先送りの実行は `PublishedValue` の合図で行う。合図は全プレビューノードへ届くため、自分の設定が変わっていないノードは作り直さないようにしてある。

### 2. リビジョンの位置づけを変えた

コンポーネント設定のリビジョンは、これまで「進んだら再生成」だった。インスペクタは `ApplyModifiedProperties` のたびに進めるので、スライダーのドラッグ中も毎フレーム進み、これがあると先送りが一切効かない。

監視している項目は生成に関わるフィールドを網羅している（`debugMode` 以外のすべて）ため、判定の主役は設定値の比較で足りる。リビジョンは「比較で差分を検出できなかったが設定は変わっている」場合の保険として後段へ移した。署名のハッシュ衝突などの取りこぼしは従来どおり拾える。

### 3. 判定をスナップショットへ切り出した

`Refresh` に並んでいた同じ形の分岐11個を `PreviewSettingsSnapshot.CompareWith` へまとめた。NDMFに触れないので単体テストできる。

## 効果

スライダーを1秒ドラッグした場合のフル再生成の回数は、エディタが60fpsで更新するとして約60回から2〜3回になる。1回あたりのコストは #62（マージ済み）のアロケーション削減がそのまま効く。

## 検証

- 判定の分類（連続値／それ以外／変化なし、混在時はすぐ作り直す）と、署名が内容の変化を拾うことのテストを追加
- 先送りの時刻計算（要求が止むまで待つ／最初の要求から一定時間で打ち切る／実行後は測り直す）のテストを追加
- 既存のEditModeテストはそのまま通る

## 未実施

issueの手順1・5にあるProfilerでの実測は、Unityエディタと実アバターが必要なためこのPRでは行っていない。

NDMFのプレビュー機構との噛み合わせ（`Refresh` がノードを残したときの再監視の挙動）も、実機なしでは確かめられていない。仮に先送りが期待どおり効かない場合でも、合図は必ず届くので反映が遅れることはあっても止まることはない、という組み方にしてある。

手順4（差分再生成）はissueの記載どおり見送った。まず手順2・3の効果を実測してから判断したい。
