### PR TITLE
ci: テスト対象外の変更ではEditModeテストを飛ばす

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,14 +85,17 @@ jobs:
         run: |
           set -euo pipefail
 
+          # 1ファイルにつき1行を出す。件数を数えるためで、行数がそのままファイル数になる。
           # リネームで対象外へ移した変更（Editor/A.cs → docs/A.cs など）は新パスだけでは
-          # 検出できないため、previous_filenameも判定に含める。
-          RENAME_AWARE='.filename, (.previous_filename // empty)'
+          # 検出できないため、previous_filenameも同じ行へ並べる。
+          RENAME_AWARE='[.filename, (.previous_filename // "")] | @tsv'
 
           case "$EVENT_NAME" in
             pull_request)
               ENDPOINT="repos/$REPO/pulls/$PR_NUMBER/files"
               JQ=".[] | $RENAME_AWARE"
+              # このエンドポイントが返すのは最大3000件
+              FILE_LIMIT=3000
               ;;
             push)
               # ブランチ作成時やforce push後は`before`が到達不能なコミットを指し比較できない
@@ -104,6 +107,8 @@ jobs:
               # `?`を付けず、想定外のレスポンスではjqを失敗させる。
               # 黙って空の一覧として扱うと、判定できない変更をスキップしてしまう。
               JQ=".files[] | $RENAME_AWARE"
+              # compareの`files`が返すのは最大300件
+              FILE_LIMIT=300
               ;;
             *)
               # workflow_dispatchなど、比較対象を定められないイベントでは常に実行する
@@ -123,15 +128,28 @@ jobs:
           # テストがコンパイル・実行するコードと、その前提を決めるファイルだけを対象とする。
           # ここに載らないファイルはテスト結果を変えられない。
           RELEVANT=false
-          while IFS= read -r FILE; do
-            [ -n "$FILE" ] || continue
-            case "$FILE" in
-              Editor/*|Runtime/*|Tests/*|package.json|.github/workflows/test.yml)
-                echo "テスト対象の変更: $FILE"
-                RELEVANT=true
-                ;;
-            esac
+          COUNT=0
+          while IFS=$'\t' read -r NEW_PATH OLD_PATH; do
+            [ -n "$NEW_PATH" ] || continue
+            COUNT=$((COUNT + 1))
+            for FILE in "$NEW_PATH" "$OLD_PATH"; do
+              [ -n "$FILE" ] || continue
+              case "$FILE" in
+                Editor/*|Runtime/*|Tests/*|package.json|.github/workflows/test.yml)
+                  echo "テスト対象の変更: $FILE"
+                  RELEVANT=true
+                  ;;
+              esac
+            done
           done <<< "$CHANGED"
+
+          # `--paginate`はページを辿るだけで、エンドポイントごとの返却件数の上限は外さない。
+          # 上限に達した一覧には、返ってこなかった変更が残っている可能性がある。
+          # 完全だと確認できない一覧を根拠にスキップするわけにはいかないので、実行側へ倒す。
+          if [ "$RELEVANT" = "false" ] && [ "$COUNT" -ge "$FILE_LIMIT" ]; then
+            echo "::warning::変更ファイルが上限の${FILE_LIMIT}件に達し一覧が不完全な可能性があるためEditModeテストを実行します"
+            RELEVANT=true
+          fi
 
           if [ "$RELEVANT" = "false" ]; then
             echo "::notice::テスト対象のファイルに変更がないためEditModeテストをスキップします"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,30 +13,23 @@ name: Test
 # 取得手順は https://game.ci/docs/github/activation を参照。
 # UNITY_LICENSEを登録するとそちらで認証するため、シリアルを使う場合は登録しない。
 # どちらも未設定の場合、テストジョブはスキップされる（フォークからのPRを含む）。
+#
+# テスト対象に触れていない変更では、テストジョブをスキップする。
+# 判定は`on`の`paths`フィルタではなく`changes`ジョブと`if`で行う（理由は当該ジョブに記述）。
 
 on:
   pull_request:
-    paths:
-      - 'Editor/**'
-      - 'Runtime/**'
-      - 'Tests/**'
-      - 'package.json'
-      - '.github/workflows/test.yml'
   push:
     branches:
       - main
-    paths:
-      - 'Editor/**'
-      - 'Runtime/**'
-      - 'Tests/**'
-      - 'package.json'
-      - '.github/workflows/test.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
   # テスト結果をチェックランとしてPRへ出すために必要
   checks: write
+  # 変更ファイルの一覧をPull Requests APIから取得するために必要
+  pull-requests: read
 
 env:
   # package.jsonの unity / unityRelease に合わせる。
@@ -66,10 +59,89 @@ jobs:
             echo "::notice::UNITY_LICENSE / UNITY_SERIAL が未設定のためEditModeテストをスキップします"
           fi
 
+  # 変更がテスト対象に触れているかを判定する。
+  #
+  # `on`の`paths`フィルタを使わないのは、テストをrequired status checkに指定できる
+  # ようにするため。`paths`で起動しなかったワークフローはチェックランを作らないので、
+  # requiredに指定するとチェックが未作成のまま待ち状態になりPRをマージできなくなる。
+  # 一方、`if`で飛ばしたジョブはskippedのチェックランを残し、これはrequiredを満たす。
+  #
+  # 対象パスの一覧はこのジョブだけに置く。`on`側にも書くと二重管理になり、
+  # 片方だけ更新したときに「変更したのにテストが走らない」事故につながる。
+  changes:
+    name: Check changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      relevant: ${{ steps.check.outputs.relevant }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # リネームで対象外へ移した変更（Editor/A.cs → docs/A.cs など）は新パスだけでは
+          # 検出できないため、previous_filenameも判定に含める。
+          RENAME_AWARE='.filename, (.previous_filename // empty)'
+
+          case "$EVENT_NAME" in
+            pull_request)
+              ENDPOINT="repos/$REPO/pulls/$PR_NUMBER/files"
+              JQ=".[] | $RENAME_AWARE"
+              ;;
+            push)
+              # ブランチ作成時やforce push後は`before`が到達不能なコミットを指し比較できない
+              if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+                echo "relevant=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              ENDPOINT="repos/$REPO/compare/$BEFORE...$AFTER"
+              # `?`を付けず、想定外のレスポンスではjqを失敗させる。
+              # 黙って空の一覧として扱うと、判定できない変更をスキップしてしまう。
+              JQ=".files[] | $RENAME_AWARE"
+              ;;
+            *)
+              # workflow_dispatchなど、比較対象を定められないイベントでは常に実行する
+              echo "relevant=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          # 差分が分からないまま省略すると壊れた変更を通してしまうため、
+          # 取得に失敗した場合はテストを実行する側へ倒す。
+          if ! CHANGED=$(gh api --paginate "$ENDPOINT" --jq "$JQ"); then
+            echo "::warning::変更ファイルの一覧を取得できなかったためEditModeテストを実行します"
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # テストがコンパイル・実行するコードと、その前提を決めるファイルだけを対象とする。
+          # ここに載らないファイルはテスト結果を変えられない。
+          RELEVANT=false
+          while IFS= read -r FILE; do
+            [ -n "$FILE" ] || continue
+            case "$FILE" in
+              Editor/*|Runtime/*|Tests/*|package.json|.github/workflows/test.yml)
+                echo "テスト対象の変更: $FILE"
+                RELEVANT=true
+                ;;
+            esac
+          done <<< "$CHANGED"
+
+          if [ "$RELEVANT" = "false" ]; then
+            echo "::notice::テスト対象のファイルに変更がないためEditModeテストをスキップします"
+          fi
+          echo "relevant=$RELEVANT" >> "$GITHUB_OUTPUT"
+
   test:
     name: EditMode tests
-    needs: license
-    if: needs.license.outputs.available == 'true'
+    needs: [license, changes]
+    if: needs.license.outputs.available == 'true' && needs.changes.outputs.relevant == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout package

--- a/README.md
+++ b/README.md
@@ -164,8 +164,13 @@ CIでも実行されますが（後述）、Unityライセンスのsecretが未�
 
 ### CIでのテスト実行
 
-`.github/workflows/test.yml` が、`Editor/` `Runtime/` `Tests/` `package.json` を変更したPRでEditModeテストを実行します。
+`.github/workflows/test.yml` が、PRごとにEditModeテストを実行します。
 結果は「EditMode Test Results」チェックとしてPRに出ます。
+
+テストが読むのは `Editor/` `Runtime/` `Tests/` `package.json` とワークフロー自身だけなので、これらに触れないPRではテストジョブをスキップします。
+スキップの判定はワークフローの `changes` ジョブが行い、テストジョブはskippedとして完了します。
+`on` の `paths` フィルタを使っていないのは、そちらで起動を止めるとチェック自体が作られず、テストをrequired status checkに指定したときにPRをマージできなくなるためです。
+判定に使うパスの一覧は `changes` ジョブにのみ書かれています。テストが読むファイルを増やしたときは、この一覧にも追加してください。
 
 このリポジトリはUnityプロジェクトではないため、ワークフローは実行のたびに最小のUnityプロジェクトを組み立て、その `Packages/` へこのリポジトリを置きます。
 VPM依存（VRChat SDK / NDMF）はUnity Package Managerでは解決できないので、[vrc-get](https://github.com/vrc-get/vrc-get)で先に導入してから[game-ci](https://game.ci/)のテストランナーを回します。


### PR DESCRIPTION
## 背景

`test.yml` は `on` の `paths` フィルタで、`Editor/**` `Runtime/**` `Tests/**` `package.json` `test.yml` 以外の変更ではワークフローを起動しないようにしていた。
起動しなかったワークフローはチェックラン自体を作らないため、このテストを required status check に指定すると、ドキュメントだけを変えたPRでチェックが「Expected」のまま待ち状態になり、マージできなくなる。

「影響範囲外ならテストを省く」と「省いたPRもマージできる」を両立させるには、起動を止めるのではなく、起動したうえでジョブを飛ばす必要がある。

## 変更内容

判定を `on` のフィルタから `changes` ジョブへ移した。

- `on.pull_request` と `on.push` の `paths` フィルタを外し、全PRとmainへのpushでワークフローを起動する
- 変更ファイルがテスト対象に触れているかを判定する `changes` ジョブを追加する
- `test` ジョブを `needs.changes.outputs.relevant == 'true'` で分岐させる
- READMEのCIの節を、この仕組みに合わせて書き直す

`if` で飛ばしたジョブは skipped のチェックランを残し、required status check はこれを満たしたものとして扱う。
既存の `license` ジョブと同じ「先行ジョブの出力で `if` を分岐させる」構造にそのまま乗せている。

対象パスの一覧は `changes` ジョブだけに置いた。
`on` 側にも同じ一覧を残すと二重管理になり、片方だけ更新したときに「変更したのにテストが走らない」事故につながるため。

## 判定の作り

変更ファイルの一覧は GitHub API から取得する（PRは `pulls/{n}/files`、pushは `compare`）。
判定できない変更を黙って飛ばさないよう、確信が持てない場合はすべてテストを実行する側へ倒してある。

- リネームで対象外へ移した変更（`Editor/A.cs` → `docs/A.cs`）は新パスだけでは検出できないため、`previous_filename` も判定に含める
- 一覧を取得できなかった場合と、レスポンスが想定外の形だった場合は実行する
- 返却件数が上限に達した場合も実行する。`--paginate` はページを辿るだけで、エンドポイントごとの上限（PRのファイル一覧は3000件、compareの `files` は300件）は外さないため、上限で切れた一覧は不完全かもしれない
- ブランチ作成時やforce push後（`before` が到達不能）と `workflow_dispatch` は、比較対象を定められないので実行する

件数を数えられるよう、jqの出力は1ファイル1行のTSV（`[.filename, (.previous_filename // "")] | @tsv`）にしている。

新しいActionへの依存は追加していない。`gh api` は `auto-assign.yml` で既に使っている。
Pull Requests API を読むため、`permissions` に `pull-requests: read` を足した。

## 確認したこと

CI上では、`Check changed paths` が `.github/workflows/test.yml` の変更を検出して `relevant=true` を出し、`EditMode tests` が実走して成功することを確認した（判定は5秒、テスト本体は約3.5分）。

判定スクリプト単体では、`gh` をスタブして次の12ケースを確認した。

| 入力 | 結果 |
| --- | --- |
| ドキュメントのみのPR | skip |
| `Editor/` を含むPR | run |
| `Editor/A.cs` → `docs/A.cs` のリネーム | run |
| `docs/A.cs` → `docs/B.cs` のリネーム | skip |
| 変更ファイルが空 | skip |
| API取得失敗 | run（警告） |
| PRで2999件 / 3000件 | skip / run（警告） |
| pushで299件 / 300件 | skip / run（警告） |
| `before` がゼロのpush | run |
| `workflow_dispatch` | run |

あわせて、`pulls/files` と `compare` の実レスポンス相当のJSONに対して、jqの式が `filename` と `previous_filename` を1行のTSVへ並べることと、`files` を持たないレスポンスではjqが失敗して実行側へ倒れることを確認した。

スキップ側の経路は、対象外のファイルだけを変えたPRでしか通らない。
このPRは `test.yml` を含むため、CI上での実走では確認できていない。

## 補足

required status check の指定は、ジョブ名 `EditMode tests` に対して行う必要がある。
unity-test-runner が checks API で作る `EditMode Test Results` はテストが実際に走ったときしか生成されない（conclusion も `neutral` で作られる）ため、requiredに指定するとスキップ時に同じ問題が起きる。
