### PR TITLE
feat: 特定のARKit BlendShapeを生成対象から除外できるようにする

### DIFF
--- a/Editor/Domain/BlendShapeGenerationEngine.cs
+++ b/Editor/Domain/BlendShapeGenerationEngine.cs
@@ -18,7 +18,20 @@ namespace ARKitBlendShapeGenerator.Domain
         public List<BlendShapeSource> MouthCancellationSources { get; set; }
         public float MouthCancellationStrength { get; set; } = 1.0f;
         public HashSet<string> MouthCancellationTargets { get; set; }
+        public HashSet<string> ExcludedArkitNames { get; set; }
         public bool Debug { get; set; }
+
+        /// <summary>
+        /// 生成対象から除外されたARKit名か。
+        /// 自動マッピング・カスタムマッピング・手続き的生成の入口すべてがこの判定を共有する
+        /// （どれか1つでも通すと、除外したはずの名前がその経路だけ生成される）
+        /// </summary>
+        public bool IsExcluded(string arkitName)
+        {
+            return ExcludedArkitNames != null
+                && !string.IsNullOrEmpty(arkitName)
+                && ExcludedArkitNames.Contains(arkitName);
+        }
 
         public static BlendShapeGenerationOptions FromComponent(ARKitBlendShapeGeneratorComponent component)
         {
@@ -33,29 +46,30 @@ namespace ARKitBlendShapeGenerator.Domain
                 EnableMouthCancellation = component.enableMouthCancellation,
                 MouthCancellationSources = component.mouthCancellationSources,
                 MouthCancellationStrength = component.mouthCancellationStrength,
-                MouthCancellationTargets = BuildTargetSet(component.mouthCancellationTargets),
+                MouthCancellationTargets = BuildNameSet(component.mouthCancellationTargets),
+                ExcludedArkitNames = BuildNameSet(component.excludedArkitNames),
                 Debug = component.debugMode
             };
         }
 
         /// <summary>
-        /// 打ち消し対象のARKit名の集合を作る。
-        /// 名前は加工せず、AppliesToでの照合も完全一致で行う（ここでTrimすると
-        /// インスペクタの選択状態と実際の打ち消し対象が食い違う）。空白のみは未設定として無視する。
+        /// インスペクタで選択したARKit名の集合を作る（打ち消しの焼き込み先と、生成の除外対象）。
+        /// 名前は加工せず、照合も完全一致で行う（ここでTrimすると
+        /// インスペクタの選択状態と実際の対象が食い違う）。空白のみは未設定として無視する。
         /// </summary>
-        private static HashSet<string> BuildTargetSet(List<string> targets)
+        private static HashSet<string> BuildNameSet(List<string> names)
         {
             var result = new HashSet<string>();
-            if (targets == null)
+            if (names == null)
             {
                 return result;
             }
 
-            foreach (var target in targets)
+            foreach (var name in names)
             {
-                if (!string.IsNullOrWhiteSpace(target))
+                if (!string.IsNullOrWhiteSpace(name))
                 {
-                    result.Add(target);
+                    result.Add(name);
                 }
             }
 
@@ -740,6 +754,12 @@ namespace ARKitBlendShapeGenerator.Domain
 
             foreach (var arkitName in ProceduralMouthShapeGenerator.TargetShapeNames)
             {
+                if (options.IsExcluded(arkitName))
+                {
+                    Log(logger, options, $"Skip procedural (excluded): {arkitName}");
+                    continue;
+                }
+
                 // 既存シェイプキーからの生成が成立している場合はそちらを優先
                 if (generatedNames.Contains(arkitName))
                 {
@@ -858,6 +878,15 @@ namespace ARKitBlendShapeGenerator.Domain
                     continue;
                 }
 
+                // 除外はカスタムマッピングより優先する。
+                // customMappedNamesへ入れないが、自動マッピングと手続き的生成も同じ判定で弾くため
+                // ここで抜けた名前が別経路から生成されることはない
+                if (options.IsExcluded(mapping.arkitName))
+                {
+                    Log(logger, options, $"Skip custom (excluded): {mapping.arkitName}");
+                    continue;
+                }
+
                 if (mapping.sources == null || mapping.sources.Count == 0)
                 {
                     continue;
@@ -909,11 +938,23 @@ namespace ARKitBlendShapeGenerator.Domain
             IGenerationLogger logger)
         {
             var processedArkitNames = new HashSet<string>();
+            var loggedExclusions = new HashSet<string>();
 
             foreach (var mapping in autoMappings)
             {
                 if (mapping == null || string.IsNullOrEmpty(mapping.arkitName) || mapping.sources == null)
                 {
+                    continue;
+                }
+
+                if (options.IsExcluded(mapping.arkitName))
+                {
+                    // 同じARKit名に候補が複数あるため、既に弾いた名前はログを繰り返さない
+                    if (loggedExclusions.Add(mapping.arkitName))
+                    {
+                        Log(logger, options, $"Skip auto (excluded): {mapping.arkitName}");
+                    }
+
                     continue;
                 }
 

--- a/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
+++ b/Editor/Handler/ARKitBlendShapeGeneratorPreview.cs
@@ -145,6 +145,7 @@ namespace ARKitBlendShapeGenerator.Handler
             private readonly int _observedMouthCancellationSignature;
             private readonly int _observedTargetRendererInstanceId;
             private readonly int _observedCustomMappingsSignature;
+            private readonly int _observedExcludedArkitNamesSignature;
             private readonly Dictionary<string, int> _shapeIndices = new Dictionary<string, int>();
             private HashSet<int> _appliedInteractiveIndices = new HashSet<int>();
             private HashSet<int> _nextAppliedInteractiveIndices = new HashSet<int>();
@@ -172,6 +173,7 @@ namespace ARKitBlendShapeGenerator.Handler
                 float observedMouthCancellationStrength = 0f;
                 int observedMouthCancellationSignature = 0;
                 int observedCustomMappingsSignature = 0;
+                int observedExcludedArkitNamesSignature = 0;
                 SkinnedMeshRenderer observedTargetRenderer = null;
                 if (component != null)
                 {
@@ -186,6 +188,7 @@ namespace ARKitBlendShapeGenerator.Handler
                     observedMouthCancellationStrength = context.Observe(component, c => c.mouthCancellationStrength);
                     observedMouthCancellationSignature = BuildMouthCancellationSignature(component);
                     observedCustomMappingsSignature = BuildCustomMappingsSignature(component.customMappings);
+                    observedExcludedArkitNamesSignature = BuildExcludedArkitNamesSignature(component);
                     observedTargetRenderer = context.Observe(component, c => c.targetRenderer);
                 }
 
@@ -199,6 +202,7 @@ namespace ARKitBlendShapeGenerator.Handler
                 _observedMouthCancellationStrength = observedMouthCancellationStrength;
                 _observedMouthCancellationSignature = observedMouthCancellationSignature;
                 _observedCustomMappingsSignature = observedCustomMappingsSignature;
+                _observedExcludedArkitNamesSignature = observedExcludedArkitNamesSignature;
                 _observedTargetRendererInstanceId = observedTargetRenderer != null ? observedTargetRenderer.GetInstanceID() : 0;
 
                 context.Observe(originalRenderer, r => r.sharedMesh);
@@ -307,6 +311,12 @@ namespace ARKitBlendShapeGenerator.Handler
 
                 int currentCustomMappingsSignature = BuildCustomMappingsSignature(_component.customMappings);
                 if (currentCustomMappingsSignature != _observedCustomMappingsSignature)
+                {
+                    return Task.FromResult<IRenderFilterNode>(null);
+                }
+
+                int currentExcludedArkitNamesSignature = BuildExcludedArkitNamesSignature(_component);
+                if (currentExcludedArkitNamesSignature != _observedExcludedArkitNamesSignature)
                 {
                     return Task.FromResult<IRenderFilterNode>(null);
                 }
@@ -442,6 +452,27 @@ namespace ARKitBlendShapeGenerator.Handler
                     foreach (var target in targets)
                     {
                         hash = (hash * 31) + HashString(target);
+                    }
+
+                    return hash;
+                }
+            }
+
+            private static int BuildExcludedArkitNamesSignature(ARKitBlendShapeGeneratorComponent component)
+            {
+                unchecked
+                {
+                    int hash = 17;
+                    var excluded = component != null ? component.excludedArkitNames : null;
+                    if (excluded == null)
+                    {
+                        return (hash * 31) + 2;
+                    }
+
+                    hash = (hash * 31) + excluded.Count;
+                    foreach (var name in excluded)
+                    {
+                        hash = (hash * 31) + HashString(name);
                     }
 
                     return hash;

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -242,6 +242,25 @@ msgstr "Left/Right Split is off, so this setting is ignored during generation (t
 msgid "enum.side.cancellation.tooltip"
 msgstr "Which half the cancellation is applied to. Left Only = the avatar's left half (mesh local X < 0), Right Only = the right half (X > 0). It represents how the blend shape is applied on the avatar, so it takes effect regardless of the Left/Right Split setting."
 
+# Excluded ARKit blend shapes
+msgid "inspector.section.excluded"
+msgstr "Excluded ARKit BlendShapes"
+
+msgid "excluded.description"
+msgstr "Checked ARKit blend shapes are not generated, neither by auto mapping, custom mapping, nor procedural mouth generation. Existing blend shapes with the same name are kept as they are: they are never deleted, and never overwritten even while Overwrite Existing is on."
+
+msgid "excluded.clear"
+msgstr "Clear All"
+
+msgid "excluded.count"
+msgstr "Excluded: {0}/{1}"
+
+msgid "excluded.custom_mapping_warning"
+msgstr "These ARKit names are also set in custom mappings, but exclusion takes precedence so they are not generated: {0}"
+
+msgid "excluded.cancellation_target_warning"
+msgstr "These ARKit names are cancellation bake targets, but they are excluded from generation so the cancellation has no effect: {0}"
+
 # Preview
 msgid "inspector.section.preview"
 msgstr "Preview"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -242,6 +242,25 @@ msgstr "左右分割がOFFのため、この指定は生成時に無視されま
 msgid "enum.side.cancellation.tooltip"
 msgstr "打ち消しを適用する左右の範囲。左のみ＝アバターから見て左半分（メッシュローカル座標のX<0）、右のみ＝右半分（X>0）。アバター側での適用範囲を表すため、左右分割の設定に関わらず適用されます。"
 
+# 生成しないARKit BlendShape
+msgid "inspector.section.excluded"
+msgstr "生成しないARKit BlendShape"
+
+msgid "excluded.description"
+msgstr "チェックしたARKit BlendShapeを生成しません。自動マッピング・カスタムマッピング・口の手続き的生成のいずれからも生成されなくなります。既にメッシュにある同名のBlendShapeは消さずにそのまま残し、「既存を上書き」がONでも上書きしません。"
+
+msgid "excluded.clear"
+msgstr "全て解除"
+
+msgid "excluded.count"
+msgstr "除外: {0}/{1}"
+
+msgid "excluded.custom_mapping_warning"
+msgstr "次のARKit名はカスタムマッピングでも設定されていますが、除外が優先されるため生成されません: {0}"
+
+msgid "excluded.cancellation_target_warning"
+msgstr "次のARKit名は打ち消しの焼き込み先ですが、除外により生成されないため打ち消しが効きません: {0}"
+
 # プレビュー
 msgid "inspector.section.preview"
 msgstr "プレビュー"

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -20,6 +20,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         private List<string> _availableBlendShapes = new List<string>();
         private bool _showCustomMappings = true;
         private bool _showAutoMappings = false;
+        private bool _showExcludedNames = false;
         private bool _showPreview = false;
         private bool _showNdmfOffWarning;
         private bool _showPreviewCategoryCustom = true;
@@ -28,6 +29,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         private Vector2 _scrollPosition;
         private Vector2 _previewScrollPosition;
         private Vector2 _mouthCancellationTargetScrollPosition;
+        private Vector2 _excludedNameScrollPosition;
         private int _cachedPreviewConfigRevision = -1;
         private int _cachedPreviewRendererInstanceId;
         private int _cachedPreviewMeshInstanceId;
@@ -148,6 +150,18 @@ namespace ARKitBlendShapeGenerator.Presentation
             {
                 EditorGUI.indentLevel++;
                 DrawCustomMappingsUI();
+                EditorGUI.indentLevel--;
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+
+            // 生成しないARKit BlendShape
+            _showExcludedNames = EditorGUILayout.Foldout(_showExcludedNames, S("inspector.section.excluded"), true);
+            if (_showExcludedNames)
+            {
+                EditorGUI.indentLevel++;
+                DrawExcludedArkitNamesUI();
                 EditorGUI.indentLevel--;
             }
 
@@ -885,6 +899,153 @@ namespace ARKitBlendShapeGenerator.Presentation
             EditorGUILayout.EndScrollView();
         }
 
+        /// <summary>
+        /// 除外の選択肢。GetAllは呼び出しのたびに配列を組み立てるため、再描画ごとの確保を避ける
+        /// </summary>
+        private static readonly string[] ExcludableArkitNames = ARKitBlendShapeNames.GetAll();
+
+        /// <summary>
+        /// 生成対象から除外するARKit名を選ぶ。
+        /// 除外は「生成しない」であって「消す」ではないため、同名の既存シェイプはそのまま残る
+        /// </summary>
+        private void DrawExcludedArkitNamesUI()
+        {
+            EditorGUILayout.HelpBox(S("excluded.description"), MessageType.Info);
+
+            var excludedProperty = serializedObject.FindProperty("excludedArkitNames");
+            var selectableNames = ExcludableArkitNames;
+
+            if (GUILayout.Button(S("excluded.clear"), EditorStyles.miniButton))
+            {
+                excludedProperty.ClearArray();
+            }
+
+            EditorGUILayout.LabelField(
+                S("excluded.count", excludedProperty.arraySize, selectableNames.Length),
+                EditorStyles.miniLabel);
+
+            DrawExcludedConflictWarnings(excludedProperty);
+
+            _excludedNameScrollPosition = EditorGUILayout.BeginScrollView(
+                _excludedNameScrollPosition,
+                GUILayout.Height(200f));
+
+            foreach (var arkitName in selectableNames)
+            {
+                int existingIndex = IndexOfStringElement(excludedProperty, arkitName);
+                bool isExcluded = existingIndex >= 0;
+                bool newExcluded = EditorGUILayout.ToggleLeft(arkitName, isExcluded);
+                if (newExcluded == isExcluded)
+                {
+                    continue;
+                }
+
+                if (newExcluded)
+                {
+                    AppendStringElement(excludedProperty, arkitName);
+                }
+                else
+                {
+                    excludedProperty.DeleteArrayElementAtIndex(existingIndex);
+                }
+            }
+
+            EditorGUILayout.EndScrollView();
+        }
+
+        /// <summary>
+        /// 除外と食い違う設定を警告する。
+        /// どちらも黙って効かなくなる組み合わせのため、設定画面で気付けるようにする
+        /// </summary>
+        private void DrawExcludedConflictWarnings(SerializedProperty excludedProperty)
+        {
+            var excludedNames = new HashSet<string>();
+            for (int i = 0; i < excludedProperty.arraySize; i++)
+            {
+                var name = excludedProperty.GetArrayElementAtIndex(i).stringValue;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    excludedNames.Add(name);
+                }
+            }
+
+            if (excludedNames.Count == 0)
+            {
+                return;
+            }
+
+            // 除外はカスタムマッピングより優先するため、同名のマッピングは生成されない
+            var customMappingsProperty = serializedObject.FindProperty("customMappings");
+            var shadowedMappings = new List<string>();
+            for (int i = 0; i < customMappingsProperty.arraySize; i++)
+            {
+                var mappingProperty = customMappingsProperty.GetArrayElementAtIndex(i);
+                if (!mappingProperty.FindPropertyRelative("enabled").boolValue)
+                {
+                    continue;
+                }
+
+                var arkitName = mappingProperty.FindPropertyRelative("arkitName").stringValue;
+                if (excludedNames.Contains(arkitName) && !shadowedMappings.Contains(arkitName))
+                {
+                    shadowedMappings.Add(arkitName);
+                }
+            }
+
+            if (shadowedMappings.Count > 0)
+            {
+                EditorGUILayout.HelpBox(
+                    S("excluded.custom_mapping_warning", string.Join(", ", shadowedMappings.OrderBy(name => name))),
+                    MessageType.Warning);
+            }
+
+            // 焼き込み先が生成されないと、打ち消しは黙って効かなくなる
+            if (!serializedObject.FindProperty("enableMouthCancellation").boolValue)
+            {
+                return;
+            }
+
+            var targetsProperty = serializedObject.FindProperty("mouthCancellationTargets");
+            var shadowedTargets = new List<string>();
+            for (int i = 0; i < targetsProperty.arraySize; i++)
+            {
+                var target = targetsProperty.GetArrayElementAtIndex(i).stringValue;
+                if (excludedNames.Contains(target) && !shadowedTargets.Contains(target))
+                {
+                    shadowedTargets.Add(target);
+                }
+            }
+
+            if (shadowedTargets.Count > 0)
+            {
+                EditorGUILayout.HelpBox(
+                    S("excluded.cancellation_target_warning", string.Join(", ", shadowedTargets.OrderBy(name => name))),
+                    MessageType.Warning);
+            }
+        }
+
+        /// <summary>
+        /// 除外名の集合を作る。生成側（BuildNameSet）と同じく空白のみは未設定として無視する
+        /// </summary>
+        private HashSet<string> BuildExcludedNameSet()
+        {
+            var result = new HashSet<string>();
+            if (_component == null || _component.excludedArkitNames == null)
+            {
+                return result;
+            }
+
+            foreach (var name in _component.excludedArkitNames)
+            {
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    result.Add(name);
+                }
+            }
+
+            return result;
+        }
+
         private static int IndexOfStringElement(SerializedProperty arrayProperty, string value)
         {
             for (int i = 0; i < arrayProperty.arraySize; i++)
@@ -1219,6 +1380,7 @@ namespace ARKitBlendShapeGenerator.Presentation
             var autoSet = new HashSet<string>();
             var customMappedNames = new HashSet<string>();
             var customMappings = _component.customMappings ?? new List<CustomBlendShapeMapping>();
+            var excludedNames = BuildExcludedNameSet();
 
             foreach (var mapping in customMappings)
             {
@@ -1226,6 +1388,11 @@ namespace ARKitBlendShapeGenerator.Presentation
                 // ここだけIsNullOrEmptyだと、生成されない空白のみの名前が
                 // 空欄のスライダーとしてプレビューに並んでしまう
                 if (mapping == null || !mapping.enabled || string.IsNullOrWhiteSpace(mapping.arkitName))
+                {
+                    continue;
+                }
+
+                if (excludedNames.Contains(mapping.arkitName))
                 {
                     continue;
                 }
@@ -1261,6 +1428,11 @@ namespace ARKitBlendShapeGenerator.Presentation
             foreach (var mapping in ARKitMappingTable.GetMappings())
             {
                 if (mapping == null || string.IsNullOrEmpty(mapping.arkitName) || mapping.sources == null)
+                {
+                    continue;
+                }
+
+                if (excludedNames.Contains(mapping.arkitName))
                 {
                     continue;
                 }
@@ -1312,7 +1484,9 @@ namespace ARKitBlendShapeGenerator.Presentation
             {
                 foreach (var arkitName in ProceduralMouthShapeGenerator.TargetShapeNames)
                 {
-                    if (customMappedNames.Contains(arkitName) || autoSet.Contains(arkitName))
+                    if (excludedNames.Contains(arkitName) ||
+                        customMappedNames.Contains(arkitName) ||
+                        autoSet.Contains(arkitName))
                     {
                         continue;
                     }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 | **Enable Mouth Cancellation** | 生成した口関連BlendShapeに、指定したBlendShapeの打ち消し成分を焼き込む（デフォルト: 無効） |
 | **Mouth Cancellation Strength** | 打ち消し量の全体係数（0.0〜1.0） |
 | **Custom Mappings** | 自動マッピングできないBlendShapeを手動で指定 |
+| **生成しないARKit BlendShape** | チェックしたARKit BlendShapeを生成対象から外す |
 | **Debug Mode** | デバッグログを出力する |
 
 Target Renderer が空のときは、コンポーネントの直下にある `Body` / `body` / `Face` / `face` / `Head` / `head` のいずれかの名前を持つSkinnedMeshRendererを優先し、見つからなければ自身を含む子孫の最初のSkinnedMeshRendererを対象にします。
@@ -70,6 +71,19 @@ Sideは適用する頂点の範囲を表し、「左のみ」はアバターか�
 `Enable Left Right Split` は生成全体で頂点のX座標による左右分割を行うかどうかのスイッチです。
 OFFのときはカスタムマッピングのSideも無視され、ソースが両側に適用されます。
 無視されていることが分かるよう、OFFのあいだSideのドロップダウンは非活性で表示されます（設定値そのものは保持され、ONに戻すとまた効きます）。
+
+### 生成しないARKit BlendShape
+
+自動マッピングが成立してしまうものの、生成結果が不自然になる名前は、「生成しないARKit BlendShape」で個別に外せます。
+チェックした名前は自動マッピング、カスタムマッピング、口の手続き的生成のいずれからも生成されません。
+
+除外は「生成しない」であって「消す」ではありません。
+既にメッシュにある同名のBlendShapeはそのまま残り、`Overwrite Existing` がONでも上書きされません。
+生成する対象は減らしたいが手で作り込んだ既存のBlendShapeは残したい、という場合にも使えます。
+
+カスタムマッピングと除外で同じARKit名を指定した場合は、除外が優先されます。
+設定が食い違っていることが分かるよう、その場合はインスペクタに警告が出ます。
+打ち消しの焼き込み先を除外したときも同様で、焼き込み先が生成されないため打ち消しは効きません。
 
 ### NDMFプレビュー
 

--- a/Runtime/ARKitBlendShapeGeneratorComponent.cs
+++ b/Runtime/ARKitBlendShapeGeneratorComponent.cs
@@ -65,6 +65,10 @@ namespace ARKitBlendShapeGenerator
         [Tooltip("Manually specify blend shapes that cannot be mapped automatically")]
         public List<CustomBlendShapeMapping> customMappings = new List<CustomBlendShapeMapping>();
 
+        [Header("Exclusion")]
+        [Tooltip("ARKit blend shapes to leave ungenerated. Existing blend shapes with the same name are kept as they are (they are never deleted, and never overwritten even while Overwrite Existing is on)")]
+        public List<string> excludedArkitNames = new List<string>();
+
         [Header("Debug")]
         [Tooltip("Output debug logs")]
         public bool debugMode = false;

--- a/Tests/Editor/BlendShapeGenerationOptionsTests.cs
+++ b/Tests/Editor/BlendShapeGenerationOptionsTests.cs
@@ -94,5 +94,39 @@ namespace ARKitBlendShapeGenerator.Tests
 
             Assert.That(options.MouthCancellationTargets, Is.Empty);
         }
+
+        [Test]
+        public void FromComponent_CopiesExcludedArkitNames()
+        {
+            var component = CreateComponent();
+            component.excludedArkitNames = new List<string> { "mouthClose", "cheekPuff" };
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.ExcludedArkitNames, Is.EquivalentTo(new[] { "mouthClose", "cheekPuff" }));
+        }
+
+        [Test]
+        public void FromComponent_IgnoresBlankExcludedArkitNames()
+        {
+            // 打ち消しの焼き込み先と同じ規則。空白のみは未設定として扱い、名前自体は加工しない
+            var component = CreateComponent();
+            component.excludedArkitNames = new List<string> { "mouthClose", "", "   ", null, " cheekPuff" };
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.ExcludedArkitNames, Is.EquivalentTo(new[] { "mouthClose", " cheekPuff" }));
+        }
+
+        [Test]
+        public void FromComponent_ReturnsEmptyExclusions_WhenExcludedListIsNull()
+        {
+            var component = CreateComponent();
+            component.excludedArkitNames = null;
+
+            var options = BlendShapeGenerationOptions.FromComponent(component);
+
+            Assert.That(options.ExcludedArkitNames, Is.Empty);
+        }
     }
 }

--- a/Tests/Editor/ExcludedArkitNameTests.cs
+++ b/Tests/Editor/ExcludedArkitNameTests.cs
@@ -1,0 +1,247 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 生成対象から除外したARKit名の扱いの検証。
+    ///
+    /// 除外は自動マッピング・カスタムマッピング・口の手続き的生成の3経路すべてで効く必要がある。
+    /// どれか1つでも判定が漏れると、除外したはずの名前がその経路だけ生成される。
+    /// また、除外は「生成しない」であって「消す」ではないため、既存シェイプへは触れない。
+    /// </summary>
+    public class ExcludedArkitNameTests
+    {
+        // 左(X<0)・右(X>0)に1頂点ずつ持つ最小構成
+        private static Vector3[] TwoVertices() => new[]
+        {
+            new Vector3(-1f, 0f, 0f),
+            new Vector3(1f, 0f, 0f),
+        };
+
+        // 口領域を模した直方体（左右2 × 上下2 × 前後2）に、口から離れた頂点を1つ足した構成
+        private const float SideX = 0.05f;
+        private const float UpperY = 0.01f;
+        private const float LowerY = -0.01f;
+        private const float FrontZ = 0.05f;
+        private const float BackZ = 0f;
+
+        private const int RegionVertexCount = 8;
+        private const float MouthSourceDelta = 0.02f;
+
+        private const string MouthSourceShapeName = "vrc.v_aa";
+
+        private static Vector3[] MouthVertices() => new[]
+        {
+            new Vector3(-SideX, UpperY, FrontZ),
+            new Vector3(SideX, UpperY, FrontZ),
+            new Vector3(-SideX, LowerY, FrontZ),
+            new Vector3(SideX, LowerY, FrontZ),
+            new Vector3(-SideX, UpperY, BackZ),
+            new Vector3(SideX, UpperY, BackZ),
+            new Vector3(-SideX, LowerY, BackZ),
+            new Vector3(SideX, LowerY, BackZ),
+            new Vector3(0f, 0.5f, 0f),
+        };
+
+        private static Vector3[] RegionDeltas()
+        {
+            var deltas = new Vector3[MouthVertices().Length];
+            for (int i = 0; i < RegionVertexCount; i++)
+            {
+                deltas[i] = Vector3.down * MouthSourceDelta;
+            }
+
+            return deltas;
+        }
+
+        /// <summary>口領域を検出できるシェイプキーを1つ持つメッシュ</summary>
+        private static FakeMeshRepository MouthMesh()
+        {
+            return new FakeMeshRepository(MouthVertices())
+                .AddShape(MouthSourceShapeName, RegionDeltas());
+        }
+
+        private static BlendShapeGenerationOptions CreateOptions(params string[] excludedArkitNames)
+        {
+            return new BlendShapeGenerationOptions
+            {
+                IntensityMultiplier = 1.0f,
+                EnableLeftRightSplit = false,
+                BlendWidth = 0.02f,
+                OverwriteExisting = false,
+                ExcludedArkitNames = new HashSet<string>(excludedArkitNames),
+            };
+        }
+
+        private static List<ARKitMapping> AutoMapping(string arkitName, string sourceName)
+        {
+            return new List<ARKitMapping>
+            {
+                new ARKitMapping(arkitName, new List<SourceMapping>
+                {
+                    new SourceMapping(1.0f, sourceName),
+                }),
+            };
+        }
+
+        private static List<CustomBlendShapeMapping> CustomMapping(string arkitName, string sourceName)
+        {
+            return new List<CustomBlendShapeMapping>
+            {
+                new CustomBlendShapeMapping
+                {
+                    arkitName = arkitName,
+                    enabled = true,
+                    sources = new List<BlendShapeSource>
+                    {
+                        new BlendShapeSource { blendShapeName = sourceName, weight = 1.0f, side = BlendShapeSide.Both },
+                    },
+                },
+            };
+        }
+
+        [Test]
+        public void Generate_SkipsExcludedName_FromAutoMapping()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source,
+                target,
+                null,
+                AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                CreateOptions("eyeBlinkLeft"),
+                null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.FindShape("eyeBlinkLeft"), Is.Null);
+        }
+
+        [Test]
+        public void Generate_SkipsExcludedName_FromCustomMapping()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source,
+                target,
+                CustomMapping("eyeBlinkLeft", "vrc.blink"),
+                null,
+                CreateOptions("eyeBlinkLeft"),
+                null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.FindShape("eyeBlinkLeft"), Is.Null);
+        }
+
+        [Test]
+        public void Generate_SkipsExcludedName_FromProceduralMouthGeneration()
+        {
+            var target = MouthMesh();
+            var options = CreateOptions("mouthLeft");
+            options.EnableProceduralMouthShapes = true;
+            options.ProceduralMouthIntensity = 1.0f;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                MouthMesh(), target, null, null, options, null);
+
+            Assert.That(result.GeneratedShapes, Does.Not.Contain("mouthLeft"));
+            Assert.That(target.FindShape("mouthLeft"), Is.Null);
+
+            // 除外していない名前は手続き的生成で作られる
+            Assert.That(result.GeneratedShapes, Contains.Item("mouthRight"));
+        }
+
+        [Test]
+        public void Generate_DoesNotFallBackToProcedural_WhenExcludedNameHasCustomMapping()
+        {
+            // 除外はカスタムマッピングより優先する。
+            // カスタム定義を弾いた結果として手続き的生成へ流れてしまうと、除外が骨抜きになる
+            var target = MouthMesh();
+            var options = CreateOptions("mouthLeft");
+            options.EnableProceduralMouthShapes = true;
+            options.ProceduralMouthIntensity = 1.0f;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                MouthMesh(),
+                target,
+                CustomMapping("mouthLeft", MouthSourceShapeName),
+                null,
+                options,
+                null);
+
+            Assert.That(result.GeneratedShapes, Does.Not.Contain("mouthLeft"));
+            Assert.That(target.FindShape("mouthLeft"), Is.Null);
+        }
+
+        [Test]
+        public void Generate_KeepsExistingShape_WhenExcludedNameWouldBeOverwritten()
+        {
+            // 除外は「生成しない」であって「消す」ではない。
+            // 上書きONでも、除外した名前の既存シェイプは元のデルタのまま残る
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up)
+                .AddShape("eyeBlinkLeft", Vector3.left, Vector3.left);
+            var target = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up)
+                .AddShape("eyeBlinkLeft", Vector3.left, Vector3.left);
+
+            var options = CreateOptions("eyeBlinkLeft");
+            options.OverwriteExisting = true;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source,
+                target,
+                null,
+                AutoMapping("eyeBlinkLeft", "vrc.blink"),
+                options,
+                null);
+
+            Assert.That(result.GeneratedShapes, Is.Empty);
+            Assert.That(target.CountShapes("eyeBlinkLeft"), Is.EqualTo(1));
+
+            var shape = target.FindShape("eyeBlinkLeft");
+            Assert.That(shape.Frames[0].DeltaVertices, Is.EqualTo(new[] { Vector3.left, Vector3.left }));
+        }
+
+        [Test]
+        public void Generate_OnlySkipsExcludedNames()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+
+            var autoMappings = AutoMapping("eyeBlinkLeft", "vrc.blink");
+            autoMappings.AddRange(AutoMapping("eyeBlinkRight", "vrc.blink"));
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, autoMappings, CreateOptions("eyeBlinkLeft"), null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkRight" }));
+        }
+
+        [Test]
+        public void Generate_IgnoresExclusions_WhenNoneAreConfigured()
+        {
+            var source = new FakeMeshRepository(TwoVertices())
+                .AddShape("vrc.blink", Vector3.up, Vector3.up);
+            var target = new FakeMeshRepository(TwoVertices());
+
+            // 除外集合が未設定（null）でも生成は従来どおり動く
+            var options = CreateOptions();
+            options.ExcludedArkitNames = null;
+
+            var result = BlendShapeGenerationEngine.Generate(
+                source, target, null, AutoMapping("eyeBlinkLeft", "vrc.blink"), options, null);
+
+            Assert.That(result.GeneratedShapes, Is.EqualTo(new[] { "eyeBlinkLeft" }));
+        }
+    }
+}


### PR DESCRIPTION
Closes #66

## 概要

自動マッピングが成立してしまうものの生成結果が不自然になる名前（MMDの「あ」から導いた `mouthClose` や `cheekPuff` など）を、個別に生成対象から外せるようにする。

コンポーネントへ `excludedArkitNames`（`List<string>`）を追加し、インスペクタのトグル一覧で選択する。
除外した名前は**自動マッピング・カスタムマッピング・口の手続き的生成のいずれからも生成されない**。

除外は「生成しない」であって「消す」ではない。
同名の既存BlendShapeは削除せず、`Overwrite Existing` がONでも上書きしない。
名前単位で上書きから守れる手段は他に無いため、この扱いを既定とした。

設計案の比較（`enabled = false` の再解釈を採らなかった理由など）は #66 に記載している。

## 変更内容

### 生成ロジック

- `BlendShapeGenerationOptions` へ `ExcludedArkitNames` と判定の述語 `IsExcluded` を追加
    - 判定を1箇所に集約した。3経路のどれかで漏らすと、除外したはずの名前がその経路だけ生成される
- `CollectCustomMappings` / `CollectAutoMappings` / `CollectProceduralMouthShapes` の入口で弾く
- 除外はカスタムマッピングより優先する
    - 除外された名前は `customMappedNames` へ入らないが、手続き的生成側でも同じ判定を通すためフォールバックしない
- 打ち消しの焼き込み先と除外対象で名前集合の組み立てが同じため、`BuildTargetSet` を `BuildNameSet` へ改名して共有した（完全一致で照合し、空白のみは未設定として無視する方針も共通）
- 自動マッピングは同じARKit名に候補が複数あるため、除外のログは名前ごとに1回だけ出す

### プレビュー

- NDMFプレビュー: 除外リストをsignatureへ含め、チェックの付け外しでノードが作り直されるようにした
- インスペクタのプレビュー一覧: `BuildRealtimePreviewCategories` は生成可否を独自に組み直しているため、こちらにも同じ判定を入れた（入れないと生成されないシェイプが「自動生成」として並ぶ）

### UI

- 「生成しないARKit BlendShape」セクションを追加。対象は `ARKitBlendShapeNames.GetAll()`
- 食い違う設定に警告を出す
    - 除外名と同名の有効なカスタムマッピングがある（除外が優先されるため生成されない）
    - 除外名が打ち消しの焼き込み先に含まれる（焼き込み先が生成されず打ち消しが効かない）
- `ja-jp.po` / `en-us.po` へ文言を追加

### ドキュメント

- READMEの設定表へ1行追加し、「生成しないARKit BlendShape」の節で除外と削除の違いを明記した

## テスト

`Tests/Editor/ExcludedArkitNameTests.cs` を追加した。

- 除外した名前が自動マッピング / カスタムマッピング / 手続き的生成のどの経路でも生成されない
- 除外名にカスタムマッピングがあっても手続き的生成へフォールバックしない
- `Overwrite Existing` がONでも除外名の既存シェイプが元のデルタのまま残る
- 除外していない名前は従来どおり生成される
- 除外集合が未設定（null）でも生成が従来どおり動く

`BlendShapeGenerationOptionsTests` へ `excludedArkitNames` の変換（空白のみの無視、null時の空集合）を追加した。

> [!NOTE]
> この環境にUnityが無いためEditModeテストは未実行で、CIの結果に依存している。
> 手元で確認する場合はREADMEの手順で `ARKitBlendShapeGenerator.Editor.Tests` を実行してほしい。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FSR1pKnBC4md93KQfq1ddY)_