### PR TITLE
feat: releasesから更新を検知してインスペクタで知らせる

### DIFF
--- a/Editor/Domain/PackageInstallation.cs
+++ b/Editor/Domain/PackageInstallation.cs
@@ -1,0 +1,82 @@
+using System;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// このパッケージがプロジェクトへどう置かれているか
+    /// </summary>
+    internal enum InstallLocation
+    {
+        /// <summary>判別できなかった</summary>
+        Unknown,
+
+        /// <summary>`Packages/`配下。VCC/ALCOMがvpm-manifest.jsonで版を管理している</summary>
+        Vpm,
+
+        /// <summary>`Assets/`配下。unitypackageから取り込まれ、版の管理者はいない</summary>
+        Booth,
+    }
+
+    /// <summary>
+    /// asmdefの位置からインストール形態とパッケージのルートを求める。
+    ///
+    /// 更新の案内先が形態ごとに違うため、まずどちらへ入っているかを知る必要がある。
+    /// Unityへ問い合わせるのは呼び出し側で、ここでは受け取ったパスの解釈だけを行う
+    /// （Localization.GetLocalizationRootと同じく、asmdefの位置を起点にする）
+    /// </summary>
+    internal static class PackageInstallation
+    {
+        private const string EditorDirectoryName = "Editor";
+
+        /// <summary>
+        /// 「ルート/Editor/なにか.asmdef」の形を前提に、ルートとインストール形態を取り出す。
+        ///
+        /// 形が合わないパスでは偽を返す。
+        /// ルートが分からなければpackage.jsonも読めず、手元の版が確かめられない
+        /// </summary>
+        public static bool TryResolve(string editorAsmdefPath, out InstallLocation location, out string packageRoot)
+        {
+            location = InstallLocation.Unknown;
+            packageRoot = null;
+
+            if (string.IsNullOrWhiteSpace(editorAsmdefPath))
+            {
+                return false;
+            }
+
+            // Unityのパスは`/`区切りだが、環境によっては`\`が混ざったものが返る
+            var segments = editorAsmdefPath.Trim().Replace('\\', '/').Split('/');
+
+            // ルート・Editor・asmdefの3要素が最低限必要
+            if (segments.Length < 3)
+            {
+                return false;
+            }
+
+            if (!string.Equals(segments[segments.Length - 2], EditorDirectoryName, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var rootSegments = new string[segments.Length - 2];
+            Array.Copy(segments, rootSegments, rootSegments.Length);
+
+            packageRoot = string.Join("/", rootSegments);
+            location = ResolveLocation(rootSegments[0]);
+            return true;
+        }
+
+        private static InstallLocation ResolveLocation(string topSegment)
+        {
+            switch (topSegment)
+            {
+                case "Packages":
+                    return InstallLocation.Vpm;
+                case "Assets":
+                    return InstallLocation.Booth;
+                default:
+                    return InstallLocation.Unknown;
+            }
+        }
+    }
+}

--- a/Editor/Domain/PackageInstallation.cs.meta
+++ b/Editor/Domain/PackageInstallation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2f4dd87f37108f084f839d2f9c57722
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Domain/PackageVersion.cs
+++ b/Editor/Domain/PackageVersion.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Globalization;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// リリースのタグとpackage.jsonのversionを比較するための版数。
+    ///
+    /// 扱うのは`0.1.9`形式の安定版だけで、`0.1.9-test2`のようなプレリリースは解釈しない。
+    /// releases/latestはプレリリースを除いて返すが、更新の通知は
+    /// 「安定版が出たときだけ出す」ことを解釈側でも守る
+    /// </summary>
+    internal readonly struct PackageVersion : IEquatable<PackageVersion>, IComparable<PackageVersion>
+    {
+        private const int ComponentCount = 3;
+
+        public int Major { get; }
+        public int Minor { get; }
+        public int Patch { get; }
+
+        private PackageVersion(int major, int minor, int patch)
+        {
+            Major = major;
+            Minor = minor;
+            Patch = patch;
+        }
+
+        /// <summary>
+        /// `0.1.9` `v0.1.9` `0.1` `1` を受け付け、省略された下位の要素は0として扱う。
+        ///
+        /// プレリリースやビルドメタデータの接尾辞（`-test2` `+build`）が付くものは、
+        /// 安定版との大小を決められないため解釈しない
+        /// </summary>
+        public static bool TryParse(string text, out PackageVersion version)
+        {
+            version = default;
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return false;
+            }
+
+            var body = text.Trim();
+            if (body.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+            {
+                body = body.Substring(1);
+            }
+
+            if (body.IndexOf('-') >= 0 || body.IndexOf('+') >= 0)
+            {
+                return false;
+            }
+
+            var parts = body.Split('.');
+            if (parts.Length > ComponentCount)
+            {
+                return false;
+            }
+
+            var components = new int[ComponentCount];
+            for (var i = 0; i < parts.Length; i++)
+            {
+                // NumberStyles.Noneを指定して、符号や桁区切り、前後の空白が混ざったものを弾く
+                if (!int.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out components[i]))
+                {
+                    return false;
+                }
+            }
+
+            version = new PackageVersion(components[0], components[1], components[2]);
+            return true;
+        }
+
+        /// <summary>
+        /// 手元の版と最新リリースのタグを比べ、更新が出ていれば真を返す。
+        ///
+        /// どちらかを解釈できないときは偽を返す。
+        /// 通知は無くても実害が無い一方、誤った通知は利用者を無駄に動かすため、
+        /// 判断できない場合は黙っている側へ倒す
+        /// </summary>
+        public static bool IsUpdateAvailable(string currentVersionText, string latestTagText)
+        {
+            if (!TryParse(currentVersionText, out var current) || !TryParse(latestTagText, out var latest))
+            {
+                return false;
+            }
+
+            return latest.CompareTo(current) > 0;
+        }
+
+        public int CompareTo(PackageVersion other)
+        {
+            var major = Major.CompareTo(other.Major);
+            if (major != 0)
+            {
+                return major;
+            }
+
+            var minor = Minor.CompareTo(other.Minor);
+            return minor != 0 ? minor : Patch.CompareTo(other.Patch);
+        }
+
+        public bool Equals(PackageVersion other)
+        {
+            return Major == other.Major && Minor == other.Minor && Patch == other.Patch;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is PackageVersion other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Major * 397 ^ Minor) * 397 ^ Patch;
+            }
+        }
+
+        public override string ToString()
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch);
+        }
+    }
+}

--- a/Editor/Domain/PackageVersion.cs.meta
+++ b/Editor/Domain/PackageVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1ed90b3bc1b3334bd1c1b99cf5a60aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Infra/PackageLocation.cs
+++ b/Editor/Infra/PackageLocation.cs
@@ -1,0 +1,122 @@
+using System;
+using System.IO;
+using UnityEditor.Compilation;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Infra
+{
+    /// <summary>
+    /// 手元に入っているパッケージの形態と版を、asmdefの位置を起点に調べる。
+    ///
+    /// 解決の規則はPackageInstallationが持ち、ここはUnityへの問い合わせとファイルの読み取りを担う。
+    /// 結果はドメインリロードまで変わらないため、一度求めたら使い回す
+    /// </summary>
+    internal static class PackageLocation
+    {
+        private const string EditorAssemblyName = "ARKitBlendShapeGenerator.Editor";
+        private const string ManifestFileName = "package.json";
+
+        private static bool _resolved;
+        private static InstallLocation _location;
+        private static string _version;
+
+        /// <summary>インストール形態。判別できなければUnknown</summary>
+        public static InstallLocation Location
+        {
+            get
+            {
+                Resolve();
+                return _location;
+            }
+        }
+
+        /// <summary>package.jsonが持つ手元の版。読めなければnull</summary>
+        public static string Version
+        {
+            get
+            {
+                Resolve();
+                return _version;
+            }
+        }
+
+        private static void Resolve()
+        {
+            if (_resolved)
+            {
+                return;
+            }
+
+            _resolved = true;
+
+            var asmdefPath = CompilationPipeline.GetAssemblyDefinitionFilePathFromAssemblyName(EditorAssemblyName);
+            if (!PackageInstallation.TryResolve(asmdefPath, out _location, out var packageRoot))
+            {
+                return;
+            }
+
+            _version = ReadVersion(packageRoot);
+        }
+
+        private static string ReadVersion(string packageRoot)
+        {
+            // リリース時にrelease.ymlがタグでversionを書き換えてからzipへ入れるため、
+            // 配布物のpackage.jsonは常にそのリリースの版を持つ
+            try
+            {
+                var manifestPath = Path.Combine(packageRoot, ManifestFileName);
+                if (!File.Exists(manifestPath))
+                {
+                    return null;
+                }
+
+                return TryParseVersion(File.ReadAllText(manifestPath), out var version) ? version : null;
+            }
+            catch (Exception exception) when (
+                exception is IOException
+                || exception is UnauthorizedAccessException
+                || exception is ArgumentException
+                || exception is NotSupportedException)
+            {
+                // 版が読めなくても更新の通知が出なくなるだけで、生成そのものには影響しない
+                return null;
+            }
+        }
+
+        /// <summary>package.jsonのversionを取り出す。読めない形なら偽を返す</summary>
+        internal static bool TryParseVersion(string manifestJson, out string version)
+        {
+            version = null;
+
+            if (string.IsNullOrWhiteSpace(manifestJson))
+            {
+                return false;
+            }
+
+            try
+            {
+                var manifest = JsonUtility.FromJson<PackageManifest>(manifestJson);
+                if (manifest == null || string.IsNullOrWhiteSpace(manifest.version))
+                {
+                    return false;
+                }
+
+                version = manifest.version.Trim();
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                // JsonUtilityはJSONとして読めない文字列でArgumentExceptionを投げる
+                return false;
+            }
+        }
+
+        [Serializable]
+        private class PackageManifest
+        {
+            // JsonUtilityはフィールド名でJSONのキーと対応づけるため、package.jsonの綴りに合わせる
+            public string version;
+        }
+    }
+}

--- a/Editor/Infra/PackageLocation.cs.meta
+++ b/Editor/Infra/PackageLocation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de736a931c23defc5b2a22baa5878b41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Infra/UpdateCheck.cs
+++ b/Editor/Infra/UpdateCheck.cs
@@ -1,0 +1,302 @@
+using System;
+using System.Globalization;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Infra
+{
+    /// <summary>更新確認を行うかどうかについての利用者の選択</summary>
+    internal enum UpdateCheckPreference
+    {
+        /// <summary>まだ尋ねていない。この状態では通信しない</summary>
+        Unset = 0,
+
+        /// <summary>確認する</summary>
+        Enabled = 1,
+
+        /// <summary>確認しない</summary>
+        Disabled = 2,
+    }
+
+    /// <summary>
+    /// GitHubのreleasesから最新の安定版を調べ、手元より新しければ知らせる。
+    ///
+    /// エディタが黙って外部へ通信するのは避けたいので、利用者が選ぶまでは何もしない。
+    /// 確認するときも1日1回までとし、失敗しても黙って次の機会へ回す。
+    /// 更新の通知は無くても生成の妨げにならず、警告を積む価値が無い。
+    ///
+    /// 判断の材料はEditorPrefsに置くが、問い合わせるのはインスペクタの描画のたびになるため、
+    /// 結果はメモリへ持ち、変化したときだけ読み直す
+    /// </summary>
+    internal static class UpdateCheck
+    {
+        private const string LatestReleaseApiUrl =
+            "https://api.github.com/repos/limit7412/VRCARKitBlendShapeGenerator/releases/latest";
+
+        /// <summary>更新の入手先として案内するページ</summary>
+        public const string ReleasesPageUrl =
+            "https://github.com/limit7412/VRCARKitBlendShapeGenerator/releases/latest";
+
+        private const string PreferenceKey = "ARKitBlendShapeGenerator.UpdateCheck.Preference";
+        private const string LastAttemptKey = "ARKitBlendShapeGenerator.UpdateCheck.LastAttemptUtcTicks";
+        private const string LatestTagKey = "ARKitBlendShapeGenerator.UpdateCheck.LatestTag";
+        private const string DismissedTagKey = "ARKitBlendShapeGenerator.UpdateCheck.DismissedTag";
+
+        private const double CheckIntervalHours = 24.0;
+        private const int RequestTimeoutSeconds = 15;
+
+        // 前回の確認時刻はEditorPrefsにあり、描画のたびに読むと無駄が多い。
+        // 1日1回の判定にこの粗さは影響しない
+        private const double IntervalCheckThrottleSeconds = 5.0;
+
+        private static bool _isStateCached;
+        private static UpdateCheckPreference _cachedPreference;
+        private static string _cachedPendingTag;
+
+        private static bool _isRequestInFlight;
+        private static double _nextIntervalCheckTime;
+
+        /// <summary>確認の結果が変わったときに発火する。インスペクタの再描画に使う</summary>
+        public static event Action ResultChanged;
+
+        /// <summary>更新確認についての選択</summary>
+        public static UpdateCheckPreference Preference
+        {
+            get
+            {
+                EnsureStateCached();
+                return _cachedPreference;
+            }
+            set
+            {
+                EditorPrefs.SetInt(PreferenceKey, (int)value);
+
+                // 選び直した直後は、間隔を待たずに確認できるようにする
+                _nextIntervalCheckTime = 0.0;
+                Invalidate();
+            }
+        }
+
+        /// <summary>
+        /// 通知すべき新しい版があればそのタグを返す。無ければnull。
+        ///
+        /// 利用者が確認を選んでおり、手元より新しい安定版が出ていて、
+        /// その版を「通知しない」と選んでいない場合に限る
+        /// </summary>
+        public static string PendingUpdateTag
+        {
+            get
+            {
+                EnsureStateCached();
+                return _cachedPendingTag;
+            }
+        }
+
+        /// <summary>この版については以後知らせない</summary>
+        public static void Dismiss(string tag)
+        {
+            EditorPrefs.SetString(DismissedTagKey, tag ?? string.Empty);
+            Invalidate();
+        }
+
+        /// <summary>
+        /// 必要なら最新の安定版を問い合わせる。
+        ///
+        /// インスペクタの描画から毎フレーム呼ばれるため、通信を始めるかどうかはここで絞る
+        /// </summary>
+        public static void PollIfDue()
+        {
+            if (Preference != UpdateCheckPreference.Enabled || _isRequestInFlight)
+            {
+                return;
+            }
+
+            var now = EditorApplication.timeSinceStartup;
+            if (now < _nextIntervalCheckTime)
+            {
+                return;
+            }
+
+            _nextIntervalCheckTime = now + IntervalCheckThrottleSeconds;
+
+            if (!IsIntervalElapsed())
+            {
+                return;
+            }
+
+            // 失敗も含めて次の機会を遅らせる。
+            // 通信できない環境で描画のたびに要求を投げ続けるのを防ぐ
+            EditorPrefs.SetString(LastAttemptKey, DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture));
+            SendRequest();
+        }
+
+        private static void EnsureStateCached()
+        {
+            if (_isStateCached)
+            {
+                return;
+            }
+
+            _isStateCached = true;
+            _cachedPreference = ReadPreference();
+            _cachedPendingTag = ComputePendingTag(_cachedPreference);
+        }
+
+        private static void Invalidate()
+        {
+            _isStateCached = false;
+            ResultChanged?.Invoke();
+        }
+
+        private static UpdateCheckPreference ReadPreference()
+        {
+            var stored = EditorPrefs.GetInt(PreferenceKey, (int)UpdateCheckPreference.Unset);
+            return Enum.IsDefined(typeof(UpdateCheckPreference), stored)
+                ? (UpdateCheckPreference)stored
+                : UpdateCheckPreference.Unset;
+        }
+
+        private static string ComputePendingTag(UpdateCheckPreference preference)
+        {
+            if (preference != UpdateCheckPreference.Enabled)
+            {
+                return null;
+            }
+
+            var latest = EditorPrefs.GetString(LatestTagKey, string.Empty);
+            if (string.IsNullOrEmpty(latest) || latest == EditorPrefs.GetString(DismissedTagKey, string.Empty))
+            {
+                return null;
+            }
+
+            return PackageVersion.IsUpdateAvailable(PackageLocation.Version, latest) ? latest : null;
+        }
+
+        private static bool IsIntervalElapsed()
+        {
+            var stored = EditorPrefs.GetString(LastAttemptKey, string.Empty);
+
+            // NumberStyles.Noneは符号を認めないためticksは0以上になる。
+            // 上限だけは、書き換えられた値でDateTimeが例外を投げないよう確かめる
+            if (!long.TryParse(stored, NumberStyles.None, CultureInfo.InvariantCulture, out var ticks)
+                || ticks > DateTime.MaxValue.Ticks)
+            {
+                return true;
+            }
+
+            // 保存された時刻が未来を指す場合（時計を戻したなど）も確認へ倒す。
+            // そうしないと、その時刻を過ぎるまで確認が止まったままになる
+            var elapsed = DateTime.UtcNow - new DateTime(ticks, DateTimeKind.Utc);
+            return elapsed.TotalHours >= CheckIntervalHours || elapsed < TimeSpan.Zero;
+        }
+
+        private static void SendRequest()
+        {
+            UnityWebRequest request = null;
+
+            // 更新の通知はインスペクタの描画の途中で始まる。
+            // 要求を組み立てられなくても、そこで例外を投げて設定UIごと止めるわけにはいかない
+            try
+            {
+                request = UnityWebRequest.Get(LatestReleaseApiUrl);
+
+                // User-Agentは指定しない。GitHubのAPIはこれの無い要求を拒むが、
+                // UnityWebRequestが既定で付けるもので通る。
+                // 上書きを認めないヘッダとして扱われる場合があり、指定する利点に見合わない
+                request.SetRequestHeader("Accept", "application/vnd.github+json");
+                request.timeout = RequestTimeoutSeconds;
+
+                _isRequestInFlight = true;
+                request.SendWebRequest().completed += _ =>
+                {
+                    try
+                    {
+                        HandleResponse(request);
+                    }
+                    finally
+                    {
+                        request.Dispose();
+                        _isRequestInFlight = false;
+                    }
+                };
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException || exception is InvalidOperationException)
+            {
+                _isRequestInFlight = false;
+                request?.Dispose();
+            }
+        }
+
+        private static void HandleResponse(UnityWebRequest request)
+        {
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                return;
+            }
+
+            if (!TryParseTag(request.downloadHandler?.text, out var tag))
+            {
+                return;
+            }
+
+            if (tag == EditorPrefs.GetString(LatestTagKey, string.Empty))
+            {
+                return;
+            }
+
+            EditorPrefs.SetString(LatestTagKey, tag);
+            Invalidate();
+        }
+
+        /// <summary>
+        /// releases/latestの応答からタグを取り出す。
+        ///
+        /// このエンドポイントはプレリリースを除いて返すが、応答が想定と違ってもよいように、
+        /// 安定版として解釈できないタグはここで落とす
+        /// </summary>
+        internal static bool TryParseTag(string json, out string tag)
+        {
+            tag = null;
+
+            if (string.IsNullOrWhiteSpace(json))
+            {
+                return false;
+            }
+
+            LatestReleaseResponse response;
+            try
+            {
+                response = JsonUtility.FromJson<LatestReleaseResponse>(json);
+            }
+            catch (ArgumentException)
+            {
+                // JsonUtilityはJSONとして読めない文字列でArgumentExceptionを投げる
+                return false;
+            }
+
+            if (response == null || string.IsNullOrWhiteSpace(response.tag_name))
+            {
+                return false;
+            }
+
+            var candidate = response.tag_name.Trim();
+            if (!PackageVersion.TryParse(candidate, out _))
+            {
+                return false;
+            }
+
+            tag = candidate;
+            return true;
+        }
+
+        [Serializable]
+        private class LatestReleaseResponse
+        {
+            // JsonUtilityはフィールド名でJSONのキーと対応づけるため、APIの綴りに合わせる
+            public string tag_name;
+        }
+    }
+}

--- a/Editor/Infra/UpdateCheck.cs.meta
+++ b/Editor/Infra/UpdateCheck.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5bee231de853c6a2ad8ca30acb152e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -344,3 +344,34 @@ msgstr "There are duplicate ARKit names in the custom mappings."
 
 msgid "validation.duplicate.message"
 msgstr "The same ARKit name cannot be used in multiple custom mappings.\nDuplicates: {0}"
+
+# Update check
+msgid "update.consent.description"
+msgstr "Check GitHub Releases for a newer version?\nThe check runs at most once a day and only requests release information. You can change this later in Preferences > ARKit BlendShape Generator."
+
+msgid "update.consent.enable"
+msgstr "Check for updates"
+
+msgid "update.consent.disable"
+msgstr "Do not check"
+
+msgid "update.available.vpm"
+msgstr "Version {0} is available.\nUpdate through VCC/ALCOM."
+
+msgid "update.available.booth"
+msgstr "Version {0} is available.\nDownload it from Releases, then delete the existing folder under Assets and import it again."
+
+msgid "update.available.unknown"
+msgstr "Version {0} is available."
+
+msgid "update.open_releases"
+msgstr "Open Releases"
+
+msgid "update.dismiss"
+msgstr "Skip this version"
+
+msgid "update.settings.enabled"
+msgstr "Check for updates"
+
+msgid "update.settings.description"
+msgstr "Queries GitHub Releases at most once a day and shows a notice in the inspector when a newer version is available."

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -344,3 +344,34 @@ msgstr "カスタムマッピングに同一ARKit名の重複があります。"
 
 msgid "validation.duplicate.message"
 msgstr "カスタムマッピングで同一ARKit名は複数設定できません。\n重複: {0}"
+
+# 更新の確認
+msgid "update.consent.description"
+msgstr "新しいバージョンが出ているかをGitHubのReleasesへ問い合わせますか？\n確認は1日1回までで、送るのはリリース情報の取得要求だけです。この設定は Preferences > ARKit BlendShape Generator から変更できます。"
+
+msgid "update.consent.enable"
+msgstr "確認する"
+
+msgid "update.consent.disable"
+msgstr "確認しない"
+
+msgid "update.available.vpm"
+msgstr "新しいバージョン {0} が公開されています。\nVCC/ALCOMから更新してください。"
+
+msgid "update.available.booth"
+msgstr "新しいバージョン {0} が公開されています。\nReleasesから最新版を入手し、Assets配下の既存フォルダを削除してから入れ直してください。"
+
+msgid "update.available.unknown"
+msgstr "新しいバージョン {0} が公開されています。"
+
+msgid "update.open_releases"
+msgstr "Releasesを開く"
+
+msgid "update.dismiss"
+msgstr "このバージョンは通知しない"
+
+msgid "update.settings.enabled"
+msgstr "更新を確認する"
+
+msgid "update.settings.description"
+msgstr "GitHubのReleasesへ1日1回まで問い合わせ、新しいバージョンが出ていればインスペクタに知らせます。"

--- a/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
+++ b/Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs
@@ -60,6 +60,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         {
             _component = (ARKitBlendShapeGeneratorComponent)target;
             Undo.undoRedoPerformed += OnUndoRedoPerformed;
+            UpdateCheck.ResultChanged += Repaint;
             InvalidatePreviewCategoryCache();
             RefreshBlendShapeList();
         }
@@ -67,6 +68,7 @@ namespace ARKitBlendShapeGenerator.Presentation
         private void OnDisable()
         {
             Undo.undoRedoPerformed -= OnUndoRedoPerformed;
+            UpdateCheck.ResultChanged -= Repaint;
             int componentId = _component != null ? _component.GetInstanceID() : 0;
             ARKitBlendShapeGeneratorPreviewState.ReleaseIfActive(componentId);
             InvalidatePreviewCategoryCache();
@@ -95,6 +97,10 @@ namespace ARKitBlendShapeGenerator.Presentation
             // 言語切替 + ヘッダー
             LanguageSwitcher.DrawImmediate();
             EditorGUILayout.LabelField("ARKit BlendShape Generator", EditorStyles.boldLabel);
+
+            // 更新の案内はヘッダーの直下へ置く。読み飛ばされない位置で、設定の並びは崩さない
+            UpdateNotice.Draw();
+
             EditorGUILayout.HelpBox(S("inspector.description"), MessageType.Info);
 
             EditorGUILayout.Space();

--- a/Editor/Presentation/UpdateNotice.cs
+++ b/Editor/Presentation/UpdateNotice.cs
@@ -1,0 +1,120 @@
+using UnityEditor;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+using ARKitBlendShapeGenerator.Infra;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator.Presentation
+{
+    /// <summary>
+    /// 更新の確認についての問いかけと、新しい版が出ているときの案内をインスペクタの先頭へ描く。
+    ///
+    /// 案内の文面はインストール形態で変わる。
+    /// VPM版の版数はVCC/ALCOMがvpm-manifest.jsonで管理しているため、
+    /// こちらでファイルを置き換えると管理側の記録と実態がずれる。
+    /// booth版には版を管理する主体がおらず、入れ直しが更新の手段になる
+    /// </summary>
+    internal static class UpdateNotice
+    {
+        public static void Draw()
+        {
+            switch (UpdateCheck.Preference)
+            {
+                case UpdateCheckPreference.Unset:
+                    DrawConsent();
+                    break;
+                case UpdateCheckPreference.Enabled:
+                    UpdateCheck.PollIfDue();
+                    DrawAvailableUpdate();
+                    break;
+            }
+        }
+
+        private static void DrawConsent()
+        {
+            EditorGUILayout.HelpBox(S("update.consent.description"), MessageType.Info);
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button(S("update.consent.enable")))
+            {
+                UpdateCheck.Preference = UpdateCheckPreference.Enabled;
+            }
+
+            if (GUILayout.Button(S("update.consent.disable")))
+            {
+                UpdateCheck.Preference = UpdateCheckPreference.Disabled;
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+        }
+
+        private static void DrawAvailableUpdate()
+        {
+            var tag = UpdateCheck.PendingUpdateTag;
+            if (tag == null)
+            {
+                return;
+            }
+
+            EditorGUILayout.HelpBox(DescribeUpdate(tag), MessageType.Info);
+
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button(S("update.open_releases")))
+            {
+                Application.OpenURL(UpdateCheck.ReleasesPageUrl);
+            }
+
+            if (GUILayout.Button(S("update.dismiss")))
+            {
+                UpdateCheck.Dismiss(tag);
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+        }
+
+        private static string DescribeUpdate(string tag)
+        {
+            switch (PackageLocation.Location)
+            {
+                case InstallLocation.Vpm:
+                    return S("update.available.vpm", tag);
+                case InstallLocation.Booth:
+                    return S("update.available.booth", tag);
+                default:
+                    return S("update.available.unknown", tag);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 更新確認の入切をPreferencesからも変えられるようにする。
+    ///
+    /// インスペクタの問いかけで「確認しない」を選ぶと、以後その問いかけは出ない。
+    /// 選び直す場所がここになる
+    /// </summary>
+    internal static class UpdateCheckSettingsProvider
+    {
+        [SettingsProvider]
+        public static SettingsProvider Create()
+        {
+            return new SettingsProvider("Preferences/ARKit BlendShape Generator", SettingsScope.User)
+            {
+                guiHandler = _ =>
+                {
+                    var enabled = UpdateCheck.Preference == UpdateCheckPreference.Enabled;
+                    var changed = EditorGUILayout.Toggle(S("update.settings.enabled"), enabled);
+                    if (changed != enabled)
+                    {
+                        UpdateCheck.Preference = changed
+                            ? UpdateCheckPreference.Enabled
+                            : UpdateCheckPreference.Disabled;
+                    }
+
+                    EditorGUILayout.HelpBox(S("update.settings.description"), MessageType.None);
+                },
+            };
+        }
+    }
+}

--- a/Editor/Presentation/UpdateNotice.cs.meta
+++ b/Editor/Presentation/UpdateNotice.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c681abf761899c98d830965985100c5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ Jerry's Templatesと組み合わせて使用することで、フェイストラ
 2. VCCのプロジェクト管理画面で「Add Package」→「Add from Archive」を選択
 3. ダウンロードしたzipファイルを選択
 
+### 更新の確認
+
+新しいバージョンが出ているかを[Releases](https://github.com/limit7412/VRCARKitBlendShapeGenerator/releases/latest)へ問い合わせ、インスペクタの先頭で知らせます。
+
+エディタから外部へ通信するため、確認するかどうかは初回にインスペクタで尋ねます。
+確認しないことを選べば通信は行いません。
+確認する場合も1日1回までで、送るのはリリース情報の取得要求だけです。
+
+選択は Preferences > ARKit BlendShape Generator からいつでも変更できます。
+
+更新の手段はインストール方法で違います。
+`Packages/` 配下（VCC/ALCOM経由）ならVCC/ALCOMから更新してください。
+`Assets/` 配下（unitypackageから導入）の場合は、Releasesから最新版を入手し、既存のフォルダを削除してから入れ直してください。
+
 ## 使用方法
 
 ### 基本的な使い方

--- a/Tests/Editor/PackageInstallationTests.cs
+++ b/Tests/Editor/PackageInstallationTests.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// asmdefの位置からインストール形態を見分ける規則の検証。
+    ///
+    /// VPM版とbooth版では更新の手段が違い、案内の文面もそれで決まる。
+    /// booth版は利用者がフォルダを移動できるため、固定のパスではなく
+    /// asmdefの位置を起点に判別できることを確かめる。
+    /// </summary>
+    public class PackageInstallationTests
+    {
+        private const string VpmAsmdefPath =
+            "Packages/com.qazx7412.kx-vrc-arkit-blendshape-generator/Editor/ARKitBlendShapeGenerator.Editor.asmdef";
+
+        private const string BoothAsmdefPath =
+            "Assets/AtelierKairox/VRCARKitBlendShapeGenerator/Editor/ARKitBlendShapeGenerator.Editor.asmdef";
+
+        [Test]
+        public void TryResolve_ReadsAVpmInstall()
+        {
+            Assert.That(PackageInstallation.TryResolve(VpmAsmdefPath, out var location, out var root), Is.True);
+            Assert.That(location, Is.EqualTo(InstallLocation.Vpm));
+            Assert.That(root, Is.EqualTo("Packages/com.qazx7412.kx-vrc-arkit-blendshape-generator"));
+        }
+
+        [Test]
+        public void TryResolve_ReadsABoothInstall()
+        {
+            Assert.That(PackageInstallation.TryResolve(BoothAsmdefPath, out var location, out var root), Is.True);
+            Assert.That(location, Is.EqualTo(InstallLocation.Booth));
+            Assert.That(root, Is.EqualTo("Assets/AtelierKairox/VRCARKitBlendShapeGenerator"));
+        }
+
+        // booth版はunitypackageで取り込まれるため、利用者が任意の場所へ移動できる
+        [Test]
+        public void TryResolve_FollowsABoothInstallThatWasMoved()
+        {
+            const string movedPath = "Assets/ThirdParty/Tools/ARKitGen/Editor/ARKitBlendShapeGenerator.Editor.asmdef";
+
+            Assert.That(PackageInstallation.TryResolve(movedPath, out var location, out var root), Is.True);
+            Assert.That(location, Is.EqualTo(InstallLocation.Booth));
+            Assert.That(root, Is.EqualTo("Assets/ThirdParty/Tools/ARKitGen"));
+        }
+
+        [Test]
+        public void TryResolve_NormalizesWindowsSeparators()
+        {
+            const string windowsPath =
+                @"Assets\AtelierKairox\VRCARKitBlendShapeGenerator\Editor\ARKitBlendShapeGenerator.Editor.asmdef";
+
+            Assert.That(PackageInstallation.TryResolve(windowsPath, out var location, out var root), Is.True);
+            Assert.That(location, Is.EqualTo(InstallLocation.Booth));
+            Assert.That(root, Is.EqualTo("Assets/AtelierKairox/VRCARKitBlendShapeGenerator"));
+        }
+
+        // ルートは分かるが形態を決められない場合。案内の文面だけが一般的なものになる
+        [Test]
+        public void TryResolve_ReportsUnknown_ForAnUnexpectedRoot()
+        {
+            const string path = "Library/PackageCache/whatever/Editor/ARKitBlendShapeGenerator.Editor.asmdef";
+
+            Assert.That(PackageInstallation.TryResolve(path, out var location, out var root), Is.True);
+            Assert.That(location, Is.EqualTo(InstallLocation.Unknown));
+            Assert.That(root, Is.EqualTo("Library/PackageCache/whatever"));
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("ARKitBlendShapeGenerator.Editor.asmdef")]
+        [TestCase("Packages/whatever/ARKitBlendShapeGenerator.Editor.asmdef")]
+        [TestCase("Packages/whatever/Runtime/ARKitBlendShapeGenerator.Runtime.asmdef")]
+        public void TryResolve_Fails_WhenThePathIsNotUnderAnEditorDirectory(string path)
+        {
+            Assert.That(PackageInstallation.TryResolve(path, out var location, out var root), Is.False);
+            Assert.That(location, Is.EqualTo(InstallLocation.Unknown));
+            Assert.That(root, Is.Null);
+        }
+    }
+}

--- a/Tests/Editor/PackageVersionTests.cs
+++ b/Tests/Editor/PackageVersionTests.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// リリースのタグと手元の版を比べる規則の検証。
+    ///
+    /// 誤って新しいと判断すると、更新の必要が無い利用者を動かしてしまう。
+    /// 解釈できないものを黙って通さないことと、プレリリースを新しい版として扱わないことを固定化する。
+    /// </summary>
+    public class PackageVersionTests
+    {
+        [TestCase("0.1.9", 0, 1, 9)]
+        [TestCase("v0.1.9", 0, 1, 9)]
+        [TestCase("V1.2.3", 1, 2, 3)]
+        [TestCase("1.2", 1, 2, 0)]
+        [TestCase("2", 2, 0, 0)]
+        [TestCase(" 0.1.9 ", 0, 1, 9)]
+        [TestCase("0.10.0", 0, 10, 0)]
+        public void TryParse_AcceptsStableVersions(string text, int major, int minor, int patch)
+        {
+            Assert.That(PackageVersion.TryParse(text, out var version), Is.True);
+            Assert.That(version.Major, Is.EqualTo(major));
+            Assert.That(version.Minor, Is.EqualTo(minor));
+            Assert.That(version.Patch, Is.EqualTo(patch));
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("v")]
+        [TestCase("0.1.9.1")]
+        [TestCase("0..9")]
+        [TestCase("0.1.x")]
+        [TestCase("-1.0.0")]
+        [TestCase("+1.0.0")]
+        [TestCase("1,000.0.0")]
+        [TestCase("latest")]
+        public void TryParse_RejectsWhatItCannotOrder(string text)
+        {
+            Assert.That(PackageVersion.TryParse(text, out _), Is.False);
+        }
+
+        // releases/latestはプレリリースを除いて返すが、応答の形が変わっても
+        // プレリリースを新しい版として扱わないことを、解釈側でも保証する
+        [TestCase("0.1.9-test2")]
+        [TestCase("v0.2.0-rc.1")]
+        [TestCase("0.1.9+build.5")]
+        public void TryParse_RejectsPrereleaseAndBuildMetadata(string text)
+        {
+            Assert.That(PackageVersion.TryParse(text, out _), Is.False);
+        }
+
+        [TestCase("0.1.8", "0.1.9")]
+        [TestCase("0.1.9", "0.2.0")]
+        [TestCase("0.9.0", "1.0.0")]
+        [TestCase("0.1.9", "v0.1.10")]
+        [TestCase("0.1", "0.1.1")]
+        public void IsUpdateAvailable_IsTrue_WhenTheReleaseIsNewer(string current, string latest)
+        {
+            Assert.That(PackageVersion.IsUpdateAvailable(current, latest), Is.True);
+        }
+
+        [TestCase("0.1.9", "0.1.9")]
+        [TestCase("0.1.9", "v0.1.9")]
+        [TestCase("0.2.0", "0.1.9")]
+        [TestCase("1.0.0", "0.9.9")]
+        public void IsUpdateAvailable_IsFalse_WhenTheReleaseIsNotNewer(string current, string latest)
+        {
+            Assert.That(PackageVersion.IsUpdateAvailable(current, latest), Is.False);
+        }
+
+        // 解釈できない値では黙る。通知が出ないのは実害が無いが、誤った通知は利用者を無駄に動かす
+        [TestCase(null, "0.1.9")]
+        [TestCase("0.1.9", null)]
+        [TestCase("unknown", "0.1.9")]
+        [TestCase("0.1.9", "0.2.0-test1")]
+        public void IsUpdateAvailable_IsFalse_WhenEitherSideCannotBeParsed(string current, string latest)
+        {
+            Assert.That(PackageVersion.IsUpdateAvailable(current, latest), Is.False);
+        }
+    }
+}

--- a/Tests/Editor/UpdatePayloadTests.cs
+++ b/Tests/Editor/UpdatePayloadTests.cs
@@ -1,0 +1,76 @@
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Infra;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 更新確認が読み取る2つのJSON（releases/latestの応答とpackage.json）の解釈の検証。
+    ///
+    /// どちらも手元で作ったものではないため、想定と違う形が来ても
+    /// 例外を投げずに「分からなかった」として返ることを確かめる。
+    /// </summary>
+    public class UpdatePayloadTests
+    {
+        [Test]
+        public void TryParseTag_ReadsTheTagFromAReleaseResponse()
+        {
+            const string json = @"{""tag_name"":""0.1.9"",""name"":""0.1.9"",""prerelease"":false}";
+
+            Assert.That(UpdateCheck.TryParseTag(json, out var tag), Is.True);
+            Assert.That(tag, Is.EqualTo("0.1.9"));
+        }
+
+        // 応答にはアセット一覧などが並ぶ。必要なキー以外は読み飛ばせること
+        [Test]
+        public void TryParseTag_IgnoresTheOtherFields()
+        {
+            const string json =
+                @"{""id"":373145658,""tag_name"":""0.2.0"",""assets"":[{""name"":""package.zip""}],""body"":""...""}";
+
+            Assert.That(UpdateCheck.TryParseTag(json, out var tag), Is.True);
+            Assert.That(tag, Is.EqualTo("0.2.0"));
+        }
+
+        // releases/latestはプレリリースを除いて返すが、除かれなかった場合も通さない
+        [Test]
+        public void TryParseTag_RejectsAPrereleaseTag()
+        {
+            const string json = @"{""tag_name"":""0.1.9-test2"",""prerelease"":true}";
+
+            Assert.That(UpdateCheck.TryParseTag(json, out var tag), Is.False);
+            Assert.That(tag, Is.Null);
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase("not json")]
+        [TestCase(@"{""message"":""Not Found""}")]
+        [TestCase(@"{""tag_name"":""""}")]
+        public void TryParseTag_Fails_WhenTheResponseIsNotAUsableRelease(string json)
+        {
+            Assert.That(UpdateCheck.TryParseTag(json, out var tag), Is.False);
+            Assert.That(tag, Is.Null);
+        }
+
+        [Test]
+        public void TryParseVersion_ReadsTheVersionFromAPackageManifest()
+        {
+            const string json = @"{""name"":""com.qazx7412.kx-vrc-arkit-blendshape-generator"",""version"":""0.1.9""}";
+
+            Assert.That(PackageLocation.TryParseVersion(json, out var version), Is.True);
+            Assert.That(version, Is.EqualTo("0.1.9"));
+        }
+
+        [TestCase((string)null)]
+        [TestCase("")]
+        [TestCase("not json")]
+        [TestCase(@"{""name"":""com.example.package""}")]
+        [TestCase(@"{""version"":""  ""}")]
+        public void TryParseVersion_Fails_WhenTheManifestHasNoVersion(string json)
+        {
+            Assert.That(PackageLocation.TryParseVersion(json, out var version), Is.False);
+            Assert.That(version, Is.Null);
+        }
+    }
+}

--- a/docs/code-reading.md
+++ b/docs/code-reading.md
@@ -23,7 +23,8 @@ VRChatアバターの既存シェイプキー（まばたき、あ、い、う �
   処理対象の選定と、Infra実装の組み立て
 - **`Editor/Domain/`**：生成ロジックの本体。
   メッシュの読み書きは `IMeshRepository` 越しに行い、`UnityEngine.Mesh` へ直接依存しない
-- **`Editor/Infra/`**：Domainが定義した抽象のUnity実装（`UnityMeshRepository` など）と、エディタAPIへ触る部品
+- **`Editor/Infra/`**：Domainが定義した抽象のUnity実装（`UnityMeshRepository` など）と、エディタAPIへ触る部品。
+  更新確認の通信とEditorPrefsの読み書き（`UpdateCheck`）、インストール形態の問い合わせ（`PackageLocation`）もここに置く
 - **`Editor/Presentation/`**：インスペクタUI
 - **`Editor/Localization/`**：NDMFのローカライズ機構を使った文言管理（日英の `.po`）
 - **`Tests/Editor/`**：EditModeテスト
@@ -105,6 +106,20 @@ NDMFのGenerating Phaseで、Jerry's Templatesより先に実行されるよう�
 設定UIのほか、自動マッピング一覧の表示（`AutoMappingSummary` がマッピング定義から組み立てる）と、生成シェイプをスライダーで動かすプレビュー再生を持つ。
 プレビュー再生は `ARKitBlendShapeGeneratorPreviewState`（`PublishedValue` によるエディタ全体の共有状態）へウェイトを書き、プレビューノードが毎フレームそれをプロキシへ適用する。
 
+### 更新の確認
+
+インスペクタの先頭に、新しいバージョンが出ているかの案内を出す。
+GitHubのreleasesへ問い合わせるのは `UpdateCheck` で、確認するかどうかを利用者が選ぶまでは通信しない。
+確認する場合も1日1回までとし、失敗しても黙って次の機会へ回す。
+
+案内の文面はインストール形態で変わる。
+形態の判別は `PackageLocation` がasmdefの位置をUnityへ問い合わせ、そのパスの解釈を `PackageInstallation` が行う。
+`Packages/` 配下ならVPM版、`Assets/` 配下ならbooth版とみなす。
+booth版は利用者がフォルダを移動できるため、固定のパスではなくasmdefの位置を起点にする（`Localization` の翻訳ファイル探索と同じ考え方）。
+
+VPM版でファイルを置き換えないのは、版数をVCC/ALCOMが `vpm-manifest.json` で管理しているためである。
+こちらが中身だけ差し替えると、管理側の記録と実態がずれる。
+
 ## どこから読み始めるか
 
 次の順で読むと迷いにくい。
@@ -133,6 +148,8 @@ NDMFのGenerating Phaseで、Jerry's Templatesより先に実行されるよう�
   このほかインスペクタも、編集中に同じ判定（`CustomMappingValidation`）でエラーを表示する
 - **重複コンポーネントの排除**：`DisallowMultipleComponent` は同一GameObject内しか防げないため、アバター単位の一意性は `DuplicateComponentGuard` が `OnValidate` フック経由で担保する。
   ビルド時にも `SelectPrimaryComponent` で1つに絞る
+- **更新確認の外部通信**：Editorから外部へ出る通信はここだけで、利用者が確認を選ぶまでは行わない。
+  選択は `EditorPrefs` に持ち、インスペクタの問いかけと Preferences > ARKit BlendShape Generator のどちらからも変えられる
 - **文言**：Editor側でユーザーへ見せる文字列は直接書かず、`Localization.S(キー)` で引く。
   文言の実体は `Editor/Localization/*.po` にある。
   例外はRuntimeコンポーネントの `[Header]` と `[Tooltip]` で、Editorアセンブリにある `Localization` をRuntime側からは参照できないため、カスタムエディタが無効なとき用の英語文言を直接持っている


### PR DESCRIPTION
#82 の段階2を実装する。

GitHubの `releases/latest` へ問い合わせ、手元より新しい安定版が出ていればインスペクタの先頭で知らせる。
booth版のワンクリック更新（段階3）は、取得対象となるzipの添付を #81 が用意してから着手する。

## やったこと

### 更新の検知

`releases/latest` は安定版だけを返すため、`0.1.9-test2` のようなプレリリースを誤検知しない。
応答の形が変わった場合に備えて、解釈側（`PackageVersion`）でもプレリリースと解釈できないタグを落とす。

手元の版は `package.json` の `version` から読む。
`release.yml` がタグでversionを書き換えてからzipへ入れるため、配布物の `package.json` は常にそのリリースの版を持つ。

### 通信のタイミング

エディタが黙って外部へ通信するのは避けたいので、確認するかどうかを利用者が選ぶまでは何もしない。
初回はインスペクタで尋ね、「確認しない」を選べば通信は行わない。
選択は Preferences &gt; ARKit BlendShape Generator からいつでも変更できる。

確認する場合も1日1回までとする。
失敗した場合も次の試行時刻を進めるため、通信できない環境で描画のたびに要求を投げ続けることはない。
更新の通知は無くても生成の妨げにならないので、失敗はログを出さず黙って次の機会へ回す。

### インストール形態の判別

`Localization` の翻訳ファイル探索と同じく、asmdefの位置を起点にする。
`Packages/` 配下ならVPM版、`Assets/` 配下ならbooth版とみなす。
booth版は利用者がフォルダを移動できるため、固定のパスでは判別できない。

案内の文面は形態で変わる。

| 形態 | 案内 |
| ---- | ---- |
| VPM版 | VCC/ALCOMから更新 |
| booth版 | Releasesから入手し、既存フォルダを削除してから入れ直す |
| 判別不能 | 新しいバージョンがあることのみ |

VPM版でファイルを置き換えないのは、版数をVCC/ALCOMが `vpm-manifest.json` で管理しているためである。
中身だけ差し替えると管理側の記録と実態がずれる。

## 変更したファイル

```
Editor/Domain/PackageVersion.cs           新規 タグとversionの解釈・比較
Editor/Domain/PackageInstallation.cs      新規 asmdefのパスからインストール形態を判別
Editor/Infra/PackageLocation.cs           新規 Unityへの問い合わせとpackage.jsonの読み取り
Editor/Infra/UpdateCheck.cs               新規 選択の保持、間隔の制御、releases/latestへの問い合わせ
Editor/Presentation/UpdateNotice.cs       新規 問いかけと案内の描画、Preferencesの項目
Editor/Presentation/ARKitBlendShapeGeneratorEditor.cs  案内の描画位置と再描画の購読
Editor/Localization/{ja-jp,en-us}.po      文言10件
Editor/**/*.meta                          新規スクリプトぶんの.meta（5件、詳細は下記）
Tests/Editor/PackageVersionTests.cs       新規
Tests/Editor/PackageInstallationTests.cs  新規
Tests/Editor/UpdatePayloadTests.cs        新規
README.md, docs/code-reading.md           更新の確認についての記述
```

## テスト

通信を伴わない部分をEditModeテストで固定化した。

- タグとversionの解釈：`v` 接頭辞、要素の省略、プレリリースとビルドメタデータの排除、解釈できない値
- 更新の有無の判定：新旧の比較と、どちらかを解釈できないときに黙ること
- インストール形態の判別：VPM版、booth版、移動されたbooth版、Windowsの区切り、`Editor/` 配下でないパス
- JSONの解釈：`releases/latest` の応答と `package.json`。想定と違う形でも例外を投げず「分からなかった」と返ること

CIで **260/260 passed**（Unity 2022.3.6f1）。

## PR #84 との関係

[#84](https://github.com/limit7412/VRCARKitBlendShapeGenerator/pull/84)（#81、booth用ビルドの自動作成）が、同梱対象のスクリプトに `.meta` を要求する。
このPRが追加する5件のスクリプトぶんの `.meta` をここへ入れてあり、GUIDの導出も #84 と揃えてある。
どちらを先にマージしてもmainの `packaging` は通る（両方を合わせた状態で検証が通ることは確認済み）。

ただし **README.md がコンフリクトします。** 両PRとも「インストール」節へ追記しているためです。
片方をマージした時点で、もう片方を解消します（両方の節を並べるだけです）。

## 補足

リポジトリの `package.json` は `0.1.4` のまま置かれている（release.ymlがリリース時に書き換えるため）。
そのためクローンを `Packages/` へ置いて開発している場合、更新の案内が出る。
配布物では正しい版が入るので実害は無いが、煩わしければ Preferences から切れる。

Closes #82