### PR TITLE
取り込みの完了を待ってから読み直させる

### DIFF
--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -221,31 +221,30 @@ namespace ARKitBlendShapeGenerator.Infra
             SessionState.SetString(BackupPathKey, backupPath);
 
             // ここから先はプロジェクトのファイルを書き換える。
-            // 削除の途中でアセンブリが読み直されると、消えたファイルのまま取り込みへ辿り着けない。
-            // 止めるのは削除の間だけでよく、取り込みは要求を積むだけで走るのはこの後になる
+            // 消したC#やasmdefが保留のリロードを起こす。それが取り込みの要求より先に走ると、
+            // 古いファイルを消しただけで新しい版が入らないまま、実行中のコードが捨てられる。
+            // 要求を積み終えるまでreloadを止めておく
 
-            IReadOnlyList<string> failed;
             EditorApplication.LockReloadAssemblies();
             try
             {
-                failed = DeleteObsolete(obsolete);
+                var failed = DeleteObsolete(obsolete);
+                if (failed.Count > 0)
+                {
+                    // 消せなかった古いファイルが新しい版と同居するとコンパイルが通らない。
+                    // 取り込みへ進むと、版だけが新しくなって壊れた状態が残る
+                    Delete(unityPackagePath);
+                    Fail(S("update.error.delete", string.Join(", ", failed), backupPath));
+                    return;
+                }
+
+                SessionState.SetString(PendingCompletionKey, tag);
+                Import(unityPackagePath);
             }
             finally
             {
                 EditorApplication.UnlockReloadAssemblies();
             }
-
-            if (failed.Count > 0)
-            {
-                // 消せなかった古いファイルが新しい版と同居するとコンパイルが通らない。
-                // 取り込みへ進むと、版だけが新しくなって壊れた状態が残る
-                Delete(unityPackagePath);
-                Fail(S("update.error.delete", string.Join(", ", failed), backupPath));
-                return;
-            }
-
-            SessionState.SetString(PendingCompletionKey, tag);
-            Import(unityPackagePath);
         }
 
         /// <summary>
@@ -267,8 +266,19 @@ namespace ARKitBlendShapeGenerator.Infra
             AssetDatabase.importPackageFailed += OnImportFailed;
             AssetDatabase.importPackageCancelled += OnImportCancelled;
 
-            // 要求した時点で、この先のコードは差し替えの対象になる
-            AssetDatabase.ImportPackage(unityPackagePath, false);
+            try
+            {
+                // 要求した時点で、この先のコードは差し替えの対象になる
+                AssetDatabase.ImportPackage(unityPackagePath, false);
+            }
+            catch (Exception exception) when (IsFileFailure(exception))
+            {
+                // ここで投げられると合図は届かない。待ち続けると更新ボタンが戻らないうえ、
+                // 次に手で取り込まれたパッケージを自己更新の結果として扱ってしまう
+                StopWatchingImport();
+                SessionState.EraseString(PendingCompletionKey);
+                Fail(S("update.error.import", exception.Message, SessionState.GetString(BackupPathKey, string.Empty)));
+            }
         }
 
         private static void OnImportCompleted(string packageName)

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -45,6 +45,9 @@ namespace ARKitBlendShapeGenerator.Infra
 
         private static bool _isRunning;
 
+        /// <summary>取り込みを頼んだパッケージの名前。完了の合図を選り分けるために控える</summary>
+        private static string _requestedPackageName;
+
         /// <summary>更新の実行中。ボタンを二重に押されても始めない</summary>
         public static bool IsRunning
         {
@@ -253,11 +256,13 @@ namespace ARKitBlendShapeGenerator.Infra
         /// 新しいコードが効くのはエディタを開き直したときになり、それまでインスペクタは
         /// 古い版の判断で描かれ続ける。
         ///
-        /// 完了の合図は取り込むパッケージの名前で絞らない。
-        /// 名前の付き方に頼って取りこぼすより、他の取り込みで一度多く読み直すほうが害が無い
+        /// 完了の合図はグローバルで、別のunitypackageの取り込みでも鳴る。
+        /// 頼んだものだけを拾えるよう、名前を控えてから要求する
         /// </summary>
         private static void Import(string unityPackagePath)
         {
+            _requestedPackageName = Path.GetFileNameWithoutExtension(unityPackagePath);
+
             AssetDatabase.importPackageCompleted += OnImportCompleted;
             AssetDatabase.importPackageFailed += OnImportFailed;
             AssetDatabase.importPackageCancelled += OnImportCancelled;
@@ -268,6 +273,11 @@ namespace ARKitBlendShapeGenerator.Infra
 
         private static void OnImportCompleted(string packageName)
         {
+            if (!IsRequested(packageName))
+            {
+                return;
+            }
+
             StopWatchingImport();
 
             // 取り込まれたスクリプトをコンパイルさせ、ドメインリロードへつなげる。
@@ -278,6 +288,11 @@ namespace ARKitBlendShapeGenerator.Infra
 
         private static void OnImportFailed(string packageName, string errorMessage)
         {
+            if (!IsRequested(packageName))
+            {
+                return;
+            }
+
             StopWatchingImport();
             SessionState.EraseString(PendingCompletionKey);
             Fail(S("update.error.import", errorMessage, SessionState.GetString(BackupPathKey, string.Empty)));
@@ -285,9 +300,28 @@ namespace ARKitBlendShapeGenerator.Infra
 
         private static void OnImportCancelled(string packageName)
         {
+            if (!IsRequested(packageName))
+            {
+                return;
+            }
+
             StopWatchingImport();
             SessionState.EraseString(PendingCompletionKey);
             Fail(S("update.error.import_cancelled", SessionState.GetString(BackupPathKey, string.Empty)));
+        }
+
+        /// <summary>
+        /// 自分が頼んだ取り込みの合図かどうか。
+        ///
+        /// 別の取り込みで読み直すと、UpdateCheckStartupがまだ古い版を見たまま
+        /// PendingCompletionKeyを消してしまい、終わっていない更新を失敗として報告する。
+        /// その後で本来の取り込みが終わっても、購読を解いた後では読み直しが起きない。
+        ///
+        /// 一致しない間は購読を続ける。取りこぼしても待ち続けるだけで、誤って先へ進むことはない
+        /// </summary>
+        private static bool IsRequested(string packageName)
+        {
+            return string.Equals(packageName, _requestedPackageName, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -302,6 +336,8 @@ namespace ARKitBlendShapeGenerator.Infra
             AssetDatabase.importPackageCompleted -= OnImportCompleted;
             AssetDatabase.importPackageFailed -= OnImportFailed;
             AssetDatabase.importPackageCancelled -= OnImportCancelled;
+
+            _requestedPackageName = null;
         }
 
         /// <summary>同梱されたpackage.jsonが、取りに行った版のものかどうか</summary>

--- a/Editor/Infra/SelfUpdater.cs
+++ b/Editor/Infra/SelfUpdater.cs
@@ -20,8 +20,9 @@ namespace ARKitBlendShapeGenerator.Infra
     /// 手順を分けているのは、プロジェクトのファイルへ触れるのを最後に寄せるため。
     /// 取得と検証と展開を先に済ませ、どれかが失敗した場合は手元に手を付けずに終わる。
     ///
-    /// 取り込みは自分自身を差し替える。要求した時点でエディタのアセンブリが読み直されるため、
-    /// 以降の処理をここへ書いても実行されない。完了の知らせはSessionStateへ残し、
+    /// 取り込みは自分自身を差し替える。
+    /// ImportPackageは要求を積んで戻るため、完了の合図を受けてから読み直させる。
+    /// 読み直しでこのクラスごと入れ替わるので、完了の知らせはSessionStateへ残し、
     /// 読み込み後にUpdateCheckStartupが拾う
     /// </summary>
     internal static class SelfUpdater
@@ -217,31 +218,90 @@ namespace ARKitBlendShapeGenerator.Infra
             SessionState.SetString(BackupPathKey, backupPath);
 
             // ここから先はプロジェクトのファイルを書き換える。
-            // 途中でアセンブリが読み直されると取り込みまで辿り着けないため、reloadを止めておく
+            // 削除の途中でアセンブリが読み直されると、消えたファイルのまま取り込みへ辿り着けない。
+            // 止めるのは削除の間だけでよく、取り込みは要求を積むだけで走るのはこの後になる
 
+            IReadOnlyList<string> failed;
             EditorApplication.LockReloadAssemblies();
             try
             {
-                var failed = DeleteObsolete(obsolete);
-                if (failed.Count > 0)
-                {
-                    // 消せなかった古いファイルが新しい版と同居するとコンパイルが通らない。
-                    // 取り込みへ進むと、版だけが新しくなって壊れた状態が残る
-                    Delete(unityPackagePath);
-                    Fail(S("update.error.delete", string.Join(", ", failed), backupPath));
-                    return;
-                }
-
-                SessionState.SetString(PendingCompletionKey, tag);
-
-                // 取り込みを要求した時点で、この先のコードは差し替えの対象になる
-                AssetDatabase.ImportPackage(unityPackagePath, false);
+                failed = DeleteObsolete(obsolete);
             }
             finally
             {
                 EditorApplication.UnlockReloadAssemblies();
-                _isRunning = false;
             }
+
+            if (failed.Count > 0)
+            {
+                // 消せなかった古いファイルが新しい版と同居するとコンパイルが通らない。
+                // 取り込みへ進むと、版だけが新しくなって壊れた状態が残る
+                Delete(unityPackagePath);
+                Fail(S("update.error.delete", string.Join(", ", failed), backupPath));
+                return;
+            }
+
+            SessionState.SetString(PendingCompletionKey, tag);
+            Import(unityPackagePath);
+        }
+
+        /// <summary>
+        /// 取り込みを要求し、終わったところで読み直させる。
+        ///
+        /// ImportPackageは要求を積んで戻る。完了を待たずに終えると、ファイルだけが入れ替わり、
+        /// 動いているアセンブリは古いまま残る。
+        /// 新しいコードが効くのはエディタを開き直したときになり、それまでインスペクタは
+        /// 古い版の判断で描かれ続ける。
+        ///
+        /// 完了の合図は取り込むパッケージの名前で絞らない。
+        /// 名前の付き方に頼って取りこぼすより、他の取り込みで一度多く読み直すほうが害が無い
+        /// </summary>
+        private static void Import(string unityPackagePath)
+        {
+            AssetDatabase.importPackageCompleted += OnImportCompleted;
+            AssetDatabase.importPackageFailed += OnImportFailed;
+            AssetDatabase.importPackageCancelled += OnImportCancelled;
+
+            // 要求した時点で、この先のコードは差し替えの対象になる
+            AssetDatabase.ImportPackage(unityPackagePath, false);
+        }
+
+        private static void OnImportCompleted(string packageName)
+        {
+            StopWatchingImport();
+
+            // 取り込まれたスクリプトをコンパイルさせ、ドメインリロードへつなげる。
+            // リロードで静的フィールドが捨てられ、インスペクタが新しい版で描き直される
+            AssetDatabase.Refresh();
+            EditorUtility.RequestScriptReload();
+        }
+
+        private static void OnImportFailed(string packageName, string errorMessage)
+        {
+            StopWatchingImport();
+            SessionState.EraseString(PendingCompletionKey);
+            Fail(S("update.error.import", errorMessage, SessionState.GetString(BackupPathKey, string.Empty)));
+        }
+
+        private static void OnImportCancelled(string packageName)
+        {
+            StopWatchingImport();
+            SessionState.EraseString(PendingCompletionKey);
+            Fail(S("update.error.import_cancelled", SessionState.GetString(BackupPathKey, string.Empty)));
+        }
+
+        /// <summary>
+        /// 合図の購読をやめる。
+        ///
+        /// 実行中の印はここでは下ろさない。
+        /// 完了なら直後の読み直しで静的フィールドごと消え、失敗と中止はFailが下ろす。
+        /// 取り込みが終わるまで下ろさないことで、その間の二度押しも防げる
+        /// </summary>
+        private static void StopWatchingImport()
+        {
+            AssetDatabase.importPackageCompleted -= OnImportCompleted;
+            AssetDatabase.importPackageFailed -= OnImportFailed;
+            AssetDatabase.importPackageCancelled -= OnImportCancelled;
         }
 
         /// <summary>同梱されたpackage.jsonが、取りに行った版のものかどうか</summary>

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -427,5 +427,11 @@ msgstr "Stopped because the installed files could not be inspected: {0}"
 
 
 
+msgid "update.error.import"
+msgstr "The import failed: {0}\nThe previous contents are kept at {1}."
+
+msgid "update.error.import_cancelled"
+msgstr "The import was cancelled.\nThe previous contents are kept at {0}."
+
 msgid "update.error.backup"
 msgstr "Stopped because the previous contents could not be backed up: {0}"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -427,5 +427,11 @@ msgstr "手元のファイルを調べられなかったため中止しました
 
 
 
+msgid "update.error.import"
+msgstr "取り込みに失敗しました: {0}\n更新前の内容は {1} に控えてあります。"
+
+msgid "update.error.import_cancelled"
+msgstr "取り込みが中止されました。\n更新前の内容は {0} に控えてあります。"
+
 msgid "update.error.backup"
 msgstr "更新前の内容を控えられなかったため中止しました: {0}"


### PR DESCRIPTION
## 直す不具合

自己更新を実行しても、エディタを開き直すまで「更新する」ボタンが消えず、新しい版が効きません。

`AssetDatabase.ImportPackage` は要求を積んで戻ります。これまでは完了を待つ仕組みが無く、`AssetDatabase.Refresh()` も `EditorUtility.RequestScriptReload()` も呼んでいませんでした。ファイルはディスク上で入れ替わる一方、動いているアセンブリは古いまま残ります。インスペクタは古い版の判断で描かれ続け、`PackageLocation` の静的キャッシュもドメインリロードまで捨てられません。

完了の知らせを置く `SessionState` はエディタを閉じると消えるため、開き直しても「バージョン X へ更新しました」のログは出ませんでした。

## 変えたところ

- `importPackageCompleted` / `importPackageFailed` / `importPackageCancelled` を購読し、完了で `AssetDatabase.Refresh()` と `EditorUtility.RequestScriptReload()` を要求する
  - 合図はグローバルで、別の unitypackage の取り込みでも鳴る。`Path.GetFileNameWithoutExtension` の名前を控え、一致した合図だけを処理する
  - 一致しない間は購読を解かずに待ち続けるので、別のパッケージの結果を自己更新の結果として扱うことはない
- `ImportPackage` が同期的に投げた場合も、その場で購読と `PendingCompletionKey` を解いて `Fail` へ渡す
  - 合図が届かないまま待ち続けると、更新ボタンが戻らないうえ、次に手で取り込まれたパッケージを自己更新の結果として扱ってしまう
- 実行中の印を取り込みの前に下ろしていたのをやめた
  - 取り込みが走っている間もボタンを押せる状態だった
  - 完了なら直後の読み直しで静的フィールドごと消え、失敗と中止は `Fail` が下ろす
- 取り込みに失敗・中止したときの文言（`update.error.import` / `update.error.import_cancelled`）を ja/en に足した
  - どちらも退避先を案内し、`PendingCompletionKey` を消して完了と誤報されないようにする

`LockReloadAssemblies` の範囲は変えていません。一度は削除の間だけに絞りましたが、消した C# や asmdef が保留のリロードを起こし、それが取り込みの要求より先に走ると、古いファイルを消しただけで新しい版が入らないまま実行中のコードが捨てられます。要求を積み終えるまで保つ元の形へ戻しました。

## 確認できていないこと

Unity のドキュメントへこの環境から到達できず（egress で遮断）、`ImportPackage` が非同期であることと、合図が受け取る `packageName` の形を API の契約としては裏付けられていません。症状（開き直すと反映される）と、リロードを促す呼び出しが一つも無かったことは整合します。

名前が想定と違った場合、合図に一致せず読み直しが起きません。その場合も購読を続けるだけで壊れはしませんが、不具合は直らないままになります。**手元で更新ボタンを押し、開き直さずに反映されるかを確かめていただけると確実です。**

`Refresh()` と `RequestScriptReload()` を両方呼んでいるのは、取り込み後にコンパイルが走らなかった場合にも読み直しを起こすためです。両方効いた場合はリロードが二度走りますが、結果は変わりません。片方で足りることが確認できれば、そちらに寄せます。

Unity を持たない環境のため、コンパイルとテストの実行は CI に委ねています。

## 同じ修正

VRCFE-JsTBridge の `SelfUpdater` は名前以外まったく同じコードで、同じ症状が出ます。[limit7412/VRCFE-JsTBridge#25](https://github.com/limit7412/VRCFE-JsTBridge/pull/25) で同じ変更を当てています。適用後、両者は名前を除いて一致します。