### PR TITLE
更新確認を読み込み時に行い、booth版はその場で更新する

### DIFF
--- a/Editor/Domain/PackageVersion.cs
+++ b/Editor/Domain/PackageVersion.cs
@@ -88,6 +88,19 @@ namespace ARKitBlendShapeGenerator.Domain
             return latest.CompareTo(current) > 0;
         }
 
+        /// <summary>
+        /// 2つの表記が同じ版を指すか。
+        ///
+        /// `v0.2.0`と`0.2.0`、`0.2`と`0.2.0`は同じ版として扱う。
+        /// タグとpackage.jsonのversionは書き方が揃うとは限らないため、文字列では比べられない
+        /// </summary>
+        public static bool IsSameVersion(string leftText, string rightText)
+        {
+            return TryParse(leftText, out var left)
+                && TryParse(rightText, out var right)
+                && left.Equals(right);
+        }
+
         public int CompareTo(PackageVersion other)
         {
             var major = Major.CompareTo(other.Major);

--- a/Editor/Domain/ReleaseAsset.cs
+++ b/Editor/Domain/ReleaseAsset.cs
@@ -1,0 +1,27 @@
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// リリースに添付されたファイル1件。
+    ///
+    /// 自己更新はここからbooth用zipを選んで取得する
+    /// </summary>
+    internal readonly struct ReleaseAsset
+    {
+        public string Name { get; }
+        public string DownloadUrl { get; }
+
+        /// <summary>
+        /// GitHubがアセットごとに返すダイジェスト。`sha256:`で始まる。
+        ///
+        /// 古いリリースや応答の形によっては付かないため、空になりうる
+        /// </summary>
+        public string Digest { get; }
+
+        public ReleaseAsset(string name, string downloadUrl, string digest)
+        {
+            Name = name;
+            DownloadUrl = downloadUrl;
+            Digest = digest;
+        }
+    }
+}

--- a/Editor/Domain/ReleaseAsset.cs.meta
+++ b/Editor/Domain/ReleaseAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f16cf8c7117d5816f02b4f86d69d9f8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Domain/SelfUpdatePlan.cs
+++ b/Editor/Domain/SelfUpdatePlan.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// booth版の自己更新について、Unityへ触れずに決められることをまとめる。
+    ///
+    /// どのアセットを取りに行くか、更新してよい置かれ方か、取り込みの前に何を消すか。
+    /// いずれも失敗すると利用者のプロジェクトを壊すため、規則をここへ集めて検証できるようにする
+    /// </summary>
+    internal static class SelfUpdatePlan
+    {
+        /// <summary>
+        /// unitypackageが自身の中に持つ取り込み先。
+        ///
+        /// 取り込みはこのパスへ向かうため、手元のフォルダがここに無い場合、
+        /// 更新は既存のフォルダを置き換えず、canonicalな位置へもう一組を作ってしまう
+        /// </summary>
+        public const string InstallRoot = "Assets/AtelierKairox/VRCARKitBlendShapeGenerator";
+
+        private const string BoothAssetPrefix = "VRCARKitBlendShapeGenerator_";
+        private const string BoothAssetSuffix = ".zip";
+
+        /// <summary>そのタグのリリースに添付されるbooth用zipの名前</summary>
+        public static string BoothAssetName(string tag)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", BoothAssetPrefix, tag, BoothAssetSuffix);
+        }
+
+        /// <summary>
+        /// 自己更新を行える置かれ方かどうか。
+        ///
+        /// booth版であっても、フォルダが動かされていれば行わない。
+        /// 取り込み先はunitypackageの側で決まっており、手元の位置へは追従しないため、
+        /// 実行すると同じアセンブリがプロジェクトに二組できてコンパイルが通らなくなる
+        /// </summary>
+        public static bool CanSelfUpdate(InstallLocation location, string packageRoot)
+        {
+            return location == InstallLocation.Booth
+                && string.Equals(Normalize(packageRoot), InstallRoot, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// 取得すべきアセットを名前で選ぶ。見つからなければ偽を返す。
+        ///
+        /// 同じリリースにはVPM用zipも並ぶため、拡張子だけでは選べない
+        /// </summary>
+        public static bool TrySelectBoothAsset(IEnumerable<ReleaseAsset> assets, string tag, out ReleaseAsset selected)
+        {
+            selected = default;
+
+            if (assets == null || string.IsNullOrEmpty(tag))
+            {
+                return false;
+            }
+
+            var expected = BoothAssetName(tag);
+            foreach (var asset in assets)
+            {
+                if (!string.Equals(asset.Name, expected, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(asset.DownloadUrl))
+                {
+                    return false;
+                }
+
+                selected = asset;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 取り込みの前に消すアセットを選ぶ。
+        ///
+        /// unitypackageの取り込みは追加と上書きしかしないため、前の版にあって新しい版で
+        /// 無くなったファイルが残る。クラスを消したりリネームした版へ更新すると、
+        /// 残ったファイルがコンパイルエラーを起こす。
+        ///
+        /// 手元にしか無いファイルは、利用者が自分で置いたものである可能性もあるが、
+        /// パッケージのフォルダの中に限る。
+        /// </summary>
+        /// <param name="installedAssetPaths">手元のフォルダにあるアセットのパス（.metaを除く）</param>
+        /// <param name="packagedPathnames">新しいunitypackageが持つ取り込み先のパス</param>
+        public static IReadOnlyList<string> SelectObsoleteAssets(
+            IEnumerable<string> installedAssetPaths,
+            IEnumerable<string> packagedPathnames)
+        {
+            var obsolete = new List<string>();
+
+            if (installedAssetPaths == null)
+            {
+                return obsolete;
+            }
+
+            var packaged = new HashSet<string>(StringComparer.Ordinal);
+            if (packagedPathnames != null)
+            {
+                foreach (var pathname in packagedPathnames)
+                {
+                    var normalized = Normalize(pathname);
+                    if (normalized != null)
+                    {
+                        packaged.Add(normalized);
+                    }
+                }
+            }
+
+            // 新しい版が1件も読めなかった場合に手元を消し尽くさないよう、空の一覧は使わない
+            if (packaged.Count == 0)
+            {
+                return obsolete;
+            }
+
+            foreach (var path in installedAssetPaths)
+            {
+                var normalized = Normalize(path);
+                if (normalized == null || packaged.Contains(normalized))
+                {
+                    continue;
+                }
+
+                obsolete.Add(normalized);
+            }
+
+            obsolete.Sort(StringComparer.Ordinal);
+            return obsolete;
+        }
+
+        private static string Normalize(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return null;
+            }
+
+            return path.Trim().Replace('\\', '/').TrimEnd('/');
+        }
+    }
+}

--- a/Editor/Domain/SelfUpdatePlan.cs
+++ b/Editor/Domain/SelfUpdatePlan.cs
@@ -164,7 +164,7 @@ namespace ARKitBlendShapeGenerator.Domain
         /// 手元にしか無いファイルは、利用者が自分で置いたものである可能性もあるが、
         /// パッケージのフォルダの中に限る。
         /// </summary>
-        /// <param name="installedAssetPaths">手元のフォルダにあるアセットのパス（.metaを除く）</param>
+        /// <param name="installedAssetPaths">手元のフォルダにあるアセットのパス（フォルダを含み、.metaを除く）</param>
         /// <param name="packagedPathnames">新しいunitypackageが持つ取り込み先のパス</param>
         public static IReadOnlyList<string> SelectObsoleteAssets(
             IEnumerable<string> installedAssetPaths,
@@ -196,6 +196,7 @@ namespace ARKitBlendShapeGenerator.Domain
                 return obsolete;
             }
 
+            var candidates = new List<string>();
             foreach (var path in installedAssetPaths)
             {
                 var normalized = Normalize(path);
@@ -204,11 +205,41 @@ namespace ARKitBlendShapeGenerator.Domain
                     continue;
                 }
 
-                obsolete.Add(normalized);
+                candidates.Add(normalized);
+            }
+
+            // 消すフォルダの中身は、そのフォルダごと消える。
+            // 中身まで並べると、先にフォルダが消えた時点で残りが「消せなかった」ものとして
+            // 返り、更新そのものが中止になる
+            var removedFolders = new HashSet<string>(candidates, StringComparer.Ordinal);
+            foreach (var candidate in candidates)
+            {
+                if (!HasAncestorIn(candidate, removedFolders))
+                {
+                    obsolete.Add(candidate);
+                }
             }
 
             obsolete.Sort(StringComparer.Ordinal);
             return obsolete;
+        }
+
+        /// <summary>そのパスの親をたどり、消す一覧に含まれるものがあるか</summary>
+        private static bool HasAncestorIn(string path, HashSet<string> paths)
+        {
+            var separator = path.LastIndexOf('/');
+            while (separator > 0)
+            {
+                path = path.Substring(0, separator);
+                if (paths.Contains(path))
+                {
+                    return true;
+                }
+
+                separator = path.LastIndexOf('/');
+            }
+
+            return false;
         }
 
         private static string Normalize(string path)

--- a/Editor/Domain/SelfUpdatePlan.cs
+++ b/Editor/Domain/SelfUpdatePlan.cs
@@ -22,11 +22,45 @@ namespace ARKitBlendShapeGenerator.Domain
 
         private const string BoothAssetPrefix = "VRCARKitBlendShapeGenerator_";
         private const string BoothAssetSuffix = ".zip";
+        private const string TagVersionPrefix = "v";
+
+        /// <summary>
+        /// このパッケージのunitypackageなら必ず持つ取り込み先。
+        ///
+        /// アセンブリの定義とマニフェストが欠けたものは、少なくともこのパッケージではない
+        /// </summary>
+        private static readonly string[] RequiredPathnames =
+        {
+            InstallRoot,
+            InstallRoot + "/package.json",
+            InstallRoot + "/Editor/ARKitBlendShapeGenerator.Editor.asmdef",
+            InstallRoot + "/Runtime/ARKitBlendShapeGenerator.Runtime.asmdef",
+        };
+
+        /// <summary>
+        /// タグから、配布物の名前に使われるバージョンを取り出す。
+        ///
+        /// release.ymlは先頭の`v`を落としてから資材を作るため、`v0.2.0`のタグからは
+        /// `VRCARKitBlendShapeGenerator_0.2.0.zip`ができる。同じ形にしないと取りに行く名前が外れる
+        /// </summary>
+        public static string AssetVersion(string tag)
+        {
+            if (string.IsNullOrWhiteSpace(tag))
+            {
+                return tag;
+            }
+
+            var trimmed = tag.Trim();
+            return trimmed.StartsWith(TagVersionPrefix, StringComparison.Ordinal)
+                ? trimmed.Substring(TagVersionPrefix.Length)
+                : trimmed;
+        }
 
         /// <summary>そのタグのリリースに添付されるbooth用zipの名前</summary>
         public static string BoothAssetName(string tag)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}{1}{2}", BoothAssetPrefix, tag, BoothAssetSuffix);
+            return string.Format(
+                CultureInfo.InvariantCulture, "{0}{1}{2}", BoothAssetPrefix, AssetVersion(tag), BoothAssetSuffix);
         }
 
         /// <summary>
@@ -74,6 +108,50 @@ namespace ARKitBlendShapeGenerator.Domain
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// 取り込もうとしている中身が、このパッケージのものかどうか。
+        ///
+        /// 消すファイルは「新しい版に無いもの」として選ぶため、中身の欠けたunitypackageや
+        /// 別のパッケージのものを受け入れると、手元のほとんどが消える。
+        /// ダイジェストは配布されたファイルそのものとは一致するので、この防ぎ方にはならない
+        /// </summary>
+        public static bool IsExpectedPackage(IEnumerable<string> packagedPathnames)
+        {
+            if (packagedPathnames == null)
+            {
+                return false;
+            }
+
+            var packaged = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var pathname in packagedPathnames)
+            {
+                var normalized = Normalize(pathname);
+                if (normalized == null)
+                {
+                    continue;
+                }
+
+                // 取り込み先がフォルダの外を指すものが混ざっていれば、このパッケージではない
+                if (normalized != InstallRoot
+                    && !normalized.StartsWith(InstallRoot + "/", StringComparison.Ordinal))
+                {
+                    return false;
+                }
+
+                packaged.Add(normalized);
+            }
+
+            foreach (var required in RequiredPathnames)
+            {
+                if (!packaged.Contains(required))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/Editor/Domain/SelfUpdatePlan.cs.meta
+++ b/Editor/Domain/SelfUpdatePlan.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0a0c9a5c6c9e72fc97cee42120d6c460
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Domain/UnityPackageContents.cs
+++ b/Editor/Domain/UnityPackageContents.cs
@@ -23,22 +23,26 @@ namespace ARKitBlendShapeGenerator.Domain
         private const int SizeLength = 12;
 
         private const string PathnameEntry = "pathname";
+        private const string AssetEntry = "asset";
 
         /// <summary>
-        /// 取り込み先のパスを読み取る。
+        /// 取り込み先と中身を読み取る。
         ///
         /// 壊れた書庫では読めたところまでを返さず、例外を投げる。
         /// 途中までの一覧を「新しい版の中身」として扱うと、
         /// 残りのファイルを消してよいと判断してしまう
         /// </summary>
-        public static IReadOnlyList<string> ReadPathnames(Stream unityPackage)
+        public static IReadOnlyList<UnityPackageEntry> Read(Stream unityPackage)
         {
             if (unityPackage == null)
             {
                 throw new ArgumentNullException(nameof(unityPackage));
             }
 
-            var pathnames = new List<string>();
+            // エントリは`<guid>/`の下に分かれて並び、中身と取り込み先の順序は決まっていない
+            var pathnames = new Dictionary<string, string>(StringComparer.Ordinal);
+            var assets = new Dictionary<string, byte[]>(StringComparer.Ordinal);
+            var order = new List<string>();
 
             using (var gzip = new GZipStream(unityPackage, CompressionMode.Decompress, leaveOpen: true))
             {
@@ -57,26 +61,58 @@ namespace ARKitBlendShapeGenerator.Domain
                     var size = ReadOctal(header, SizeOffset, SizeLength);
                     var content = ReadContent(gzip, size);
 
-                    if (IsPathnameEntry(name))
+                    if (!TrySplitEntry(name, out var guid, out var kind))
+                    {
+                        continue;
+                    }
+
+                    if (kind == PathnameEntry)
                     {
                         var pathname = Encoding.UTF8.GetString(content).Trim().Replace('\\', '/');
-                        if (pathname.Length > 0)
+                        if (pathname.Length == 0)
                         {
-                            pathnames.Add(pathname);
+                            continue;
                         }
+
+                        if (!pathnames.ContainsKey(guid))
+                        {
+                            order.Add(guid);
+                        }
+
+                        pathnames[guid] = pathname;
+                    }
+                    else if (kind == AssetEntry)
+                    {
+                        assets[guid] = content;
                     }
                 }
             }
 
-            return pathnames;
+            var entries = new List<UnityPackageEntry>(order.Count);
+            foreach (var guid in order)
+            {
+                assets.TryGetValue(guid, out var asset);
+                entries.Add(new UnityPackageEntry(pathnames[guid], asset));
+            }
+
+            return entries;
         }
 
-        private static bool IsPathnameEntry(string name)
+        private static bool TrySplitEntry(string name, out string guid, out string kind)
         {
-            // エントリは`<guid>/pathname`の形をとる
+            guid = null;
+            kind = null;
+
+            // エントリは`<guid>/asset`のような形をとる
             var separator = name.LastIndexOf('/');
-            return separator >= 0
-                && string.Equals(name.Substring(separator + 1), PathnameEntry, StringComparison.Ordinal);
+            if (separator <= 0)
+            {
+                return false;
+            }
+
+            guid = name.Substring(0, separator);
+            kind = name.Substring(separator + 1);
+            return true;
         }
 
         private static byte[] ReadContent(Stream stream, long size)

--- a/Editor/Domain/UnityPackageContents.cs
+++ b/Editor/Domain/UnityPackageContents.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// unitypackageが何をどこへ取り込むかを読み取る。
+    ///
+    /// unitypackageはgzipで圧縮したtarで、アセット1件につきGUIDを名前とするディレクトリを持ち、
+    /// その中の`pathname`が取り込み先を持つ。ここではその一覧だけを取り出す。
+    /// 取り込みで消えないファイルを知るために、新しい版が何を持っているかが要る
+    /// </summary>
+    internal static class UnityPackageContents
+    {
+        private const int BlockSize = 512;
+        private const int NameOffset = 0;
+        private const int NameLength = 100;
+        private const int SizeOffset = 124;
+        private const int SizeLength = 12;
+
+        private const string PathnameEntry = "pathname";
+
+        /// <summary>
+        /// 取り込み先のパスを読み取る。
+        ///
+        /// 壊れた書庫では読めたところまでを返さず、例外を投げる。
+        /// 途中までの一覧を「新しい版の中身」として扱うと、
+        /// 残りのファイルを消してよいと判断してしまう
+        /// </summary>
+        public static IReadOnlyList<string> ReadPathnames(Stream unityPackage)
+        {
+            if (unityPackage == null)
+            {
+                throw new ArgumentNullException(nameof(unityPackage));
+            }
+
+            var pathnames = new List<string>();
+
+            using (var gzip = new GZipStream(unityPackage, CompressionMode.Decompress, leaveOpen: true))
+            {
+                var header = new byte[BlockSize];
+                while (true)
+                {
+                    ReadExactly(gzip, header, BlockSize);
+
+                    // ファイル名が空のブロックは終端を表す
+                    if (header[NameOffset] == 0)
+                    {
+                        break;
+                    }
+
+                    var name = ReadString(header, NameOffset, NameLength);
+                    var size = ReadOctal(header, SizeOffset, SizeLength);
+                    var content = ReadContent(gzip, size);
+
+                    if (IsPathnameEntry(name))
+                    {
+                        var pathname = Encoding.UTF8.GetString(content).Trim().Replace('\\', '/');
+                        if (pathname.Length > 0)
+                        {
+                            pathnames.Add(pathname);
+                        }
+                    }
+                }
+            }
+
+            return pathnames;
+        }
+
+        private static bool IsPathnameEntry(string name)
+        {
+            // エントリは`<guid>/pathname`の形をとる
+            var separator = name.LastIndexOf('/');
+            return separator >= 0
+                && string.Equals(name.Substring(separator + 1), PathnameEntry, StringComparison.Ordinal);
+        }
+
+        private static byte[] ReadContent(Stream stream, long size)
+        {
+            if (size < 0 || size > int.MaxValue)
+            {
+                throw new InvalidDataException("unitypackageのエントリの大きさが読み取れません");
+            }
+
+            var content = new byte[size];
+            ReadExactly(stream, content, (int)size);
+
+            // 中身はブロック境界まで埋められている
+            var padding = (int)(BlockSize - size % BlockSize) % BlockSize;
+            if (padding > 0)
+            {
+                ReadExactly(stream, new byte[padding], padding);
+            }
+
+            return content;
+        }
+
+        private static void ReadExactly(Stream stream, byte[] buffer, int count)
+        {
+            var read = 0;
+            while (read < count)
+            {
+                var chunk = stream.Read(buffer, read, count - read);
+                if (chunk <= 0)
+                {
+                    throw new EndOfStreamException("unitypackageが途中で終わっています");
+                }
+
+                read += chunk;
+            }
+        }
+
+        private static string ReadString(byte[] header, int offset, int length)
+        {
+            var end = offset;
+            var limit = offset + length;
+            while (end < limit && header[end] != 0)
+            {
+                end++;
+            }
+
+            return Encoding.UTF8.GetString(header, offset, end - offset);
+        }
+
+        private static long ReadOctal(byte[] header, int offset, int length)
+        {
+            var text = ReadString(header, offset, length).Trim();
+            if (text.Length == 0)
+            {
+                return 0;
+            }
+
+            long value = 0;
+            foreach (var character in text)
+            {
+                if (character < '0' || character > '7')
+                {
+                    throw new InvalidDataException(string.Format(
+                        CultureInfo.InvariantCulture, "tarヘッダの数値が読み取れません: {0}", text));
+                }
+
+                value = value * 8 + (character - '0');
+            }
+
+            return value;
+        }
+    }
+}

--- a/Editor/Domain/UnityPackageContents.cs.meta
+++ b/Editor/Domain/UnityPackageContents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f15adfe2ce46390f2ec8855f2f52ff77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Domain/UnityPackageEntry.cs
+++ b/Editor/Domain/UnityPackageEntry.cs
@@ -1,0 +1,22 @@
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// unitypackageに入っているアセット1件。
+    ///
+    /// フォルダのエントリは中身を持たない
+    /// </summary>
+    internal readonly struct UnityPackageEntry
+    {
+        /// <summary>プロジェクトルートから見た取り込み先</summary>
+        public string Pathname { get; }
+
+        /// <summary>アセットの中身。フォルダならnull</summary>
+        public byte[] Asset { get; }
+
+        public UnityPackageEntry(string pathname, byte[] asset)
+        {
+            Pathname = pathname;
+            Asset = asset;
+        }
+    }
+}

--- a/Editor/Domain/UnityPackageEntry.cs.meta
+++ b/Editor/Domain/UnityPackageEntry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f9ce2fd06234e09139ef05beb2a38641
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Domain/UpdateAnnouncement.cs
+++ b/Editor/Domain/UpdateAnnouncement.cs
@@ -1,0 +1,31 @@
+namespace ARKitBlendShapeGenerator.Domain
+{
+    /// <summary>
+    /// 新しい版が出ていることをポップアップで知らせるかどうかの判断。
+    ///
+    /// 知らせるのは版ごとに一度だけで、二度目以降はインスペクタのボタンに任せる。
+    /// 作業の途中に割り込む形になるため、同じ版で繰り返し出すわけにはいかない。
+    /// 更にその先の版が出たときは、その版について改めて一度だけ出す
+    /// </summary>
+    internal static class UpdateAnnouncement
+    {
+        /// <param name="location">手元のインストール形態</param>
+        /// <param name="pendingTag">知らせるべき新しい版。無ければnull</param>
+        /// <param name="announcedTag">既にポップアップで知らせた版。まだ無ければnullか空</param>
+        public static bool ShouldAnnounce(InstallLocation location, string pendingTag, string announcedTag)
+        {
+            // VPM版の更新はVCC/ALCOMが担うため、こちらから割り込まない
+            if (location != InstallLocation.Booth)
+            {
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(pendingTag))
+            {
+                return false;
+            }
+
+            return pendingTag != announcedTag;
+        }
+    }
+}

--- a/Editor/Domain/UpdateAnnouncement.cs.meta
+++ b/Editor/Domain/UpdateAnnouncement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 220245669d7975b0e81eed67dd0e0abe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Handler/UpdateCheckStartup.cs
+++ b/Editor/Handler/UpdateCheckStartup.cs
@@ -127,13 +127,13 @@ namespace ARKitBlendShapeGenerator.Handler
             // タグは`v0.2.0`のようにも書ける。package.jsonのversionとは表記が揃わない
             if (PackageVersion.IsSameVersion(PackageLocation.Version, requested))
             {
-                EditorPrefs.DeleteKey(SelfUpdater.BackupPathKey);
+                SessionState.EraseString(SelfUpdater.BackupPathKey);
                 Debug.Log("[ARKitGenerator] " + S("update.completed", requested));
                 return;
             }
 
             // 取り込みが途中で終わった場合に備えて、退避先を知らせる
-            var backup = EditorPrefs.GetString(SelfUpdater.BackupPathKey, string.Empty);
+            var backup = SessionState.GetString(SelfUpdater.BackupPathKey, string.Empty);
             Debug.LogWarning("[ARKitGenerator] " + S("update.incomplete", requested, backup));
         }
     }

--- a/Editor/Handler/UpdateCheckStartup.cs
+++ b/Editor/Handler/UpdateCheckStartup.cs
@@ -36,10 +36,23 @@ namespace ARKitBlendShapeGenerator.Handler
 
             // 応答は起動後しばらくして返る。届いた時点で改めて見る
             UpdateCheck.ResultChanged += Announce;
+
+            // 再生中に届いた場合は知らせを見送るため、戻ってきたところで拾い直す。
+            // ドメインリロードを切っているプロジェクトでは、再生の前後で読み込みが起きない
+            EditorApplication.playModeStateChanged += OnPlayModeChanged;
+
             UpdateCheck.PollIfDue();
 
             // 前回の確認結果が残っていることもあるため、応答を待たずに一度見る
             Announce();
+        }
+
+        private static void OnPlayModeChanged(PlayModeStateChange change)
+        {
+            if (change == PlayModeStateChange.EnteredEditMode)
+            {
+                Announce();
+            }
         }
 
         private static void Announce()
@@ -111,7 +124,8 @@ namespace ARKitBlendShapeGenerator.Handler
 
             SessionState.EraseString(SelfUpdater.PendingCompletionKey);
 
-            if (PackageLocation.Version == requested)
+            // タグは`v0.2.0`のようにも書ける。package.jsonのversionとは表記が揃わない
+            if (PackageVersion.IsSameVersion(PackageLocation.Version, requested))
             {
                 EditorPrefs.DeleteKey(SelfUpdater.BackupPathKey);
                 Debug.Log("[ARKitGenerator] " + S("update.completed", requested));

--- a/Editor/Handler/UpdateCheckStartup.cs
+++ b/Editor/Handler/UpdateCheckStartup.cs
@@ -1,0 +1,126 @@
+using UnityEditor;
+using UnityEngine;
+using ARKitBlendShapeGenerator.Domain;
+using ARKitBlendShapeGenerator.Infra;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator.Handler
+{
+    /// <summary>
+    /// 読み込み時に更新を確認し、booth版で新しい版が出ていれば一度だけポップアップで知らせる。
+    ///
+    /// 確認のためにインスペクタを開かせるわけにはいかないので、契機はエディタの読み込みに置く。
+    /// 通信するかどうかと1日1回までの間隔はUpdateCheckが持つ判断のままで、ここは契機だけを足す。
+    ///
+    /// ポップアップは版ごとに一度きりで、二度目以降はインスペクタのボタンに任せる
+    /// </summary>
+    [InitializeOnLoad]
+    internal static class UpdateCheckStartup
+    {
+        static UpdateCheckStartup()
+        {
+            // バッチ実行ではダイアログを出せず、待つ相手もいない
+            if (Application.isBatchMode)
+            {
+                return;
+            }
+
+            // 静的コンストラクタの時点ではAssetDatabaseもEditorPrefsも触りにくいため、
+            // エディタが落ち着いてから始める
+            EditorApplication.delayCall += Begin;
+        }
+
+        private static void Begin()
+        {
+            ReportCompletedUpdate();
+
+            // 応答は起動後しばらくして返る。届いた時点で改めて見る
+            UpdateCheck.ResultChanged += Announce;
+            UpdateCheck.PollIfDue();
+
+            // 前回の確認結果が残っていることもあるため、応答を待たずに一度見る
+            Announce();
+        }
+
+        private static void Announce()
+        {
+            // 再生へ入る操作の途中でダイアログを挟むと、手を止めさせることになる。
+            // 版ごとに一度きりの知らせなので、落ち着いた場面まで待ってよい
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                return;
+            }
+
+            var tag = UpdateCheck.PendingUpdateTag;
+            if (!UpdateAnnouncement.ShouldAnnounce(PackageLocation.Location, tag, UpdateCheck.AnnouncedTag))
+            {
+                return;
+            }
+
+            // 出したことを先に記録する。ここで何を選ばれても、この版で再び出すことはない
+            UpdateCheck.AnnouncedTag = tag;
+
+            if (!SelfUpdater.IsSupported)
+            {
+                // フォルダが動かされている場合、取り込み先が手元と合わないため入れ直しを案内する
+                if (EditorUtility.DisplayDialog(
+                        S("dialog.title"),
+                        S("update.available.booth", tag),
+                        S("common.ok"),
+                        S("update.dismiss")))
+                {
+                    return;
+                }
+
+                UpdateCheck.Dismiss(tag);
+                return;
+            }
+
+            switch (EditorUtility.DisplayDialogComplex(
+                        S("dialog.title"),
+                        S("update.announce.message", tag),
+                        S("update.announce.update"),
+                        S("update.announce.later"),
+                        S("update.dismiss")))
+            {
+                case 0:
+                    SelfUpdater.Run(tag);
+                    break;
+                case 1:
+                    // インスペクタのボタンから改めて更新できる
+                    break;
+                default:
+                    UpdateCheck.Dismiss(tag);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// 取り込みを要求した版が入ったかを確かめ、結果を知らせる。
+        ///
+        /// 取り込みはアセンブリの読み直しを起こし、要求した側のコードはそこで消える。
+        /// 完了を知らせられるのは読み直しの後になる
+        /// </summary>
+        private static void ReportCompletedUpdate()
+        {
+            var requested = SessionState.GetString(SelfUpdater.PendingCompletionKey, string.Empty);
+            if (string.IsNullOrEmpty(requested))
+            {
+                return;
+            }
+
+            SessionState.EraseString(SelfUpdater.PendingCompletionKey);
+
+            if (PackageLocation.Version == requested)
+            {
+                EditorPrefs.DeleteKey(SelfUpdater.BackupPathKey);
+                Debug.Log("[ARKitGenerator] " + S("update.completed", requested));
+                return;
+            }
+
+            // 取り込みが途中で終わった場合に備えて、退避先を知らせる
+            var backup = EditorPrefs.GetString(SelfUpdater.BackupPathKey, string.Empty);
+            Debug.LogWarning("[ARKitGenerator] " + S("update.incomplete", requested, backup));
+        }
+    }
+}

--- a/Editor/Handler/UpdateCheckStartup.cs.meta
+++ b/Editor/Handler/UpdateCheckStartup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aceb2b8e022f68116debaf2a211c53d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Infra/PackageLocation.cs
+++ b/Editor/Infra/PackageLocation.cs
@@ -20,6 +20,7 @@ namespace ARKitBlendShapeGenerator.Infra
         private static bool _resolved;
         private static InstallLocation _location;
         private static string _version;
+        private static string _root;
 
         /// <summary>インストール形態。判別できなければUnknown</summary>
         public static InstallLocation Location
@@ -41,6 +42,16 @@ namespace ARKitBlendShapeGenerator.Infra
             }
         }
 
+        /// <summary>パッケージのルート。判別できなければnull</summary>
+        public static string Root
+        {
+            get
+            {
+                Resolve();
+                return _root;
+            }
+        }
+
         private static void Resolve()
         {
             if (_resolved)
@@ -56,6 +67,7 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
+            _root = packageRoot;
             _version = ReadVersion(packageRoot);
         }
 

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Security.Cryptography;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+using ARKitBlendShapeGenerator.Domain;
+using static ARKitBlendShapeGenerator.Localization;
+
+namespace ARKitBlendShapeGenerator.Infra
+{
+    /// <summary>
+    /// booth版を新しい版のunitypackageで置き換える。
+    ///
+    /// 手順を分けているのは、プロジェクトのファイルへ触れるのを最後に寄せるため。
+    /// 取得と検証と展開を先に済ませ、どれかが失敗した場合は手元に手を付けずに終わる。
+    ///
+    /// 取り込みは自分自身を差し替える。要求した時点でエディタのアセンブリが読み直されるため、
+    /// 以降の処理をここへ書いても実行されない。完了の知らせはSessionStateへ残し、
+    /// 読み込み後にUpdateCheckStartupが拾う
+    /// </summary>
+    internal static class SelfUpdater
+    {
+        /// <summary>取り込みを要求した版。読み込み後に完了を知らせるために置く</summary>
+        internal const string PendingCompletionKey = "ARKitBlendShapeGenerator.SelfUpdate.PendingTag";
+
+        /// <summary>退避先の場所。失敗したときに案内する</summary>
+        internal const string BackupPathKey = "ARKitBlendShapeGenerator.SelfUpdate.BackupPath";
+
+        private const int RequestTimeoutSeconds = 60;
+        private const string UnityPackageExtension = ".unitypackage";
+        private const string DigestPrefix = "sha256:";
+
+        private static bool _isRunning;
+
+        /// <summary>更新の実行中。ボタンを二重に押されても始めない</summary>
+        public static bool IsRunning
+        {
+            get { return _isRunning; }
+        }
+
+        /// <summary>この置かれ方で自己更新を行えるか</summary>
+        public static bool IsSupported
+        {
+            get { return SelfUpdatePlan.CanSelfUpdate(PackageLocation.Location, PackageLocation.Root); }
+        }
+
+        /// <summary>
+        /// 指定した版へ更新する。
+        ///
+        /// 呼ぶ前に利用者の同意を取ること。取り込みはUndoできない
+        /// </summary>
+        public static void Run(string tag)
+        {
+            if (_isRunning || string.IsNullOrEmpty(tag))
+            {
+                return;
+            }
+
+            if (!IsSupported)
+            {
+                Fail(S("update.error.unsupported"));
+                return;
+            }
+
+            _isRunning = true;
+
+            // アセットのURLは応答ごとに変わりうるため、確認時のものを覚えず、その場で取り直す
+            Send(() => UnityWebRequest.Get(UpdateCheck.LatestReleaseApiUrl), request =>
+            {
+                if (!UpdateCheck.TryParseRelease(request.downloadHandler?.text, out var latest, out var assets)
+                    || latest != tag)
+                {
+                    Fail(S("update.error.release_missing", tag));
+                    return;
+                }
+
+                if (!SelfUpdatePlan.TrySelectBoothAsset(assets, tag, out var asset))
+                {
+                    Fail(S("update.error.asset_missing", SelfUpdatePlan.BoothAssetName(tag)));
+                    return;
+                }
+
+                Download(asset, tag);
+            });
+        }
+
+        private static void Download(ReleaseAsset asset, string tag)
+        {
+            var archivePath = FileUtil.GetUniqueTempPathInProject() + ".zip";
+
+            Send(
+                () =>
+                {
+                    var request = UnityWebRequest.Get(asset.DownloadUrl);
+                    request.downloadHandler = new DownloadHandlerFile(archivePath);
+                    return request;
+                },
+                _ =>
+                {
+                    try
+                    {
+                        Install(archivePath, asset, tag);
+                    }
+                    finally
+                    {
+                        Delete(archivePath);
+                    }
+                });
+        }
+
+        private static void Install(string archivePath, ReleaseAsset asset, string tag)
+        {
+            if (!TryVerifyDigest(archivePath, asset.Digest))
+            {
+                Fail(S("update.error.digest"));
+                return;
+            }
+
+            var unityPackagePath = FileUtil.GetUniqueTempPathInProject() + UnityPackageExtension;
+            IReadOnlyList<string> packagedPathnames;
+
+            try
+            {
+                ExtractUnityPackage(archivePath, unityPackagePath);
+
+                using (var stream = File.OpenRead(unityPackagePath))
+                {
+                    packagedPathnames = UnityPackageContents.ReadPathnames(stream);
+                }
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.archive", exception.Message));
+                return;
+            }
+
+            var obsolete = SelfUpdatePlan.SelectObsoleteAssets(EnumerateInstalledAssets(), packagedPathnames);
+
+            string backupPath;
+            try
+            {
+                backupPath = Backup();
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.backup", exception.Message));
+                return;
+            }
+
+            // ここから先はプロジェクトのファイルを書き換える。
+            // 途中でアセンブリが読み直されると取り込みまで辿り着けないため、reloadを止めておく
+            EditorApplication.LockReloadAssemblies();
+            try
+            {
+                DeleteObsolete(obsolete);
+
+                EditorPrefs.SetString(BackupPathKey, backupPath);
+                SessionState.SetString(PendingCompletionKey, tag);
+
+                // 取り込みを要求した時点で、この先のコードは差し替えの対象になる
+                AssetDatabase.ImportPackage(unityPackagePath, false);
+            }
+            finally
+            {
+                EditorApplication.UnlockReloadAssemblies();
+                _isRunning = false;
+            }
+        }
+
+        private static void DeleteObsolete(IReadOnlyList<string> obsolete)
+        {
+            if (obsolete.Count == 0)
+            {
+                return;
+            }
+
+            // .metaはAssetDatabaseが一緒に始末する
+            var failed = new List<string>();
+            AssetDatabase.DeleteAssets(obsolete.ToArray(), failed);
+
+            // 消せなかったファイルが残ってもコンパイルが通らなくなるだけで、取り込みは進む。
+            // 何が残ったかは分かるようにしておく
+            foreach (var path in failed)
+            {
+                Debug.LogWarning(string.Format(
+                    CultureInfo.InvariantCulture, "[ARKitGenerator] {0} を削除できませんでした", path));
+            }
+        }
+
+        /// <summary>手元のフォルダにあるアセットを、プロジェクトからの相対パスで並べる</summary>
+        private static IEnumerable<string> EnumerateInstalledAssets()
+        {
+            var root = PackageLocation.Root;
+            if (string.IsNullOrEmpty(root) || !Directory.Exists(root))
+            {
+                yield break;
+            }
+
+            foreach (var path in Directory.GetFiles(root, "*", SearchOption.AllDirectories))
+            {
+                if (path.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                yield return path.Replace('\\', '/');
+            }
+        }
+
+        private static string Backup()
+        {
+            var backupPath = FileUtil.GetUniqueTempPathInProject();
+            FileUtil.CopyFileOrDirectory(PackageLocation.Root, backupPath);
+            return Path.GetFullPath(backupPath);
+        }
+
+        private static void ExtractUnityPackage(string archivePath, string destination)
+        {
+            using (var stream = File.OpenRead(archivePath))
+            using (var archive = new ZipArchive(stream, ZipArchiveMode.Read))
+            {
+                ZipArchiveEntry found = null;
+                foreach (var entry in archive.Entries)
+                {
+                    if (!entry.FullName.EndsWith(UnityPackageExtension, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    if (found != null)
+                    {
+                        throw new InvalidDataException("zipに.unitypackageが複数入っています");
+                    }
+
+                    found = entry;
+                }
+
+                if (found == null)
+                {
+                    throw new InvalidDataException("zipに.unitypackageが入っていません");
+                }
+
+                using (var source = found.Open())
+                using (var target = File.Create(destination))
+                {
+                    source.CopyTo(target);
+                }
+            }
+        }
+
+        /// <summary>
+        /// ダイジェストと突き合わせる。
+        ///
+        /// 応答がダイジェストを持たない場合は照合できないが、取得はHTTPSで行っており、
+        /// 照合できないことを理由に更新を止めるほどではない
+        /// </summary>
+        private static bool TryVerifyDigest(string archivePath, string digest)
+        {
+            if (string.IsNullOrEmpty(digest) || !digest.StartsWith(DigestPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var expected = digest.Substring(DigestPrefix.Length).Trim();
+
+            try
+            {
+                using (var sha256 = SHA256.Create())
+                using (var stream = File.OpenRead(archivePath))
+                {
+                    var actual = BitConverter.ToString(sha256.ComputeHash(stream))
+                        .Replace("-", string.Empty)
+                        .ToLowerInvariant();
+
+                    return string.Equals(actual, expected.ToLowerInvariant(), StringComparison.Ordinal);
+                }
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// 要求を組み立てて送り、成功した場合だけ続きへ渡す。
+        ///
+        /// 組み立てで失敗した場合もここで止める。投げっぱなしにすると、
+        /// 実行中の印が立ったままになり、以後ボタンが効かなくなる
+        /// </summary>
+        private static void Send(Func<UnityWebRequest> create, Action<UnityWebRequest> onSuccess)
+        {
+            UnityWebRequest request = null;
+
+            try
+            {
+                request = create();
+                request.timeout = RequestTimeoutSeconds;
+                request.SetRequestHeader("Accept", "application/vnd.github+json");
+
+                request.SendWebRequest().completed += _ =>
+                {
+                    try
+                    {
+                        if (request.result != UnityWebRequest.Result.Success)
+                        {
+                            Fail(S("update.error.download", request.error));
+                            return;
+                        }
+
+                        onSuccess(request);
+                    }
+                    finally
+                    {
+                        request.Dispose();
+                    }
+                };
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException || exception is InvalidOperationException)
+            {
+                request?.Dispose();
+                Fail(S("update.error.download", exception.Message));
+            }
+        }
+
+        private static void Fail(string message)
+        {
+            _isRunning = false;
+
+            Debug.LogWarning("[ARKitGenerator] " + message);
+
+            if (!Application.isBatchMode)
+            {
+                EditorUtility.DisplayDialog(S("dialog.title"), message, S("common.ok"));
+            }
+        }
+
+        private static void Delete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                // 一時ファイルを消せなくても更新の成否は変わらない
+                Debug.LogWarning(string.Format(
+                    CultureInfo.InvariantCulture, "[ARKitGenerator] {0}: {1}", path, exception.Message));
+            }
+        }
+
+        private static bool IsFileFailure(Exception exception)
+        {
+            return exception is IOException
+                || exception is UnauthorizedAccessException
+                || exception is ArgumentException
+                || exception is NotSupportedException
+                || exception is InvalidDataException;
+        }
+    }
+}

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -140,6 +140,14 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
+            // 中身の欠けたものや別のパッケージを受け入れると、消すファイルの選択が破滅的に外れる
+            if (!SelfUpdatePlan.IsExpectedPackage(packagedPathnames))
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.contents"));
+                return;
+            }
+
             var obsolete = SelfUpdatePlan.SelectObsoleteAssets(EnumerateInstalledAssets(), packagedPathnames);
 
             string backupPath;

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -28,11 +29,17 @@ namespace ARKitBlendShapeGenerator.Infra
         /// <summary>取り込みを要求した版。読み込み後に完了を知らせるために置く</summary>
         internal const string PendingCompletionKey = "ARKitBlendShapeGenerator.SelfUpdate.PendingTag";
 
-        /// <summary>退避先の場所。失敗したときに案内する</summary>
+        /// <summary>
+        /// 退避先の場所。失敗したときに案内する。
+        ///
+        /// EditorPrefsではなくSessionStateへ置く。前者はプロジェクトを跨いで共有されるため、
+        /// 複数のプロジェクトで同じ頃に更新すると、互いの退避先を上書きしてしまう
+        /// </summary>
         internal const string BackupPathKey = "ARKitBlendShapeGenerator.SelfUpdate.BackupPath";
 
         private const int RequestTimeoutSeconds = 60;
         private const string UnityPackageExtension = ".unitypackage";
+        private const string ManifestFileName = "package.json";
         private const string DigestPrefix = "sha256:";
 
         private static bool _isRunning;
@@ -131,7 +138,7 @@ namespace ARKitBlendShapeGenerator.Infra
             }
 
             var unityPackagePath = FileUtil.GetUniqueTempPathInProject() + UnityPackageExtension;
-            IReadOnlyList<string> packagedPathnames;
+            IReadOnlyList<UnityPackageEntry> entries;
 
             try
             {
@@ -139,7 +146,7 @@ namespace ARKitBlendShapeGenerator.Infra
 
                 using (var stream = File.OpenRead(unityPackagePath))
                 {
-                    packagedPathnames = UnityPackageContents.ReadPathnames(stream);
+                    entries = UnityPackageContents.Read(stream);
                 }
             }
             catch (Exception exception) when (IsFileFailure(exception))
@@ -149,11 +156,26 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
+            var packagedPathnames = new List<string>(entries.Count);
+            foreach (var entry in entries)
+            {
+                packagedPathnames.Add(entry.Pathname);
+            }
+
             // 中身の欠けたものや別のパッケージを受け入れると、消すファイルの選択が破滅的に外れる
             if (!SelfUpdatePlan.IsExpectedPackage(packagedPathnames))
             {
                 Delete(unityPackagePath);
                 Fail(S("update.error.contents"));
+                return;
+            }
+
+            // 名前だけ合った別の版が添付されていることもある。
+            // ダイジェストはそのファイル自体と一致するため、中身のマニフェストで確かめる
+            if (!IsExpectedVersion(entries, tag))
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.version", tag));
                 return;
             }
 
@@ -192,7 +214,7 @@ namespace ARKitBlendShapeGenerator.Infra
             }
 
             // 控えの場所は、この先で中断した場合にも辿れるよう先に残す
-            EditorPrefs.SetString(BackupPathKey, backupPath);
+            SessionState.SetString(BackupPathKey, backupPath);
 
             // ここから先はプロジェクトのファイルを書き換える。
             // 途中でアセンブリが読み直されると取り込みまで辿り着けないため、reloadを止めておく
@@ -220,6 +242,26 @@ namespace ARKitBlendShapeGenerator.Infra
                 EditorApplication.UnlockReloadAssemblies();
                 _isRunning = false;
             }
+        }
+
+        /// <summary>同梱されたpackage.jsonが、取りに行った版のものかどうか</summary>
+        private static bool IsExpectedVersion(IReadOnlyList<UnityPackageEntry> entries, string tag)
+        {
+            var manifestPath = SelfUpdatePlan.InstallRoot + "/" + ManifestFileName;
+
+            foreach (var entry in entries)
+            {
+                if (!string.Equals(entry.Pathname, manifestPath, StringComparison.Ordinal) || entry.Asset == null)
+                {
+                    continue;
+                }
+
+                var manifest = Encoding.UTF8.GetString(entry.Asset);
+                return PackageLocation.TryParseVersion(manifest, out var version)
+                    && PackageVersion.IsSameVersion(version, tag);
+            }
+
+            return false;
         }
 
         /// <summary>古い版にしか無いアセットを消し、消せなかったものを返す</summary>

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -67,10 +67,19 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
+            // 再生中にスクリプトを差し替えるわけにはいかない
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                Fail(S("update.error.playing"));
+                return;
+            }
+
             _isRunning = true;
 
-            // アセットのURLは応答ごとに変わりうるため、確認時のものを覚えず、その場で取り直す
-            Send(() => UnityWebRequest.Get(UpdateCheck.LatestReleaseApiUrl), request =>
+            // 版を指定して引く。`latest`を引き直すと、知らせてから実行するまでに次の版が
+            // 出た場合に、確かめたものと違う版が入る。
+            // アセットのURLは応答ごとに変わりうるため、確認時のものは覚えずここで取り直す
+            Send(() => UnityWebRequest.Get(UpdateCheck.ReleaseByTagApiUrl(tag)), request =>
             {
                 if (!UpdateCheck.TryParseRelease(request.downloadHandler?.text, out var latest, out var assets)
                     || latest != tag)
@@ -148,7 +157,18 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
-            var obsolete = SelfUpdatePlan.SelectObsoleteAssets(EnumerateInstalledAssets(), packagedPathnames);
+            IReadOnlyList<string> obsolete;
+            try
+            {
+                // 走査はここで動く。権限の無いフォルダなどに当たると例外が出る
+                obsolete = SelfUpdatePlan.SelectObsoleteAssets(EnumerateInstalledAssets(), packagedPathnames);
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.scan", exception.Message));
+                return;
+            }
 
             string backupPath;
             try
@@ -159,6 +179,15 @@ namespace ARKitBlendShapeGenerator.Infra
             {
                 Delete(unityPackagePath);
                 Fail(S("update.error.backup", exception.Message));
+                return;
+            }
+
+            // 開始から取得までの間に再生へ入られることがある。
+            // ファイルへ触る直前にもう一度確かめる
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                Delete(unityPackagePath);
+                Fail(S("update.error.playing"));
                 return;
             }
 
@@ -214,7 +243,12 @@ namespace ARKitBlendShapeGenerator.Infra
             return failed;
         }
 
-        /// <summary>手元のフォルダにあるアセットを、プロジェクトからの相対パスで並べる</summary>
+        /// <summary>
+        /// 手元のフォルダにあるアセットを、プロジェクトからの相対パスで並べる。
+        ///
+        /// フォルダも含める。新しい版で無くなったフォルダを残すと、`.meta`ごと残った
+        /// 空のフォルダが、同じGUIDを持つ移動後のフォルダとぶつかる
+        /// </summary>
         private static IEnumerable<string> EnumerateInstalledAssets()
         {
             var root = PackageLocation.Root;
@@ -223,8 +257,14 @@ namespace ARKitBlendShapeGenerator.Infra
                 yield break;
             }
 
+            foreach (var path in Directory.GetDirectories(root, "*", SearchOption.AllDirectories))
+            {
+                yield return path.Replace('\\', '/');
+            }
+
             foreach (var path in Directory.GetFiles(root, "*", SearchOption.AllDirectories))
             {
+                // .metaはアセットではなく、消すときもAssetDatabaseが一緒に始末する
                 if (path.EndsWith(".meta", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -162,14 +162,25 @@ namespace ARKitBlendShapeGenerator.Infra
                 return;
             }
 
+            // 控えの場所は、この先で中断した場合にも辿れるよう先に残す
+            EditorPrefs.SetString(BackupPathKey, backupPath);
+
             // ここから先はプロジェクトのファイルを書き換える。
             // 途中でアセンブリが読み直されると取り込みまで辿り着けないため、reloadを止めておく
+
             EditorApplication.LockReloadAssemblies();
             try
             {
-                DeleteObsolete(obsolete);
+                var failed = DeleteObsolete(obsolete);
+                if (failed.Count > 0)
+                {
+                    // 消せなかった古いファイルが新しい版と同居するとコンパイルが通らない。
+                    // 取り込みへ進むと、版だけが新しくなって壊れた状態が残る
+                    Delete(unityPackagePath);
+                    Fail(S("update.error.delete", string.Join(", ", failed), backupPath));
+                    return;
+                }
 
-                EditorPrefs.SetString(BackupPathKey, backupPath);
                 SessionState.SetString(PendingCompletionKey, tag);
 
                 // 取り込みを要求した時点で、この先のコードは差し替えの対象になる
@@ -182,24 +193,25 @@ namespace ARKitBlendShapeGenerator.Infra
             }
         }
 
-        private static void DeleteObsolete(IReadOnlyList<string> obsolete)
+        /// <summary>古い版にしか無いアセットを消し、消せなかったものを返す</summary>
+        private static IReadOnlyList<string> DeleteObsolete(IReadOnlyList<string> obsolete)
         {
+            var failed = new List<string>();
             if (obsolete.Count == 0)
             {
-                return;
+                return failed;
             }
 
             // .metaはAssetDatabaseが一緒に始末する
-            var failed = new List<string>();
             AssetDatabase.DeleteAssets(obsolete.ToArray(), failed);
 
-            // 消せなかったファイルが残ってもコンパイルが通らなくなるだけで、取り込みは進む。
-            // 何が残ったかは分かるようにしておく
             foreach (var path in failed)
             {
                 Debug.LogWarning(string.Format(
                     CultureInfo.InvariantCulture, "[ARKitGenerator] {0} を削除できませんでした", path));
             }
+
+            return failed;
         }
 
         /// <summary>手元のフォルダにあるアセットを、プロジェクトからの相対パスで並べる</summary>

--- a/Editor/Infra/SelfUpdater.cs.meta
+++ b/Editor/Infra/SelfUpdater.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f9a8965554badd5ccf246fae92173fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Infra/UpdateCheck.cs
+++ b/Editor/Infra/UpdateCheck.cs
@@ -33,9 +33,22 @@ namespace ARKitBlendShapeGenerator.Infra
     /// </summary>
     internal static class UpdateCheck
     {
-        /// <summary>最新の安定版を返すエンドポイント。自己更新も同じ応答からアセットを選ぶ</summary>
-        internal const string LatestReleaseApiUrl =
-            "https://api.github.com/repos/limit7412/VRCARKitBlendShapeGenerator/releases/latest";
+        private const string ReleasesApiUrl =
+            "https://api.github.com/repos/limit7412/VRCARKitBlendShapeGenerator/releases";
+
+        /// <summary>最新の安定版を返すエンドポイント</summary>
+        internal const string LatestReleaseApiUrl = ReleasesApiUrl + "/latest";
+
+        /// <summary>
+        /// 版を指定してリリースを引くエンドポイント。
+        ///
+        /// 自己更新は利用者が確かめた版を取りに行く。`latest`を引き直すと、知らせてから
+        /// 実行するまでに次の版が出た場合に、確かめたものと違う版を入れることになる
+        /// </summary>
+        internal static string ReleaseByTagApiUrl(string tag)
+        {
+            return ReleasesApiUrl + "/tags/" + Uri.EscapeDataString(tag ?? string.Empty);
+        }
 
         /// <summary>更新の入手先として案内するページ</summary>
         public const string ReleasesPageUrl =

--- a/Editor/Infra/UpdateCheck.cs
+++ b/Editor/Infra/UpdateCheck.cs
@@ -316,6 +316,13 @@ namespace ARKitBlendShapeGenerator.Infra
                 return false;
             }
 
+            // 版を指定して引く場合、`latest`の対象から外れた版もそのまま返る。
+            // 不具合などで取り下げられた版を、古い知らせのまま入れるわけにはいかない
+            if (response.prerelease || response.draft)
+            {
+                return false;
+            }
+
             var candidate = response.tag_name.Trim();
             if (!PackageVersion.TryParse(candidate, out _))
             {
@@ -356,6 +363,8 @@ namespace ARKitBlendShapeGenerator.Infra
         {
             // JsonUtilityはフィールド名でJSONのキーと対応づけるため、APIの綴りに合わせる
             public string tag_name;
+            public bool prerelease;
+            public bool draft;
             public ReleaseAssetResponse[] assets;
         }
 

--- a/Editor/Infra/UpdateCheck.cs
+++ b/Editor/Infra/UpdateCheck.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using UnityEditor;
 using UnityEngine;
@@ -32,7 +33,8 @@ namespace ARKitBlendShapeGenerator.Infra
     /// </summary>
     internal static class UpdateCheck
     {
-        private const string LatestReleaseApiUrl =
+        /// <summary>最新の安定版を返すエンドポイント。自己更新も同じ応答からアセットを選ぶ</summary>
+        internal const string LatestReleaseApiUrl =
             "https://api.github.com/repos/limit7412/VRCARKitBlendShapeGenerator/releases/latest";
 
         /// <summary>更新の入手先として案内するページ</summary>
@@ -43,6 +45,7 @@ namespace ARKitBlendShapeGenerator.Infra
         private const string LastAttemptKey = "ARKitBlendShapeGenerator.UpdateCheck.LastAttemptUtcTicks";
         private const string LatestTagKey = "ARKitBlendShapeGenerator.UpdateCheck.LatestTag";
         private const string DismissedTagKey = "ARKitBlendShapeGenerator.UpdateCheck.DismissedTag";
+        private const string AnnouncedTagKey = "ARKitBlendShapeGenerator.UpdateCheck.AnnouncedTag";
 
         private const double CheckIntervalHours = 24.0;
         private const int RequestTimeoutSeconds = 15;
@@ -92,6 +95,13 @@ namespace ARKitBlendShapeGenerator.Infra
                 EnsureStateCached();
                 return _cachedPendingTag;
             }
+        }
+
+        /// <summary>ポップアップで知らせた版。まだ無ければ空</summary>
+        public static string AnnouncedTag
+        {
+            get { return EditorPrefs.GetString(AnnouncedTagKey, string.Empty); }
+            set { EditorPrefs.SetString(AnnouncedTagKey, value ?? string.Empty); }
         }
 
         /// <summary>この版については以後知らせない</summary>
@@ -259,7 +269,18 @@ namespace ARKitBlendShapeGenerator.Infra
         /// </summary>
         internal static bool TryParseTag(string json, out string tag)
         {
+            return TryParseRelease(json, out tag, out _);
+        }
+
+        /// <summary>
+        /// releases/latestの応答から、タグと添付されたアセットの一覧を取り出す。
+        ///
+        /// 自己更新はアセットの側も要るが、応答は通知と同じものなので解釈も1箇所にまとめる
+        /// </summary>
+        internal static bool TryParseRelease(string json, out string tag, out ReleaseAsset[] assets)
+        {
             tag = null;
+            assets = Array.Empty<ReleaseAsset>();
 
             if (string.IsNullOrWhiteSpace(json))
             {
@@ -289,7 +310,32 @@ namespace ARKitBlendShapeGenerator.Infra
             }
 
             tag = candidate;
+            assets = ToReleaseAssets(response.assets);
             return true;
+        }
+
+        private static ReleaseAsset[] ToReleaseAssets(ReleaseAssetResponse[] responses)
+        {
+            if (responses == null)
+            {
+                return Array.Empty<ReleaseAsset>();
+            }
+
+            var assets = new List<ReleaseAsset>(responses.Length);
+            foreach (var response in responses)
+            {
+                if (response == null || string.IsNullOrWhiteSpace(response.name))
+                {
+                    continue;
+                }
+
+                assets.Add(new ReleaseAsset(
+                    response.name.Trim(),
+                    response.browser_download_url?.Trim(),
+                    response.digest?.Trim()));
+            }
+
+            return assets.ToArray();
         }
 
         [Serializable]
@@ -297,6 +343,17 @@ namespace ARKitBlendShapeGenerator.Infra
         {
             // JsonUtilityはフィールド名でJSONのキーと対応づけるため、APIの綴りに合わせる
             public string tag_name;
+            public ReleaseAssetResponse[] assets;
+        }
+
+        [Serializable]
+        private class ReleaseAssetResponse
+        {
+            public string name;
+            public string browser_download_url;
+
+            /// <summary>`sha256:`で始まるダイジェスト。付かない応答もある</summary>
+            public string digest;
         }
     }
 }

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -424,6 +424,12 @@ msgstr "Stopped because the downloaded package does not contain what was expecte
 msgid "update.error.delete"
 msgstr "Stopped before importing because old files could not be deleted.\nCould not delete: {0}\nThe previous contents are kept at {1}."
 
+msgid "update.error.playing"
+msgstr "Cannot update while in play mode. Exit play mode and try again."
+
+msgid "update.error.scan"
+msgstr "Stopped because the installed files could not be inspected: {0}"
+
 
 
 msgid "update.error.backup"

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -418,5 +418,9 @@ msgstr "The downloaded file does not match the digest reported by GitHub. The up
 msgid "update.error.archive"
 msgstr "Could not read the downloaded file: {0}"
 
+msgid "update.error.contents"
+msgstr "Stopped because the downloaded package does not contain what was expected."
+
+
 msgid "update.error.backup"
 msgstr "Stopped because the previous contents could not be backed up: {0}"

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -421,6 +421,10 @@ msgstr "Could not read the downloaded file: {0}"
 msgid "update.error.contents"
 msgstr "Stopped because the downloaded package does not contain what was expected."
 
+msgid "update.error.delete"
+msgstr "Stopped before importing because old files could not be deleted.\nCould not delete: {0}\nThe previous contents are kept at {1}."
+
+
 
 msgid "update.error.backup"
 msgstr "Stopped because the previous contents could not be backed up: {0}"

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -375,3 +375,48 @@ msgstr "Check for updates"
 
 msgid "update.settings.description"
 msgstr "Queries GitHub Releases at most once a day and shows a notice in the inspector when a newer version is available."
+
+msgid "update.available.booth_updatable"
+msgstr "Version {0} is available.\nYou can update from here."
+
+msgid "update.run"
+msgstr "Update"
+
+msgid "update.confirm"
+msgstr "Update to version {0}.\nThe contents of {1} will be replaced and this cannot be undone. Back up your own changes to that folder first."
+
+msgid "update.announce.message"
+msgstr "Version {0} is available.\nUpdate now?\n\nThe contents of Assets/AtelierKairox/VRCARKitBlendShapeGenerator will be replaced and this cannot be undone."
+
+msgid "update.announce.update"
+msgstr "Update"
+
+msgid "update.announce.later"
+msgstr "Later"
+
+msgid "update.completed"
+msgstr "Updated to version {0}."
+
+msgid "update.incomplete"
+msgstr "The update to version {0} did not finish. The previous contents are kept at {1}."
+
+msgid "update.error.unsupported"
+msgstr "This project cannot be updated automatically. Download the latest version from Releases and import it again."
+
+msgid "update.error.release_missing"
+msgstr "Could not fetch the release for version {0}."
+
+msgid "update.error.asset_missing"
+msgstr "The release has no {0} attached."
+
+msgid "update.error.download"
+msgstr "Download failed: {0}"
+
+msgid "update.error.digest"
+msgstr "The downloaded file does not match the digest reported by GitHub. The update was stopped."
+
+msgid "update.error.archive"
+msgstr "Could not read the downloaded file: {0}"
+
+msgid "update.error.backup"
+msgstr "Stopped because the previous contents could not be backed up: {0}"

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -421,6 +421,10 @@ msgstr "Could not read the downloaded file: {0}"
 msgid "update.error.contents"
 msgstr "Stopped because the downloaded package does not contain what was expected."
 
+msgid "update.error.version"
+msgstr "Stopped because the published package is not version {0}."
+
+
 msgid "update.error.delete"
 msgstr "Stopped before importing because old files could not be deleted.\nCould not delete: {0}\nThe previous contents are kept at {1}."
 

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -421,6 +421,10 @@ msgstr "ダウンロードしたファイルを読めませんでした: {0}"
 msgid "update.error.contents"
 msgstr "ダウンロードしたパッケージの中身が想定と違うため中止しました。"
 
+msgid "update.error.delete"
+msgstr "古いファイルを削除できなかったため、取り込みを中止しました。\n削除できなかったもの: {0}\n更新前の内容は {1} に控えてあります。"
+
+
 
 msgid "update.error.backup"
 msgstr "更新前の内容を控えられなかったため中止しました: {0}"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -424,6 +424,12 @@ msgstr "ダウンロードしたパッケージの中身が想定と違うため
 msgid "update.error.delete"
 msgstr "古いファイルを削除できなかったため、取り込みを中止しました。\n削除できなかったもの: {0}\n更新前の内容は {1} に控えてあります。"
 
+msgid "update.error.playing"
+msgstr "再生中は更新できません。再生を止めてからやり直してください。"
+
+msgid "update.error.scan"
+msgstr "手元のファイルを調べられなかったため中止しました: {0}"
+
 
 
 msgid "update.error.backup"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -375,3 +375,48 @@ msgstr "更新を確認する"
 
 msgid "update.settings.description"
 msgstr "GitHubのReleasesへ1日1回まで問い合わせ、新しいバージョンが出ていればインスペクタに知らせます。"
+
+msgid "update.available.booth_updatable"
+msgstr "新しいバージョン {0} が公開されています。\nこのウィンドウから更新できます。"
+
+msgid "update.run"
+msgstr "更新する"
+
+msgid "update.confirm"
+msgstr "バージョン {0} へ更新します。\n{1} の中身が新しいものへ置き換わり、この操作は取り消せません。フォルダの中を書き換えている場合は、先に控えを取ってください。"
+
+msgid "update.announce.message"
+msgstr "新しいバージョン {0} が公開されています。\nいま更新しますか？\n\n更新すると Assets/AtelierKairox/VRCARKitBlendShapeGenerator の中身が置き換わり、この操作は取り消せません。"
+
+msgid "update.announce.update"
+msgstr "更新する"
+
+msgid "update.announce.later"
+msgstr "あとで"
+
+msgid "update.completed"
+msgstr "バージョン {0} へ更新しました。"
+
+msgid "update.incomplete"
+msgstr "バージョン {0} への更新が完了しませんでした。更新前の内容は {1} に控えてあります。"
+
+msgid "update.error.unsupported"
+msgstr "このプロジェクトでは自動更新を行えません。Releasesから最新版を入手して入れ直してください。"
+
+msgid "update.error.release_missing"
+msgstr "バージョン {0} のリリースを取得できませんでした。"
+
+msgid "update.error.asset_missing"
+msgstr "リリースに {0} が添付されていません。"
+
+msgid "update.error.download"
+msgstr "ダウンロードに失敗しました: {0}"
+
+msgid "update.error.digest"
+msgstr "ダウンロードしたファイルがGitHubの示すダイジェストと一致しません。更新を中止しました。"
+
+msgid "update.error.archive"
+msgstr "ダウンロードしたファイルを読めませんでした: {0}"
+
+msgid "update.error.backup"
+msgstr "更新前の内容を控えられなかったため中止しました: {0}"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -421,6 +421,10 @@ msgstr "ダウンロードしたファイルを読めませんでした: {0}"
 msgid "update.error.contents"
 msgstr "ダウンロードしたパッケージの中身が想定と違うため中止しました。"
 
+msgid "update.error.version"
+msgstr "配布されているパッケージの版がバージョン {0} と一致しないため中止しました。"
+
+
 msgid "update.error.delete"
 msgstr "古いファイルを削除できなかったため、取り込みを中止しました。\n削除できなかったもの: {0}\n更新前の内容は {1} に控えてあります。"
 

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -418,5 +418,9 @@ msgstr "ダウンロードしたファイルがGitHubの示すダイジェスト
 msgid "update.error.archive"
 msgstr "ダウンロードしたファイルを読めませんでした: {0}"
 
+msgid "update.error.contents"
+msgstr "ダウンロードしたパッケージの中身が想定と違うため中止しました。"
+
+
 msgid "update.error.backup"
 msgstr "更新前の内容を控えられなかったため中止しました: {0}"

--- a/Editor/Presentation/UpdateNotice.cs
+++ b/Editor/Presentation/UpdateNotice.cs
@@ -60,7 +60,20 @@ namespace ARKitBlendShapeGenerator.Presentation
             EditorGUILayout.HelpBox(DescribeUpdate(tag), MessageType.Info);
 
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button(S("update.open_releases")))
+
+            // booth版には版を管理する主体がいないため、ここから入れ替えまで行う。
+            // VPM版はVCC/ALCOMの記録とずれるので案内にとどめる
+            if (SelfUpdater.IsSupported)
+            {
+                using (new EditorGUI.DisabledScope(SelfUpdater.IsRunning))
+                {
+                    if (GUILayout.Button(S("update.run")))
+                    {
+                        RunWithConfirmation(tag);
+                    }
+                }
+            }
+            else if (GUILayout.Button(S("update.open_releases")))
             {
                 Application.OpenURL(UpdateCheck.ReleasesPageUrl);
             }
@@ -74,6 +87,24 @@ namespace ARKitBlendShapeGenerator.Presentation
             EditorGUILayout.Space();
         }
 
+        /// <summary>
+        /// 取り込みはUndoできず、手元の改変も上書きする。
+        /// 押し間違いで走らないよう、実行の前に一度確かめる
+        /// </summary>
+        private static void RunWithConfirmation(string tag)
+        {
+            if (!EditorUtility.DisplayDialog(
+                    S("dialog.title"),
+                    S("update.confirm", tag, SelfUpdatePlan.InstallRoot),
+                    S("update.run"),
+                    S("common.cancel")))
+            {
+                return;
+            }
+
+            SelfUpdater.Run(tag);
+        }
+
         private static string DescribeUpdate(string tag)
         {
             switch (PackageLocation.Location)
@@ -81,7 +112,9 @@ namespace ARKitBlendShapeGenerator.Presentation
                 case InstallLocation.Vpm:
                     return S("update.available.vpm", tag);
                 case InstallLocation.Booth:
-                    return S("update.available.booth", tag);
+                    return SelfUpdater.IsSupported
+                        ? S("update.available.booth_updatable", tag)
+                        : S("update.available.booth", tag);
                 default:
                     return S("update.available.unknown", tag);
             }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Releasesの `VRCARKitBlendShapeGenerator_<バージョン>.zip` に、unitypacka
 **VPM版と同時に入れないでください。**
 どちらもアセンブリ名が同じため、1つのプロジェクトへ両方を入れるとコンパイルが通りません。
 
-更新するときは `Assets/AtelierKairox/VRCARKitBlendShapeGenerator/` をフォルダごと削除してから、新しいunitypackageを取り込んでください。
+更新は下の「更新の確認」の通知から行えます。
+手で入れ直す場合は `Assets/AtelierKairox/VRCARKitBlendShapeGenerator/` をフォルダごと削除してから、新しいunitypackageを取り込んでください。
 unitypackageの取り込みはファイルの追加と上書きだけを行うため、上書きするだけでは、そのバージョンで削除されたファイルが残ります。
 
 アバターに追加済みのコンポーネントは、削除して入れ直しても失われません。
@@ -43,7 +44,8 @@ unitypackageの取り込みはファイルの追加と上書きだけを行う�
 
 ### 更新の確認
 
-新しいバージョンが出ているかを[Releases](https://github.com/limit7412/VRCARKitBlendShapeGenerator/releases/latest)へ問い合わせ、インスペクタの先頭で知らせます。
+新しいバージョンが出ているかを[Releases](https://github.com/limit7412/VRCARKitBlendShapeGenerator/releases/latest)へ問い合わせます。
+確認はエディタの読み込み時に自動で走るため、インスペクタを開く必要はありません。
 
 エディタから外部へ通信するため、確認するかどうかは初回にインスペクタで尋ねます。
 確認しないことを選べば通信は行いません。
@@ -51,8 +53,23 @@ unitypackageの取り込みはファイルの追加と上書きだけを行う�
 
 選択は Preferences > ARKit BlendShape Generator からいつでも変更できます。
 
-更新の手段はインストール方法で違うため、案内もそれに合わせて変わります。
-`Packages/` 配下（VCC/ALCOM経由）ならVCC/ALCOMから、`Assets/` 配下（unitypackageから導入）なら上の「booth版」の手順で更新してください。
+更新の手段はインストール方法で違うため、扱いもそれに合わせて変わります。
+
+`Packages/` 配下（VCC/ALCOM経由）の場合は、新しいバージョンが出ていることをインスペクタで知らせるだけにとどめます。
+バージョンはVCC/ALCOMが `vpm-manifest.json` で管理しているため、こちらでファイルを置き換えると管理側の記録と実態がずれます。
+
+`Assets/` 配下（unitypackageから導入）の場合は、そのまま更新できます。
+新しいバージョンを見つけると、そのバージョンについて一度だけダイアログで知らせます。
+そこで「あとで」を選んだ場合は、インスペクタの先頭に出る「更新する」ボタンからいつでも実行できます。
+
+更新は、Releasesからbooth用zipを取得し、GitHubが示すダイジェスト（sha256）と照合してから取り込みます。
+取り込みの前に、新しいバージョンに無くなったファイルを削除し、更新前のフォルダを `Temp/` へ控えます。
+取り込みは取り消せないため、実行前に確認を挟みます。
+フォルダの中を自分で書き換えている場合は、先に控えを取ってください。
+
+フォルダを `Assets/AtelierKairox/VRCARKitBlendShapeGenerator/` から動かしている場合、この更新は行えません。
+取り込み先はunitypackageの側で決まっており、手元の位置へは追従しないため、実行すると同じアセンブリがプロジェクトに二組できてしまいます。
+この場合は上の「booth版」の手順で入れ直してください。
 
 ## 使用方法
 

--- a/Tests/Editor/PackageVersionTests.cs
+++ b/Tests/Editor/PackageVersionTests.cs
@@ -80,5 +80,23 @@ namespace ARKitBlendShapeGenerator.Tests
         {
             Assert.That(PackageVersion.IsUpdateAvailable(current, latest), Is.False);
         }
+
+        // タグは`v0.2.0`のようにも書ける。package.jsonのversionとは表記が揃わない
+        [TestCase("0.2.0", "0.2.0")]
+        [TestCase("0.2.0", "v0.2.0")]
+        [TestCase("0.2", "0.2.0")]
+        public void IsSameVersion_IsTrue_ForTheSameVersionWrittenDifferently(string left, string right)
+        {
+            Assert.That(PackageVersion.IsSameVersion(left, right), Is.True);
+        }
+
+        [TestCase("0.2.0", "0.2.1")]
+        [TestCase("0.2.0", "0.2.0-test1")]
+        [TestCase("0.2.0", "")]
+        [TestCase(null, "0.2.0")]
+        public void IsSameVersion_IsFalse_WhenTheyDifferOrCannotBeRead(string left, string right)
+        {
+            Assert.That(PackageVersion.IsSameVersion(left, right), Is.False);
+        }
     }
 }

--- a/Tests/Editor/SelfUpdatePlanTests.cs
+++ b/Tests/Editor/SelfUpdatePlanTests.cs
@@ -147,6 +147,44 @@ namespace ARKitBlendShapeGenerator.Tests
             Assert.That(SelfUpdatePlan.SelectObsoleteAssets(installed, Enumerable.Empty<string>()), Is.Empty);
         }
 
+        // 消すフォルダの中身まで並べると、先にフォルダが消えた時点で残りが
+        // 「消せなかった」ものとして返り、更新そのものが中止になる
+        [Test]
+        public void SelectObsoleteAssets_KeepsOnlyTheTopmostOfARemovedFolder()
+        {
+            var installed = new[]
+            {
+                Root + "/Editor/Gone",
+                Root + "/Editor/Gone/Deeper",
+                Root + "/Editor/Gone/Deeper/Removed.cs",
+                Root + "/Editor/Gone/Removed.cs",
+                Root + "/Editor/Kept.cs",
+            };
+            var packaged = new[]
+            {
+                Root,
+                Root + "/Editor",
+                Root + "/Editor/Kept.cs",
+            };
+
+            Assert.That(
+                SelfUpdatePlan.SelectObsoleteAssets(installed, packaged),
+                Is.EqualTo(new[] { Root + "/Editor/Gone" }));
+        }
+
+        // 新しい版で無くなったフォルダを残すと、`.meta`ごと残った空のフォルダが、
+        // 同じGUIDを持つ移動後のフォルダとぶつかる
+        [Test]
+        public void SelectObsoleteAssets_IncludesAFolderTheNewPackageNoLongerHas()
+        {
+            var installed = new[] { Root + "/Editor/Gone", Root + "/Editor/Kept.cs" };
+            var packaged = new[] { Root, Root + "/Editor", Root + "/Editor/Kept.cs" };
+
+            Assert.That(
+                SelfUpdatePlan.SelectObsoleteAssets(installed, packaged),
+                Is.EqualTo(new[] { Root + "/Editor/Gone" }));
+        }
+
         /// <summary>このパッケージのunitypackageが必ず持つ取り込み先</summary>
         private static IEnumerable<string> ExpectedContents()
         {

--- a/Tests/Editor/SelfUpdatePlanTests.cs
+++ b/Tests/Editor/SelfUpdatePlanTests.cs
@@ -34,11 +34,12 @@ namespace ARKitBlendShapeGenerator.Tests
             Assert.That(SelfUpdatePlan.CanSelfUpdate(InstallLocation.Booth, "Assets/MyAssets/ARKitGenerator"), Is.False);
         }
 
-        [TestCase(InstallLocation.Vpm)]
-        [TestCase(InstallLocation.Unknown)]
-        public void CannotSelfUpdate_OutsideABoothInstall(InstallLocation location)
+        // InstallLocationはinternalであり、publicなテストメソッドの引数には置けない
+        [Test]
+        public void CannotSelfUpdate_OutsideABoothInstall()
         {
-            Assert.That(SelfUpdatePlan.CanSelfUpdate(location, Root), Is.False);
+            Assert.That(SelfUpdatePlan.CanSelfUpdate(InstallLocation.Vpm, Root), Is.False);
+            Assert.That(SelfUpdatePlan.CanSelfUpdate(InstallLocation.Unknown, Root), Is.False);
         }
 
         [Test]

--- a/Tests/Editor/SelfUpdatePlanTests.cs
+++ b/Tests/Editor/SelfUpdatePlanTests.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// 自己更新の段取りの検証。
+    ///
+    /// 誤ると利用者のプロジェクトからファイルが消えるため、
+    /// 消してよいものの選び方と、更新してよい置かれ方の判定を確かめる。
+    /// </summary>
+    public class SelfUpdatePlanTests
+    {
+        private const string Root = SelfUpdatePlan.InstallRoot;
+
+        [Test]
+        public void BoothAssetName_MatchesTheNameAttachedToARelease()
+        {
+            Assert.That(SelfUpdatePlan.BoothAssetName("0.2.0"), Is.EqualTo("VRCARKitBlendShapeGenerator_0.2.0.zip"));
+        }
+
+        [Test]
+        public void CanSelfUpdate_WhenABoothInstallSitsAtThePackagedPath()
+        {
+            Assert.That(SelfUpdatePlan.CanSelfUpdate(InstallLocation.Booth, Root), Is.True);
+        }
+
+        // 取り込み先はunitypackageの側で決まっており、手元の位置へは追従しない。
+        // 動かされたフォルダのまま実行すると、同じアセンブリが二組できる
+        [Test]
+        public void CannotSelfUpdate_WhenTheFolderHasBeenMoved()
+        {
+            Assert.That(SelfUpdatePlan.CanSelfUpdate(InstallLocation.Booth, "Assets/MyAssets/ARKitGenerator"), Is.False);
+        }
+
+        [TestCase(InstallLocation.Vpm)]
+        [TestCase(InstallLocation.Unknown)]
+        public void CannotSelfUpdate_OutsideABoothInstall(InstallLocation location)
+        {
+            Assert.That(SelfUpdatePlan.CanSelfUpdate(location, Root), Is.False);
+        }
+
+        [Test]
+        public void TrySelectBoothAsset_PicksTheZipForTheTag()
+        {
+            var assets = new[]
+            {
+                new ReleaseAsset("com.qazx7412.kx-vrc-arkit-blendshape-generator-0.2.0.zip", "https://example/vpm", ""),
+                new ReleaseAsset("VRCARKitBlendShapeGenerator_0.2.0.zip", "https://example/booth", "sha256:abc"),
+            };
+
+            Assert.That(SelfUpdatePlan.TrySelectBoothAsset(assets, "0.2.0", out var selected), Is.True);
+            Assert.That(selected.DownloadUrl, Is.EqualTo("https://example/booth"));
+            Assert.That(selected.Digest, Is.EqualTo("sha256:abc"));
+        }
+
+        [Test]
+        public void TrySelectBoothAsset_Fails_WhenTheReleaseHasNoBoothZip()
+        {
+            var assets = new[]
+            {
+                new ReleaseAsset("com.qazx7412.kx-vrc-arkit-blendshape-generator-0.2.0.zip", "https://example/vpm", ""),
+            };
+
+            Assert.That(SelfUpdatePlan.TrySelectBoothAsset(assets, "0.2.0", out _), Is.False);
+        }
+
+        [Test]
+        public void TrySelectBoothAsset_Fails_WhenTheAssetHasNoUrl()
+        {
+            var assets = new[] { new ReleaseAsset("VRCARKitBlendShapeGenerator_0.2.0.zip", null, "") };
+
+            Assert.That(SelfUpdatePlan.TrySelectBoothAsset(assets, "0.2.0", out _), Is.False);
+        }
+
+        [Test]
+        public void SelectObsoleteAssets_PicksTheFilesTheNewPackageNoLongerHas()
+        {
+            var installed = new[]
+            {
+                Root + "/Editor/Domain/Removed.cs",
+                Root + "/Editor/Domain/Kept.cs",
+                Root + "/package.json",
+            };
+            var packaged = new[]
+            {
+                Root,
+                Root + "/Editor/Domain/Kept.cs",
+                Root + "/package.json",
+            };
+
+            var obsolete = SelfUpdatePlan.SelectObsoleteAssets(installed, packaged);
+
+            Assert.That(obsolete, Is.EqualTo(new[] { Root + "/Editor/Domain/Removed.cs" }));
+        }
+
+        // Windowsで並ぶ`\`混じりのパスでも、同じアセットは同じものとして扱う
+        [Test]
+        public void SelectObsoleteAssets_IgnoresTheDirectionOfSeparators()
+        {
+            var installed = new[] { Root.Replace('/', '\\') + "\\Editor\\Domain\\Kept.cs" };
+            var packaged = new[] { Root + "/Editor/Domain/Kept.cs" };
+
+            Assert.That(SelfUpdatePlan.SelectObsoleteAssets(installed, packaged), Is.Empty);
+        }
+
+        // 新しい版の一覧を読めなかった場合に、手元を消し尽くさないこと
+        [Test]
+        public void SelectObsoleteAssets_KeepsEverything_WhenTheNewPackageListIsEmpty()
+        {
+            var installed = new[] { Root + "/Editor/Domain/Kept.cs" };
+
+            Assert.That(SelfUpdatePlan.SelectObsoleteAssets(installed, Enumerable.Empty<string>()), Is.Empty);
+        }
+    }
+}

--- a/Tests/Editor/SelfUpdatePlanTests.cs
+++ b/Tests/Editor/SelfUpdatePlanTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using ARKitBlendShapeGenerator.Domain;
@@ -18,6 +19,37 @@ namespace ARKitBlendShapeGenerator.Tests
         public void BoothAssetName_MatchesTheNameAttachedToARelease()
         {
             Assert.That(SelfUpdatePlan.BoothAssetName("0.2.0"), Is.EqualTo("VRCARKitBlendShapeGenerator_0.2.0.zip"));
+        }
+
+        // release.ymlは先頭の`v`を落としてから資材を作る。同じ形にしないと取りに行く名前が外れる
+        [TestCase("v0.2.0")]
+        [TestCase("0.2.0")]
+        public void BoothAssetName_DropsTheTagPrefix(string tag)
+        {
+            Assert.That(SelfUpdatePlan.BoothAssetName(tag), Is.EqualTo("VRCARKitBlendShapeGenerator_0.2.0.zip"));
+        }
+
+        [Test]
+        public void IsExpectedPackage_AcceptsThePackageItself()
+        {
+            Assert.That(SelfUpdatePlan.IsExpectedPackage(ExpectedContents()), Is.True);
+        }
+
+        // ルートだけの不完全な書庫を受け入れると、手元のほとんどが消える
+        [Test]
+        public void IsExpectedPackage_RejectsAnArchiveMissingTheEssentials()
+        {
+            Assert.That(SelfUpdatePlan.IsExpectedPackage(new[] { Root }), Is.False);
+            Assert.That(SelfUpdatePlan.IsExpectedPackage(new string[0]), Is.False);
+        }
+
+        [Test]
+        public void IsExpectedPackage_RejectsAnArchiveForAnotherPackage()
+        {
+            var other = ExpectedContents().ToList();
+            other.Add("Assets/SomeoneElse/Editor/Other.cs");
+
+            Assert.That(SelfUpdatePlan.IsExpectedPackage(other), Is.False);
         }
 
         [Test]
@@ -113,6 +145,18 @@ namespace ARKitBlendShapeGenerator.Tests
             var installed = new[] { Root + "/Editor/Domain/Kept.cs" };
 
             Assert.That(SelfUpdatePlan.SelectObsoleteAssets(installed, Enumerable.Empty<string>()), Is.Empty);
+        }
+
+        /// <summary>このパッケージのunitypackageが必ず持つ取り込み先</summary>
+        private static IEnumerable<string> ExpectedContents()
+        {
+            return new[]
+            {
+                Root,
+                Root + "/package.json",
+                Root + "/Editor/ARKitBlendShapeGenerator.Editor.asmdef",
+                Root + "/Runtime/ARKitBlendShapeGenerator.Runtime.asmdef",
+            };
         }
     }
 }

--- a/Tests/Editor/UnityPackageContentsTests.cs
+++ b/Tests/Editor/UnityPackageContentsTests.cs
@@ -17,7 +17,7 @@ namespace ARKitBlendShapeGenerator.Tests
     public class UnityPackageContentsTests
     {
         [Test]
-        public void ReadPathnames_ReadsTheDestinationOfEveryEntry()
+        public void Read_ReadsTheDestinationOfEveryEntry()
         {
             var package = BuildPackage(
                 ("11111111111111111111111111111111", "Assets/Example/Editor/Foo.cs", "class Foo {}"),
@@ -25,7 +25,7 @@ namespace ARKitBlendShapeGenerator.Tests
 
             using (var stream = new MemoryStream(package))
             {
-                Assert.That(UnityPackageContents.ReadPathnames(stream), Is.EqualTo(new[]
+                Assert.That(Pathnames(stream), Is.EqualTo(new[]
                 {
                     "Assets/Example/Editor/Foo.cs",
                     "Assets/Example/package.json",
@@ -35,19 +35,19 @@ namespace ARKitBlendShapeGenerator.Tests
 
         // フォルダのエントリは中身を持たない。取り込み先だけは並ぶ
         [Test]
-        public void ReadPathnames_IncludesFolderEntries()
+        public void Read_IncludesFolderEntries()
         {
             var package = BuildPackage(("33333333333333333333333333333333", "Assets/Example/Editor", null));
 
             using (var stream = new MemoryStream(package))
             {
-                Assert.That(UnityPackageContents.ReadPathnames(stream), Is.EqualTo(new[] { "Assets/Example/Editor" }));
+                Assert.That(Pathnames(stream), Is.EqualTo(new[] { "Assets/Example/Editor" }));
             }
         }
 
         // 途中まで読めた一覧を返すと、残りのファイルを消してよいと判断してしまう
         [Test]
-        public void ReadPathnames_Throws_WhenTheArchiveIsTruncated()
+        public void Read_Throws_WhenTheArchiveIsTruncated()
         {
             var package = BuildPackage(("44444444444444444444444444444444", "Assets/Example/Editor/Foo.cs", "class Foo {}"));
             var truncated = new byte[package.Length / 2];
@@ -55,8 +55,40 @@ namespace ARKitBlendShapeGenerator.Tests
 
             using (var stream = new MemoryStream(truncated))
             {
-                Assert.That(() => UnityPackageContents.ReadPathnames(stream), Throws.InstanceOf<Exception>());
+                Assert.That(() => UnityPackageContents.Read(stream), Throws.InstanceOf<Exception>());
             }
+        }
+
+        // 取り込む中身も読める。名前だけ合った別の版が添付された場合に、
+        // 同梱されたマニフェストで気付ける
+        [Test]
+        public void Read_ReadsTheContentOfEachAsset()
+        {
+            var package = BuildPackage(
+                ("55555555555555555555555555555555", "Assets/Example/package.json", @"{""version"":""0.2.0""}"),
+                ("66666666666666666666666666666666", "Assets/Example/Editor", null));
+
+            using (var stream = new MemoryStream(package))
+            {
+                var entries = UnityPackageContents.Read(stream);
+
+                Assert.That(entries.Count, Is.EqualTo(2));
+                Assert.That(Encoding.UTF8.GetString(entries[0].Asset), Is.EqualTo(@"{""version"":""0.2.0""}"));
+
+                // フォルダのエントリは中身を持たない
+                Assert.That(entries[1].Asset, Is.Null);
+            }
+        }
+
+        private static IEnumerable<string> Pathnames(Stream unityPackage)
+        {
+            var pathnames = new List<string>();
+            foreach (var entry in UnityPackageContents.Read(unityPackage))
+            {
+                pathnames.Add(entry.Pathname);
+            }
+
+            return pathnames;
         }
 
         /// <summary>

--- a/Tests/Editor/UnityPackageContentsTests.cs
+++ b/Tests/Editor/UnityPackageContentsTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// unitypackageから取り込み先を読み取る処理の検証。
+    ///
+    /// 読み取った一覧は「新しい版に無いファイルを消す」判断の材料になるため、
+    /// 取りこぼしや、壊れた書庫を黙って受け入れることが起きないかを確かめる。
+    /// </summary>
+    public class UnityPackageContentsTests
+    {
+        [Test]
+        public void ReadPathnames_ReadsTheDestinationOfEveryEntry()
+        {
+            var package = BuildPackage(
+                ("11111111111111111111111111111111", "Assets/Example/Editor/Foo.cs", "class Foo {}"),
+                ("22222222222222222222222222222222", "Assets/Example/package.json", "{}"));
+
+            using (var stream = new MemoryStream(package))
+            {
+                Assert.That(UnityPackageContents.ReadPathnames(stream), Is.EqualTo(new[]
+                {
+                    "Assets/Example/Editor/Foo.cs",
+                    "Assets/Example/package.json",
+                }));
+            }
+        }
+
+        // フォルダのエントリは中身を持たない。取り込み先だけは並ぶ
+        [Test]
+        public void ReadPathnames_IncludesFolderEntries()
+        {
+            var package = BuildPackage(("33333333333333333333333333333333", "Assets/Example/Editor", null));
+
+            using (var stream = new MemoryStream(package))
+            {
+                Assert.That(UnityPackageContents.ReadPathnames(stream), Is.EqualTo(new[] { "Assets/Example/Editor" }));
+            }
+        }
+
+        // 途中まで読めた一覧を返すと、残りのファイルを消してよいと判断してしまう
+        [Test]
+        public void ReadPathnames_Throws_WhenTheArchiveIsTruncated()
+        {
+            var package = BuildPackage(("44444444444444444444444444444444", "Assets/Example/Editor/Foo.cs", "class Foo {}"));
+            var truncated = new byte[package.Length / 2];
+            Array.Copy(package, truncated, truncated.Length);
+
+            using (var stream = new MemoryStream(truncated))
+            {
+                Assert.That(() => UnityPackageContents.ReadPathnames(stream), Throws.InstanceOf<Exception>());
+            }
+        }
+
+        /// <summary>
+        /// unitypackageの形を組み立てる。
+        ///
+        /// gzipで圧縮したtarで、アセット1件につきGUIDのディレクトリを持ち、
+        /// その中に中身(asset)、メタ(asset.meta)、取り込み先(pathname)が並ぶ。
+        /// assetがnullのものはフォルダのエントリとして扱う
+        /// </summary>
+        private static byte[] BuildPackage(params (string Guid, string Pathname, string Asset)[] entries)
+        {
+            var body = new MemoryStream();
+            foreach (var entry in entries)
+            {
+                if (entry.Asset != null)
+                {
+                    WriteEntry(body, entry.Guid + "/asset", Encoding.UTF8.GetBytes(entry.Asset));
+                }
+
+                WriteEntry(body, entry.Guid + "/asset.meta", Encoding.UTF8.GetBytes("guid: " + entry.Guid));
+                WriteEntry(body, entry.Guid + "/pathname", Encoding.UTF8.GetBytes(entry.Pathname));
+            }
+
+            // tarの終端は空のブロックで示す
+            body.Write(new byte[1024], 0, 1024);
+
+            var compressed = new MemoryStream();
+            using (var gzip = new GZipStream(compressed, CompressionMode.Compress, leaveOpen: true))
+            {
+                var bytes = body.ToArray();
+                gzip.Write(bytes, 0, bytes.Length);
+            }
+
+            return compressed.ToArray();
+        }
+
+        private static void WriteEntry(Stream stream, string name, IReadOnlyList<byte> content)
+        {
+            var header = new byte[512];
+            Encoding.UTF8.GetBytes(name).CopyTo(header, 0);
+
+            // 大きさは8進数の文字列で、末尾はNUL
+            var size = Encoding.UTF8.GetBytes(Convert.ToString(content.Count, 8).PadLeft(11, '0'));
+            size.CopyTo(header, 124);
+
+            stream.Write(header, 0, header.Length);
+
+            var body = new byte[content.Count];
+            for (var i = 0; i < content.Count; i++)
+            {
+                body[i] = content[i];
+            }
+
+            stream.Write(body, 0, body.Length);
+
+            // 中身はブロック境界まで埋める
+            var padding = (512 - body.Length % 512) % 512;
+            if (padding > 0)
+            {
+                stream.Write(new byte[padding], 0, padding);
+            }
+        }
+    }
+}

--- a/Tests/Editor/UpdateAnnouncementTests.cs
+++ b/Tests/Editor/UpdateAnnouncementTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using ARKitBlendShapeGenerator.Domain;
+
+namespace ARKitBlendShapeGenerator.Tests
+{
+    /// <summary>
+    /// ポップアップを出すかどうかの判断の検証。
+    ///
+    /// 作業の途中へ割り込む形になるため、同じ版で繰り返し出さないことを確かめる。
+    /// </summary>
+    public class UpdateAnnouncementTests
+    {
+        [Test]
+        public void ShouldAnnounce_WhenABoothInstallHasNotSeenTheVersion()
+        {
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, "0.2.0", null), Is.True);
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, "0.2.0", string.Empty), Is.True);
+        }
+
+        [Test]
+        public void ShouldNotAnnounce_TheSameVersionTwice()
+        {
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, "0.2.0", "0.2.0"), Is.False);
+        }
+
+        // 一度知らせた後に更に新しい版が出たら、その版については改めて知らせる
+        [Test]
+        public void ShouldAnnounce_AVersionNewerThanTheAnnouncedOne()
+        {
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, "0.3.0", "0.2.0"), Is.True);
+        }
+
+        [Test]
+        public void ShouldNotAnnounce_WhenThereIsNoUpdate()
+        {
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, null, "0.2.0"), Is.False);
+        }
+
+        // VPM版の更新はVCC/ALCOMが担うため、こちらから割り込まない
+        [TestCase(InstallLocation.Vpm)]
+        [TestCase(InstallLocation.Unknown)]
+        public void ShouldNotAnnounce_OutsideABoothInstall(InstallLocation location)
+        {
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(location, "0.2.0", null), Is.False);
+        }
+    }
+}

--- a/Tests/Editor/UpdateAnnouncementTests.cs
+++ b/Tests/Editor/UpdateAnnouncementTests.cs
@@ -36,12 +36,14 @@ namespace ARKitBlendShapeGenerator.Tests
             Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Booth, null, "0.2.0"), Is.False);
         }
 
-        // VPM版の更新はVCC/ALCOMが担うため、こちらから割り込まない
-        [TestCase(InstallLocation.Vpm)]
-        [TestCase(InstallLocation.Unknown)]
-        public void ShouldNotAnnounce_OutsideABoothInstall(InstallLocation location)
+        // VPM版の更新はVCC/ALCOMが担うため、こちらから割り込まない。
+        // InstallLocationはinternalであり、publicなテストメソッドの引数には置けないため、
+        // TestCaseで並べずに本体で確かめる
+        [Test]
+        public void ShouldNotAnnounce_OutsideABoothInstall()
         {
-            Assert.That(UpdateAnnouncement.ShouldAnnounce(location, "0.2.0", null), Is.False);
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Vpm, "0.2.0", null), Is.False);
+            Assert.That(UpdateAnnouncement.ShouldAnnounce(InstallLocation.Unknown, "0.2.0", null), Is.False);
         }
     }
 }

--- a/Tests/Editor/UpdatePayloadTests.cs
+++ b/Tests/Editor/UpdatePayloadTests.cs
@@ -53,6 +53,43 @@ namespace ARKitBlendShapeGenerator.Tests
             Assert.That(tag, Is.Null);
         }
 
+        // 自己更新は同じ応答からアセットを選ぶ
+        [Test]
+        public void TryParseRelease_ReadsTheAttachedAssets()
+        {
+            const string json = @"{""tag_name"":""0.2.0"",""assets"":[" +
+                @"{""name"":""VRCARKitBlendShapeGenerator_0.2.0.zip""," +
+                @"""browser_download_url"":""https://example/booth.zip""," +
+                @"""digest"":""sha256:abc""}]}";
+
+            Assert.That(UpdateCheck.TryParseRelease(json, out var tag, out var assets), Is.True);
+            Assert.That(tag, Is.EqualTo("0.2.0"));
+            Assert.That(assets.Length, Is.EqualTo(1));
+            Assert.That(assets[0].Name, Is.EqualTo("VRCARKitBlendShapeGenerator_0.2.0.zip"));
+            Assert.That(assets[0].DownloadUrl, Is.EqualTo("https://example/booth.zip"));
+            Assert.That(assets[0].Digest, Is.EqualTo("sha256:abc"));
+        }
+
+        // ダイジェストの付かない応答もあるが、アセットの選択そのものは行える
+        [Test]
+        public void TryParseRelease_AcceptsAnAssetWithoutADigest()
+        {
+            const string json = @"{""tag_name"":""0.2.0"",""assets"":[" +
+                @"{""name"":""VRCARKitBlendShapeGenerator_0.2.0.zip""," +
+                @"""browser_download_url"":""https://example/booth.zip""}]}";
+
+            Assert.That(UpdateCheck.TryParseRelease(json, out _, out var assets), Is.True);
+            Assert.That(assets.Length, Is.EqualTo(1));
+            Assert.That(string.IsNullOrEmpty(assets[0].Digest), Is.True);
+        }
+
+        [Test]
+        public void TryParseRelease_ReturnsNoAssets_WhenTheResponseHasNone()
+        {
+            Assert.That(UpdateCheck.TryParseRelease(@"{""tag_name"":""0.2.0""}", out _, out var assets), Is.True);
+            Assert.That(assets, Is.Empty);
+        }
+
         [Test]
         public void TryParseVersion_ReadsTheVersionFromAPackageManifest()
         {

--- a/Tests/Editor/UpdatePayloadTests.cs
+++ b/Tests/Editor/UpdatePayloadTests.cs
@@ -41,6 +41,15 @@ namespace ARKitBlendShapeGenerator.Tests
             Assert.That(tag, Is.Null);
         }
 
+        // 版を指定して引く場合、`latest`の対象から外れた版もそのまま返る
+        [TestCase(@"{""tag_name"":""0.2.0"",""prerelease"":true}")]
+        [TestCase(@"{""tag_name"":""0.2.0"",""draft"":true}")]
+        public void TryParseTag_RejectsAWithdrawnRelease(string json)
+        {
+            Assert.That(UpdateCheck.TryParseTag(json, out var tag), Is.False);
+            Assert.That(tag, Is.Null);
+        }
+
         [TestCase((string)null)]
         [TestCase("")]
         [TestCase("   ")]


### PR DESCRIPTION
Closes #85

#82 の段階3（booth版へワンクリック更新を足す）にあたる。
あわせて、確認の契機と知らせ方を変える。

## 変わること

- 確認の契機がエディタの読み込みになる。インスペクタを開かなくても新しい版に気付ける
- booth版で新しい版が出ていると、その版について一度だけダイアログが出る。二度目以降はインスペクタのボタンに任せる
- 案内から入手先を開かせるのをやめ、取得から取り込みまでを行う
- VPM版は表示のみで変わらない。バージョンを VCC/ALCOM が `vpm-manifest.json` で管理しているため、こちらでファイルを置き換えると記録と実態がずれる

通信するかどうかの選択と、1日1回までの間隔は #83 のままにしてある。
確認を有効にしていない利用者に対しては、読み込み時にも通信しない。

## 更新の段取り

取得と検証と展開を先に済ませ、プロジェクトのファイルへ触るのは最後にまとめている。
通信や zip の異常では手元に手が付かない。

1. `releases/tags/{tag}` を引き、booth用zipを名前で選ぶ（確認時のURLは覚えず、その場で取り直す）
2. ダウンロードし、GitHub がアセットごとに返す `digest`（sha256）と照合する
3. zip から `.unitypackage` を取り出し、その `pathname` の一覧を読む
4. 中身がこのパッケージのものかを確かめる
5. 新しい版に無いファイルとフォルダを選ぶ
6. 更新前のフォルダを `Temp/` へ控える
7. 5 を消し、`AssetDatabase.ImportPackage` を呼ぶ

`latest` ではなく版を指定して引くのは、知らせてから実行するまでに次の版が出た場合に、利用者が確かめたものと違う版を入れないため。

5 が要るのは、unitypackage の取り込みが追加と上書きしかしないため。
クラスを消したりリネームした版へ更新すると、残骸がコンパイルエラーを起こす。
フォルダも対象に含める。`.meta` ごと残った空のフォルダは、同じGUIDを持つ移動後のフォルダとぶつかる。
中身は親ごと消えるため、消す一覧には最上位のものだけを残す。

4 が要るのは、5 の判断が新しい版の一覧を根拠にしているため。
中身の欠けた書庫や別のパッケージを受け入れると、手元のほとんどが「新しい版に無いもの」になる。
ダイジェストは配布されたファイルそのものとは一致するので、これの防ぎにはならない。

1件でも消せなければ取り込みへ進まない。
消せなかったクラスが新しい版と同居するとコンパイルが通らず、それでいて版だけが新しくなる。

## 更新しない場合

- フォルダを `Assets/AtelierKairox/VRCARKitBlendShapeGenerator` から動かしている場合。取り込み先は unitypackage の側で決まっており手元の位置へは追従しないため、実行すると同じアセンブリがプロジェクトに二組できる
- 再生中。開始時とファイルへ触る直前の両方で確かめる

どちらも従来どおり入れ直しを案内する。

## 実装

```
Editor/Domain/UpdateAnnouncement.cs     ポップアップを出すかどうかの判断
Editor/Domain/SelfUpdatePlan.cs         アセットの選択、更新してよい置かれ方、中身の確認、消すものの選択
Editor/Domain/UnityPackageContents.cs   unitypackage(gzip tar)から取り込み先を読む
Editor/Domain/ReleaseAsset.cs           リリースに添付されたファイル
Editor/Infra/SelfUpdater.cs             取得・検証・展開・控え・取り込み
Editor/Handler/UpdateCheckStartup.cs    読み込み時の契機とダイアログ
```

判断は Domain の純粋関数へ置き、EditMode テストを足した（ポップアップの状態遷移、消すものの選択、中身の確認、アセットの選択、版の比較、unitypackage の読み取り、応答の解釈）。

`ZipArchiveEntry.ExtractToFile` は `System.IO.Compression.ZipFile` 側の拡張メソッドなので使わず、エントリのストリームを自分で写している。
参照の有無でコンパイルが通らなくなるのを避けるため。

## 確認したこと

- CI がすべて成功（EditMode テスト、Packaging、変更パス判定）
- `booth_package.py verify` と `build-packages.sh` が新しいファイルを含めて通ること（ファイル45件、フォルダ9件、エントリ54件）
- 生成した unitypackage に新しいスクリプトが入り、取り込み先が `Assets/AtelierKairox/VRCARKitBlendShapeGenerator/` 配下であること
- VPM用zipに `.meta` が入らないこと、直下に `package.json` があること

実機での動作確認（ダイアログ、ダウンロード、取り込み）はまだ行っていない。

## 判断が要る点

確認を有効にするかは、いまも初回にインスペクタで尋ねる形（オプトイン）のままにしてある。
「読み込み時に自動で」を、尋ねずに既定で確認する（オプトアウト）という意味で読むこともできるが、それは #83 で入れた「利用者が選ぶまで通信しない」という判断を裏返すことになるため、こちらでは変えていない。
既定で確認する形にするなら、初期値を `Enabled` にして問いかけを外すだけで済む。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4EFJdZdgqGg6HuTS8PY72